### PR TITLE
Parse and display EDN values for NaN, +Infinity and -Infinity. Fixes …

### DIFF
--- a/edn/src/edn.rustpeg
+++ b/edn/src/edn.rustpeg
@@ -12,6 +12,7 @@
 
 use std::collections::{BTreeSet, BTreeMap, LinkedList};
 use std::iter::FromIterator;
+use std::f64::{NAN, INFINITY, NEG_INFINITY};
 
 use num::BigInt;
 use ordered_float::OrderedFloat;
@@ -29,6 +30,14 @@ use types::Value;
 
 pub nil -> Value =
     "nil" { Value::Nil }
+
+pub nan -> Value =
+    "#f NaN" { Value::Float(OrderedFloat(NAN)) }
+
+pub infinity -> Value =
+    "#f" s:$(sign) "Infinity" {
+        Value::Float(OrderedFloat(if s == "+" { INFINITY } else { NEG_INFINITY }))
+    }
 
 pub boolean -> Value =
     "true" { Value::Boolean(true) } /
@@ -125,7 +134,7 @@ pub map -> Value =
 // It's important that float comes before integer or the parser assumes that
 // floats are integers and fails to parse
 pub value -> Value =
-    __ v:(nil / boolean / float / bigint / integer / text / keyword / symbol / list / vector / map / set) __ {
+    __ v:(nil / nan / infinity / boolean / float / bigint / integer / text / keyword / symbol / list / vector / map / set) __ {
         v
     }
 

--- a/edn/tests/tests.rs
+++ b/edn/tests/tests.rs
@@ -14,6 +14,7 @@ extern crate ordered_float;
 
 use std::collections::{BTreeSet, BTreeMap, LinkedList};
 use std::iter::FromIterator;
+use std::f64;
 use num::bigint::ToBigInt;
 use num::traits::{Zero, One};
 use ordered_float::OrderedFloat;
@@ -48,6 +49,21 @@ fn test_nil() {
     assert_eq!(nil("nil").unwrap(), Nil);
 
     assert!(nil("true").is_err());
+}
+
+#[test]
+fn test_nan() {
+    assert_eq!(nan("#f NaN").unwrap(), Float(OrderedFloat(f64::NAN)));
+
+    assert!(nan("true").is_err());
+}
+
+#[test]
+fn test_infinity() {
+    assert_eq!(infinity("#f-Infinity").unwrap(), Float(OrderedFloat(f64::NEG_INFINITY)));
+    assert_eq!(infinity("#f+Infinity").unwrap(), Float(OrderedFloat(f64::INFINITY)));
+
+    assert!(infinity("true").is_err());
 }
 
 #[test]


### PR DESCRIPTION
…#232

@victorporof can you elaborate on what EDN escaping you're talking about in the TODO? And is there any other Float formatting issues you had in mind when writing that TODO?

While we're here, is `null` a special EDN type? From what I gather, this should be printed as `nil` (that's what our parser looks for, anyway)