### PR TITLE
Implement basic logging infrastructure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,17 +1,20 @@
 [package]
+authors = ["Richard Newman <rnewman@twinql.com>", "Nicholas Alexander <nalexander@mozilla.com>"]
 name = "mentat"
 version = "0.4.0"
-authors = ["Richard Newman <rnewman@twinql.com>", "Nicholas Alexander <nalexander@mozilla.com>"]
 
 [dependencies]
-rusqlite = "0.8.0"
 clap = "2.19.3"
+rusqlite = "0.8.0"
+slog = "1.4.0"
+slog-scope = "0.2.2"
+slog-term = "1.3.4"
 
 [dependencies.edn]
-  path = "edn"
+path = "edn"
 
 [dependencies.mentat_query]
-  path = "query"
+path = "query"
 
 [dependencies.mentat_query_parser]
-  path = "query-parser"
+path = "query-parser"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,11 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
+#[macro_use]
+extern crate slog;
+#[macro_use]
+extern crate slog_scope;
+
 extern crate edn;
 extern crate mentat_query;
 extern crate mentat_query_parser;
@@ -18,6 +23,7 @@ use rusqlite::Connection;
 pub mod ident;
 
 pub fn get_name() -> String {
+    info!("Called into mentat library"; "fn" => "get_name");
     return String::from("mentat");
 }
 


### PR DESCRIPTION
A take on the logging mentioned in #133. I used the mentioned slog crate and created just a terminal logger for now, with the granularity bound on the debug command line option. See the two examples below for example output.

The change in `lib.rs` is just to show the usage in a library, I can remove it if you want.

```
> cargo run serve
Finished debug [unoptimized + debuginfo] target(s) in 0.0 secs
Running `target/debug/mentat serve`
This doesn't work yet, but it will eventually serve the following database: temp.db on port: 3333.
Jan 10 22:38:12.487 ERRO Calling a function: mentat, version: 0.4.0
```

```
> cargo run serve -- --debug
Finished debug [unoptimized + debuginfo] target(s) in 0.0 secs
Running `target/debug/mentat serve --debug`
This doesn't work yet, but it will eventually serve the following database: temp.db on port: 3333.
Jan 10 22:37:51.396 INFO Serving database, version: 0.4.0, database: temp.db, port: 3333, debug mode: true
Jan 10 22:37:51.397 INFO Called into mentat library, version: 0.4.0, fn: get_name
Jan 10 22:37:51.397 ERRO Calling a function: mentat, version: 0.4.0
```