### PR TITLE
Extract assert_parses_to into a parser utility crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,9 @@ features = ["bundled"]
 [dependencies.edn]
 path = "edn"
 
+[dependencies.parser_utils]
+path = "parser-utils"
+
 [dependencies.mentat_db]
 path = "db"
 

--- a/parser-utils/Cargo.toml
+++ b/parser-utils/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "parser_utils"
+version = "0.1.0"
+authors = ["Victor Porof <vporof@mozilla.com>"]
+
+[dependencies]

--- a/parser-utils/src/lib.rs
+++ b/parser-utils/src/lib.rs
@@ -8,11 +8,13 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
-#![allow(unused_imports)]
-#[macro_use]
-extern crate parser_utils;
-
-mod error;
-mod util;
-mod parse;
-pub mod find;
+/// `assert_parses_to!` simplifies some of the boilerplate around running a
+/// parser function against input and expecting a certain result.
+#[macro_export]
+macro_rules! assert_parses_to {
+    ( $parser: path, $input: expr, $expected: expr ) => {{
+        let mut par = $parser();
+        let result = par.parse(&$input[..]);
+        assert_eq!(result, Ok(($expected, &[][..])));
+    }}
+}

--- a/query-parser/Cargo.toml
+++ b/query-parser/Cargo.toml
@@ -8,5 +8,8 @@ combine = "2.1.1"
 [dependencies.edn]
   path = "../edn"
 
+[dependencies.parser_utils]
+  path = "../parser-utils"
+
 [dependencies.mentat_query]
   path = "../query"

--- a/query-parser/src/parse.rs
+++ b/query-parser/src/parse.rs
@@ -190,14 +190,6 @@ mod test {
 
     use super::*;
 
-    macro_rules! assert_parses_to {
-        ( $parser: path, $input: expr, $expected: expr ) => {{
-            let mut par = $parser();
-            let result = par.parse(&$input[..]);
-            assert_eq!(result, Ok(($expected, &[][..])));
-        }}
-    }
-
     #[test]
     fn test_find_sp_variable() {
         let sym = edn::PlainSymbol::new("?x");


### PR DESCRIPTION
Fixes #200 

I couldn't find any other way to silence the unused imports warning when importing the `assert_parses_to` macro in the query parser crate's top level file.

Signed-off-by: Victor Porof <vporof@mozilla.com>