### PR TITLE
Don't depend on num and ordered-float in the db and query crates

### DIFF
--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -5,9 +5,6 @@ version = "0.0.1"
 [dependencies]
 error-chain = "0.8.0"
 lazy_static = "0.2.2"
-# TODO: don't depend on num and ordered-float; expose helpers in edn abstracting necessary constructors.
-num = "0.1.35"
-ordered-float = "0.4.0"
 
 [dependencies.rusqlite]
 version = "0.9.3"

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -12,8 +12,6 @@
 extern crate error_chain;
 #[macro_use]
 extern crate lazy_static;
-extern crate num;
-extern crate ordered_float;
 extern crate rusqlite;
 
 extern crate edn;

--- a/db/src/types.rs
+++ b/db/src/types.rs
@@ -11,8 +11,7 @@
 #![allow(dead_code)]
 
 use std::collections::{BTreeMap};
-
-use ordered_float::{OrderedFloat};
+use edn::OrderedFloat;
 
 extern crate mentat_core;
 

--- a/edn/src/lib.rs
+++ b/edn/src/lib.rs
@@ -21,5 +21,7 @@ pub mod parse {
     include!(concat!(env!("OUT_DIR"), "/edn.rs"));
 }
 
-pub use self::types::Value;
-pub use self::symbols::{Keyword, NamespacedKeyword, PlainSymbol, NamespacedSymbol};
+pub use ordered_float::OrderedFloat;
+pub use num::BigInt;
+pub use types::Value;
+pub use symbols::{Keyword, NamespacedKeyword, PlainSymbol, NamespacedSymbol};

--- a/query-parser/Cargo.toml
+++ b/query-parser/Cargo.toml
@@ -5,7 +5,6 @@ version = "0.0.1"
 [dependencies]
 combine = "2.1.1"
 matches = "0.1"
-ordered-float = "0.4.0"
 
 [dependencies.edn]
   path = "../edn"

--- a/query-parser/src/parse.rs
+++ b/query-parser/src/parse.rs
@@ -244,10 +244,9 @@ mod test {
     extern crate combine;
     extern crate edn;
     extern crate mentat_query;
-    extern crate ordered_float;
 
     use self::combine::Parser;
-    use self::ordered_float::OrderedFloat;
+    use self::edn::OrderedFloat;
     use self::mentat_query::{
         Element,
         FindSpec,

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -3,8 +3,6 @@ name = "mentat_query"
 version = "0.0.1"
 
 [dependencies]
-num = "0.1.35"
-ordered-float = "0.4.0"
 
 [dependencies.edn]
   path = "../edn"

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -31,12 +31,8 @@
 ///! a tradeoff against well-typed function signatures and other such boundaries.
 
 extern crate edn;
-extern crate num;
-extern crate ordered_float;
 
-use num::BigInt;
-use ordered_float::OrderedFloat;
-use edn::{NamespacedKeyword, PlainSymbol};
+use edn::{BigInt, OrderedFloat, NamespacedKeyword, PlainSymbol};
 
 pub type SrcVarName = String;          // Do not include the required syntactic '$'.
 


### PR DESCRIPTION
Depends on https://github.com/mozilla/mentat/pull/222

I've had to remove some derived traits from various data types when switching from OrderedFloat<f64> to the f64 primitive. I don't know what that implies, hoping for guidance.