### PR TITLE
Implement basic logging infrastructure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,12 @@
 [package]
+authors = ["Richard Newman <rnewman@twinql.com>", "Nicholas Alexander <nalexander@mozilla.com>"]
 name = "mentat"
 version = "0.4.0"
-authors = ["Richard Newman <rnewman@twinql.com>", "Nicholas Alexander <nalexander@mozilla.com>"]
 
 [dependencies]
 clap = "2.19.3"
+env_logger = "0.3.5"
+log = "0.3.6"
 nickel = "0.9.0"
 rusqlite = "0.8.0"
 


### PR DESCRIPTION
A replacement for #158.

I think this is a better approach to logging. Independent libraries can use the `log` crate and should be universally usable with that.

The executable provides three options to set the logging level (in order of priority): The `MENTAT_LOG` environment variable, the `RUST_LOG` environment variable and the debug flag.