### PR TITLE
Add tx{-parser} crates; start parsing transactions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,4 @@ script:
   - cargo test --verbose
   - cargo test --verbose -p edn
   - cargo test --verbose -p mentat_query_parser
+  - cargo test --verbose -p mentat_tx_parser

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,6 @@ clap = "2.19.3"
 
 [dependencies.mentat_query_parser]
   path = "query-parser"
+
+[dependencies.mentat_tx_parser]
+  path = "tx-parser"

--- a/edn/src/types.rs
+++ b/edn/src/types.rs
@@ -16,7 +16,7 @@ use num::BigInt;
 use ordered_float::OrderedFloat;
 
 /// Value represents one of the allowed values in an EDN string.
-#[derive(PartialEq, Eq, Hash, Debug)]
+#[derive(PartialEq, Eq, Hash, Clone, Debug)]
 pub enum Value {
     Nil,
     Boolean(bool),

--- a/tx-parser/Cargo.toml
+++ b/tx-parser/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "mentat_tx_parser"
+version = "0.0.1"
+
+[dependencies]
+combine = "2.1.1"
+
+[dependencies.edn]
+  path = "../edn"
+[dependencies.mentat_tx]
+  path = "../tx"

--- a/tx-parser/Cargo.toml
+++ b/tx-parser/Cargo.toml
@@ -7,5 +7,6 @@ combine = "2.1.1"
 
 [dependencies.edn]
   path = "../edn"
+
 [dependencies.mentat_tx]
   path = "../tx"

--- a/tx-parser/src/lib.rs
+++ b/tx-parser/src/lib.rs
@@ -1,0 +1,378 @@
+// Copyright 2016 Mozilla
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#![allow(dead_code)]
+
+extern crate edn;
+extern crate combine;
+extern crate mentat_tx;
+
+use combine::{any, eof, many, optional, parser, satisfy_map, token, Parser, ParseResult, Stream};
+use combine::combinator::{Expected, FnParser};
+// TODO: understand why this is self::edn rather than just edn.
+use self::edn::types::Value;
+use mentat_tx::entities::*;
+
+// TODO: implement combine::Positioner on Value.  We can't do this
+// right now because Value is defined in edn and the trait is defined
+// in combine.
+
+// #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+// pub struct ValuePosition {
+//     pub position: usize,
+// }
+
+// impl fmt::Display for ValuePosition {
+//     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+//         write!(f, "value position: {}", self.position)
+//     }
+// }
+
+// impl combine::primitives::Positioner for Value {
+//     type Position = ValuePosition;
+//     fn start() -> ValuePosition {
+//         ValuePosition { position: 1 }
+//     }
+//     fn update(&self, position: &mut ValuePosition) {
+//         position.position += 1;
+//     }
+// }
+
+struct Tx<I>(::std::marker::PhantomData<fn(I) -> I>);
+
+type TxParser<O, I> = Expected<FnParser<I, fn(I) -> ParseResult<O, I>>>;
+
+fn fn_parser<O, I>(f: fn(I) -> ParseResult<O, I>, err: &'static str) -> TxParser<O, I>
+    where I: Stream<Item = Value>
+{
+    parser(f).expected(err)
+}
+
+impl<I> Tx<I>
+    where I: Stream<Item = Value>
+{
+    fn integer() -> TxParser<i64, I> {
+        fn_parser(Tx::<I>::integer_, "integer")
+    }
+
+    fn integer_(input: I) -> ParseResult<i64, I> {
+        return satisfy_map(|x: Value| if let Value::Integer(y) = x {
+                Some(y)
+            } else {
+                None
+            })
+            .parse_stream(input);
+    }
+
+    fn keyword() -> TxParser<String, I> {
+        fn_parser(Tx::<I>::keyword_, "keyword")
+    }
+
+    fn keyword_(input: I) -> ParseResult<String, I> {
+        return satisfy_map(|x: Value| if let Value::Keyword(y) = x {
+                Some(y)
+            } else {
+                None
+            })
+            .parse_stream(input);
+    }
+
+    fn entid() -> TxParser<EntId, I> {
+        fn_parser(Tx::<I>::entid_, "entid")
+    }
+
+    fn entid_(input: I) -> ParseResult<EntId, I> {
+        let p = Tx::<I>::integer()
+            .map(|x| EntId::EntId(x))
+            .or(Tx::<I>::keyword().map(|x| EntId::Ident(x)))
+            .parse_lazy(input)
+            .into();
+        return p;
+    }
+
+    fn lookup_ref() -> TxParser<LookupRef, I> {
+        fn_parser(Tx::<I>::lookup_ref_, "lookup-ref")
+    }
+
+    fn lookup_ref_(input: I) -> ParseResult<LookupRef, I> {
+        return satisfy_map(|x: Value| if let Value::Vector(y) = x {
+                let mut p = (Tx::<&[Value]>::entid(), any(), eof())
+                    .map(|(a, v, _)| LookupRef { a: a, v: v });
+                let r = p.parse_lazy(&y[..]).into();
+                match r {
+                    Ok((r, _)) => Some(r),
+                    _ => None,
+                }
+            } else {
+                None
+            })
+            .parse_stream(input);
+    }
+
+    fn entid_or_lookup_ref() -> TxParser<EntIdOrLookupRef, I> {
+        fn_parser(Tx::<I>::entid_or_lookup_ref_, "entid|lookup-ref")
+    }
+
+    fn entid_or_lookup_ref_(input: I) -> ParseResult<EntIdOrLookupRef, I> {
+        let p = Tx::<I>::entid()
+            .map(|x| EntIdOrLookupRef::EntId(x))
+            .or(Tx::<I>::lookup_ref().map(|x| EntIdOrLookupRef::LookupRef(x)))
+            .parse_lazy(input)
+            .into();
+        return p;
+    }
+
+    // TODO: abstract the "match Vector, parse internal stream" pattern to remove this boilerplate.
+    fn add_(input: I) -> ParseResult<Entity, I> {
+        return satisfy_map(|x: Value| -> Option<Entity> {
+                if let Value::Vector(y) = x {
+                    let mut p = (token(Value::Keyword("db/add".into())),
+                                 Tx::<&[Value]>::entid_or_lookup_ref(),
+                                 Tx::<&[Value]>::entid(),
+                                 // TODO: handle lookup-ref.
+                                 any(),
+                                 // TODO: entid or special keyword :db/tx?
+                                 optional(Tx::<&[Value]>::entid()),
+                                 eof())
+                        .map(|(_, e, a, v, tx, _)| {
+                            Entity::Add {
+                                e: e,
+                                a: a,
+                                v: ValueOrLookupRef::Value(v),
+                                tx: tx,
+                            }
+                        });
+                    // TODO: use ok() with a type annotation rather than explicit match.
+                    match p.parse_lazy(&y[..]).into() {
+                        Ok((r, _)) => Some(r),
+                        _ => None,
+                    }
+                } else {
+                    None
+                }
+            })
+            .parse_stream(input);
+    }
+
+    fn add() -> TxParser<Entity, I> {
+        fn_parser(Tx::<I>::add_, "[:db/add e a v tx?]")
+    }
+
+    fn retract_(input: I) -> ParseResult<Entity, I> {
+        return satisfy_map(|x: Value| -> Option<Entity> {
+                if let Value::Vector(y) = x {
+                    let mut p = (token(Value::Keyword("db/retract".into())),
+                                 Tx::<&[Value]>::entid_or_lookup_ref(),
+                                 Tx::<&[Value]>::entid(),
+                                 // TODO: handle lookup-ref.
+                                 any(),
+                                 eof())
+                        .map(|(_, e, a, v, _)| {
+                            Entity::Retract {
+                                e: e,
+                                a: a,
+                                v: ValueOrLookupRef::Value(v),
+                            }
+                        });
+                    // TODO: use ok() with a type annotation rather than explicit match.
+                    match p.parse_lazy(&y[..]).into() {
+                        Ok((r, _)) => Some(r),
+                        _ => None,
+                    }
+                } else {
+                    None
+                }
+            })
+            .parse_stream(input);
+    }
+
+    fn retract() -> TxParser<Entity, I> {
+        fn_parser(Tx::<I>::retract_, "[:db/retract e a v]")
+    }
+
+    fn retract_attribute_(input: I) -> ParseResult<Entity, I> {
+        return satisfy_map(|x: Value| -> Option<Entity> {
+                if let Value::Vector(y) = x {
+                    let mut p = (token(Value::Keyword("db/retractAttribute".into())),
+                                 Tx::<&[Value]>::entid_or_lookup_ref(),
+                                 Tx::<&[Value]>::entid(),
+                                 eof())
+                        .map(|(_, e, a, _)| Entity::RetractAttribute { e: e, a: a });
+                    // TODO: use ok() with a type annotation rather than explicit match.
+                    match p.parse_lazy(&y[..]).into() {
+                        Ok((r, _)) => Some(r),
+                        _ => None,
+                    }
+                } else {
+                    None
+                }
+            })
+            .parse_stream(input);
+    }
+
+    fn retract_attribute() -> TxParser<Entity, I> {
+        fn_parser(Tx::<I>::retract_attribute_, "[:db/retractAttribute e a]")
+    }
+
+    fn retract_entity_(input: I) -> ParseResult<Entity, I> {
+        return satisfy_map(|x: Value| -> Option<Entity> {
+                if let Value::Vector(y) = x {
+                    let mut p = (token(Value::Keyword("db/retractEntity".into())),
+                                 Tx::<&[Value]>::entid_or_lookup_ref(),
+                                 eof())
+                        .map(|(_, e, _)| Entity::RetractEntity { e: e });
+                    // TODO: use ok() with a type annotation rather than explicit match.
+                    match p.parse_lazy(&y[..]).into() {
+                        Ok((r, _)) => Some(r),
+                        _ => None,
+                    }
+                } else {
+                    None
+                }
+            })
+            .parse_stream(input);
+    }
+
+    fn retract_entity() -> TxParser<Entity, I> {
+        fn_parser(Tx::<I>::retract_entity_, "[:db/retractEntity e]")
+    }
+
+    fn entity_(input: I) -> ParseResult<Entity, I> {
+        let mut p = Tx::<I>::add()
+            .or(Tx::<I>::retract())
+            .or(Tx::<I>::retract_attribute())
+            .or(Tx::<I>::retract_entity());
+        p.parse_stream(input)
+    }
+
+    fn entity() -> TxParser<Entity, I> {
+        fn_parser(Tx::<I>::entity_,
+                  "[:db/add|:db/retract|:db/retractAttribute|:db/retractEntity ...]")
+    }
+
+    fn entities_(input: I) -> ParseResult<Vec<Entity>, I> {
+        return satisfy_map(|x: Value| -> Option<Vec<Entity>> {
+                if let Value::Vector(y) = x {
+                    let mut p = (many(Tx::<&[Value]>::entity()), eof())
+                        .map(|(es, _)| es);
+                    // TODO: use ok() with a type annotation rather than explicit match.
+                    match p.parse_lazy(&y[..]).into() {
+                        Ok((r, _)) => Some(r),
+                        _ => None,
+                    }
+                } else {
+                    None
+                }
+            })
+            .parse_stream(input);
+    }
+
+    fn entities() -> TxParser<Vec<Entity>, I> {
+        fn_parser(Tx::<I>::entities_,
+                  "[[:db/add|:db/retract|:db/retractAttribute|:db/retractEntity ...]*]")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_add() {
+        let input = [Value::Vector(vec![Value::Keyword("db/add".into()),
+                                        Value::Keyword("ident".into()),
+                                        Value::Keyword("a".into()),
+                                        Value::Text("v".into())])];
+        let mut parser = Tx::entity();
+        let result = parser.parse(&input[..]);
+        assert_eq!(result,
+                   Ok((Entity::Add {
+                       e: EntIdOrLookupRef::EntId(EntId::Ident("ident".into())),
+                       a: EntId::Ident("a".into()),
+                       v: ValueOrLookupRef::Value(Value::Text("v".into())),
+                       tx: None,
+                   },
+                       &[][..])));
+    }
+
+    #[test]
+    fn test_retract() {
+        let input = [Value::Vector(vec![Value::Keyword("db/retract".into()),
+                                        Value::Integer(101),
+                                        Value::Keyword("a".into()),
+                                        Value::Text("v".into())])];
+        let mut parser = Tx::entity();
+        let result = parser.parse(&input[..]);
+        assert_eq!(result,
+                   Ok((Entity::Retract {
+                       e: EntIdOrLookupRef::EntId(EntId::EntId(101)),
+                       a: EntId::Ident("a".into()),
+                       v: ValueOrLookupRef::Value(Value::Text("v".into())),
+                   },
+                       &[][..])));
+    }
+
+    #[test]
+    fn test_entities() {
+        let input = [Value::Vector(vec![
+            Value::Vector(vec![Value::Keyword("db/add".into()),
+                               Value::Integer(101),
+                               Value::Keyword("a".into()),
+                               Value::Text("v".into())]),
+            Value::Vector(vec![Value::Keyword("db/retract".into()),
+                               Value::Integer(102),
+                               Value::Keyword("b".into()),
+                               Value::Text("w".into())])])];
+
+        let mut parser = Tx::entities();
+        let result = parser.parse(&input[..]);
+        assert_eq!(result,
+                   Ok((vec![
+                       Entity::Add {
+                           e: EntIdOrLookupRef::EntId(EntId::EntId(101)),
+                           a: EntId::Ident("a".into()),
+                           v: ValueOrLookupRef::Value(Value::Text("v".into())),
+                           tx: None,
+                       },
+                       Entity::Retract {
+                           e: EntIdOrLookupRef::EntId(EntId::EntId(102)),
+                           a: EntId::Ident("b".into()),
+                           v: ValueOrLookupRef::Value(Value::Text("w".into())),
+                       },
+                       ],
+                       &[][..])));
+    }
+
+    #[test]
+    fn test_lookup_ref() {
+        let input = [Value::Vector(vec![Value::Keyword("db/add".into()),
+                                        Value::Vector(vec![Value::Keyword("a1".into()),
+                                                           Value::Text("v1".into())]),
+                                        Value::Keyword("a".into()),
+                                        Value::Text("v".into())])];
+        let mut parser = Tx::entity();
+        let result = parser.parse(&input[..]);
+        assert_eq!(result,
+                   Ok((Entity::Add {
+                       e: EntIdOrLookupRef::LookupRef(LookupRef {
+                           a: EntId::Ident("a1".into()),
+                           v: Value::Text("v1".into()),
+                       }),
+                       a: EntId::Ident("a".into()),
+                       v: ValueOrLookupRef::Value(Value::Text("v".into())),
+                       tx: None,
+                   },
+                       &[][..])));
+    }
+
+    // TODO: test error handling in select cases.  It's tricky to do
+    // this without combine::Positioner; see the TODO at the top of
+    // the file.
+}

--- a/tx-parser/tests/parser.rs
+++ b/tx-parser/tests/parser.rs
@@ -1,0 +1,49 @@
+// Copyright 2016 Mozilla
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+extern crate edn;
+extern crate combine;
+extern crate mentat_tx;
+extern crate mentat_tx_parser;
+
+use edn::parse;
+use edn::symbols::NamespacedKeyword;
+use edn::types::Value;
+use mentat_tx::entities::*;
+use mentat_tx_parser::Tx;
+
+#[test]
+fn test_entities() {
+
+    // TODO: align with whitespace after the EDN parser ignores more whitespace.
+    let input = r#"[[:db/add 101 :test/a "v"]
+[:db/retract 102 :test/b "w"]]"#;
+
+    let edn = parse::value(input).unwrap();
+    let input = [edn];
+
+    let result = Tx::parse(&input[..]);
+    assert_eq!(result,
+               Ok(vec![
+                   Entity::Add {
+                       e: EntidOrLookupRef::Entid(Entid::Entid(101)),
+                       a: Entid::Ident(NamespacedKeyword::new("test", "a")),
+                       v: ValueOrLookupRef::Value(Value::Text("v".into())),
+                       tx: None,
+                   },
+                   Entity::Retract {
+                       e: EntidOrLookupRef::Entid(Entid::Entid(102)),
+                       a: Entid::Ident(NamespacedKeyword::new("test", "b")),
+                       v: ValueOrLookupRef::Value(Value::Text("w".into())),
+                   },
+                   ]));
+}
+
+// TODO: test error handling in select cases.

--- a/tx/Cargo.toml
+++ b/tx/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "mentat_tx"
+version = "0.0.1"
+
+[dependencies]
+[dependencies.edn]
+  path = "../edn"

--- a/tx/README.md
+++ b/tx/README.md
@@ -1,0 +1,1 @@
+This sub-crate implements the core types used by the transaction processor.

--- a/tx/src/entities.rs
+++ b/tx/src/entities.rs
@@ -12,25 +12,25 @@
 
 extern crate edn;
 
-// TODO: understand why this is self::edn rather than just edn.
 use self::edn::types::Value;
+use self::edn::symbols::NamespacedKeyword;
 
 #[derive(Clone, Debug, PartialEq)]
-pub enum EntId {
-    EntId(i64),
-    Ident(String),
+pub enum Entid {
+    Entid(i64),
+    Ident(NamespacedKeyword),
 }
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct LookupRef {
-    pub a: EntId,
+    pub a: Entid,
     // TODO: consider boxing to allow recursive lookup refs.
     pub v: Value,
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub enum EntIdOrLookupRef {
-    EntId(EntId),
+pub enum EntidOrLookupRef {
+    Entid(Entid),
     LookupRef(LookupRef),
 }
 
@@ -43,16 +43,16 @@ pub enum ValueOrLookupRef {
 #[derive(Clone, Debug, PartialEq)]
 pub enum Entity {
     Add {
-        e: EntIdOrLookupRef,
-        a: EntId,
+        e: EntidOrLookupRef,
+        a: Entid,
         v: ValueOrLookupRef,
-        tx: Option<EntId>,
+        tx: Option<Entid>,
     },
     Retract {
-        e: EntIdOrLookupRef,
-        a: EntId,
+        e: EntidOrLookupRef,
+        a: Entid,
         v: ValueOrLookupRef,
     },
-    RetractAttribute { e: EntIdOrLookupRef, a: EntId },
-    RetractEntity { e: EntIdOrLookupRef },
+    RetractAttribute { e: EntidOrLookupRef, a: Entid },
+    RetractEntity { e: EntidOrLookupRef },
 }

--- a/tx/src/entities.rs
+++ b/tx/src/entities.rs
@@ -1,0 +1,58 @@
+// Copyright 2016 Mozilla
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+///! This module defines core types that support the transaction processor.
+
+extern crate edn;
+
+// TODO: understand why this is self::edn rather than just edn.
+use self::edn::types::Value;
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum EntId {
+    EntId(i64),
+    Ident(String),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct LookupRef {
+    pub a: EntId,
+    // TODO: consider boxing to allow recursive lookup refs.
+    pub v: Value,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum EntIdOrLookupRef {
+    EntId(EntId),
+    LookupRef(LookupRef),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum ValueOrLookupRef {
+    Value(Value),
+    LookupRef(LookupRef),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum Entity {
+    Add {
+        e: EntIdOrLookupRef,
+        a: EntId,
+        v: ValueOrLookupRef,
+        tx: Option<EntId>,
+    },
+    Retract {
+        e: EntIdOrLookupRef,
+        a: EntId,
+        v: ValueOrLookupRef,
+    },
+    RetractAttribute { e: EntIdOrLookupRef, a: EntId },
+    RetractEntity { e: EntIdOrLookupRef },
+}

--- a/tx/src/lib.rs
+++ b/tx/src/lib.rs
@@ -1,0 +1,11 @@
+// Copyright 2016 Mozilla
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+pub mod entities;


### PR DESCRIPTION
This depends on edn and uses the combine parser combinator library.

@rnewman, you can see my progress here.  There's an abstraction around parsing the internals of vector to be worked out, but it's actually quite nice to work with (once you've absorbed some `combine` magic).  I think some of the constructors mappings might be able to be shortened, but it's not worth waiting for.