### PR TITLE
Add :db.type/{instant, uri, uuid} types to bootstrapper. Fixes #201

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -34,6 +34,8 @@ pub enum ValueType {
     Long,
     Double,
     String,
+    UUID,
+    URI,
     Keyword,
 }
 
@@ -49,6 +51,9 @@ pub enum TypedValue {
     // TODO: &str throughout?
     String(String),
     Keyword(NamespacedKeyword),
+    Instant(i64),
+    UUID(String),
+    URI(String),
 }
 
 impl TypedValue {
@@ -72,6 +77,9 @@ impl TypedValue {
             &TypedValue::Double(_) => ValueType::Double,
             &TypedValue::String(_) => ValueType::String,
             &TypedValue::Keyword(_) => ValueType::Keyword,
+            &TypedValue::Instant(_) => ValueType::Instant,
+            &TypedValue::UUID(_) => ValueType::UUID,
+            &TypedValue::URI(_) => ValueType::URI,
         }
     }
 }

--- a/db/src/entids.rs
+++ b/db/src/entids.rs
@@ -56,3 +56,7 @@ pub const DB_DOC: Entid = 35;
 // Added in SQL schema v2.
 pub const DB_SCHEMA_VERSION: Entid = 36;
 pub const DB_SCHEMA_ATTRIBUTE: Entid = 37;
+
+// Added in SQL schema v3.
+pub const DB_TYPE_UUID: Entid = 38;
+pub const DB_TYPE_URI: Entid = 39;

--- a/db/src/schema.rs
+++ b/db/src/schema.rs
@@ -103,6 +103,9 @@ impl SchemaBuilding for Schema {
                         TypedValue::Ref(entids::DB_TYPE_LONG) => { attributes.value_type = ValueType::Long; },
                         TypedValue::Ref(entids::DB_TYPE_STRING) => { attributes.value_type = ValueType::String; },
                         TypedValue::Ref(entids::DB_TYPE_KEYWORD) => { attributes.value_type = ValueType::Keyword; },
+                        TypedValue::Ref(entids::DB_TYPE_INSTANT) => { attributes.value_type = ValueType::Instant; },
+                        TypedValue::Ref(entids::DB_TYPE_UUID) => { attributes.value_type = ValueType::UUID; },
+                        TypedValue::Ref(entids::DB_TYPE_URI) => { attributes.value_type = ValueType::URI; },
                         _ => bail!(ErrorKind::BadSchemaAssertion(format!("Expected [... :db/valueType :db.type/*] but got [... :db/valueType {:?}] for ident '{}' and attribute '{}'", value, ident, attr)))
                     }
                 },


### PR DESCRIPTION
This is missing a v3.db to run in the `test_open_current_version` test in `db/src/db.rs`,but looking for a sanity check here. Commenting out that test, everything else passes. Unlikely I'll tackle the creation of a v3 DB in `./fixtures` and the SQL update migration for v1 -> v2 -> v3