### PR TITLE
fix sql quoting when calling honeysql/format

### DIFF
--- a/src/common/datomish/query.cljc
+++ b/src/common/datomish/query.cljc
@@ -110,7 +110,7 @@
   (->
     context
     context->sql-clause
-    (sql/format args :quoting sql-quoting-style)))
+    (sql/format :params args :quoting sql-quoting-style)))
 
 (defn- validate-with [with]
   (when-not (or (nil? with)
@@ -215,7 +215,7 @@
   [context find args]
   (->
     (find->sql-clause context find)
-    (sql/format args :quoting sql-quoting-style)))
+    (sql/format :params args :quoting sql-quoting-style)))
 
 (defn parse
   "Parse a Datalog query array into a structured `find` expression."

--- a/test/datomish/test/query.cljc
+++ b/test/datomish/test/query.cljc
@@ -925,3 +925,15 @@
                                                {:select ['x]
                                                 :from [:def]})}
                                      :foo])})))))
+
+(deftest-db test-sql-quoting conn
+  (testing "ansi sql quoting applied when there are no inputs"
+    (is (= ["SELECT DISTINCT \"datoms0\".\"e\" AS \"order\" FROM \"datoms\" \"datoms0\" WHERE (\"datoms0\".\"a\" = \"order\") "]
+           (datomish.query/find->sql-string
+             (conn->context conn)
+             (datomish.query/parse
+               '[:find ?order
+                 :in $
+                 :where
+                 [?order :item/order]])
+             nil)))))


### PR DESCRIPTION
I noticed this bug because I had a query like

``` clj
'[:find ?order 
:where [?order :foo/bar]
```

sqlite threw a syntax error because order is a keyword and it wasn't quoted
"SQLITE_ERROR: near "order": syntax error"