### PR TITLE
Generate SQL. Fixes #273.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,6 @@ script:
   - cargo test --verbose -p mentat_query
   - cargo test --verbose -p mentat_query_parser
   - cargo test --verbose -p mentat_query_algebrizer
+  - cargo test --verbose -p mentat_query_translator
+  - cargo test --verbose -p mentat_sql
   - cargo test --verbose -p mentat_tx_parser

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,5 +40,8 @@ path = "query-parser"
 [dependencies.mentat_query_algebrizer]
 path = "query-algebrizer"
 
+[dependencies.mentat_query_translator]
+path = "query-translator"
+
 [dependencies.mentat_tx_parser]
 path = "tx-parser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,9 @@ path = "parser-utils"
 [dependencies.mentat_core]
 path = "core"
 
+[dependencies.mentat_sql]
+path = "sql"
+
 [dependencies.mentat_db]
 path = "db"
 

--- a/query-algebrizer/src/cc.rs
+++ b/query-algebrizer/src/cc.rs
@@ -47,7 +47,7 @@ pub enum DatomsTable {
 }
 
 impl DatomsTable {
-    fn name(&self) -> &'static str {
+    pub fn name(&self) -> &'static str {
         match *self {
             DatomsTable::Datoms => "datoms",
             DatomsTable::FulltextValues => "fulltext_values",
@@ -67,16 +67,30 @@ pub enum DatomsColumn {
     ValueTypeTag,
 }
 
+impl DatomsColumn {
+    pub fn as_str(&self) -> &'static str {
+        use DatomsColumn::*;
+        match *self {
+            Entity => "e",
+            Attribute => "a",
+            Value => "v",
+            Tx => "tx",
+            ValueTypeTag => "value_type_tag",
+        }
+    }
+}
+
+
 /// A specific instance of a table within a query. E.g., "datoms123".
 pub type TableAlias = String;
 
 /// The association between a table and its alias. E.g., AllDatoms, "all_datoms123".
 #[derive(PartialEq, Eq, Debug)]
-pub struct SourceAlias(DatomsTable, TableAlias);
+pub struct SourceAlias(pub DatomsTable, pub TableAlias);
 
 /// A particular column of a particular aliased table. E.g., "datoms123", Attribute.
 #[derive(PartialEq, Eq, Clone, Debug)]
-pub struct QualifiedAlias(TableAlias, DatomsColumn);
+pub struct QualifiedAlias(pub TableAlias, pub DatomsColumn);
 
 impl QualifiedAlias {
     fn for_type_tag(&self) -> QualifiedAlias {

--- a/query-algebrizer/src/lib.rs
+++ b/query-algebrizer/src/lib.rs
@@ -37,3 +37,16 @@ pub fn algebrize(parsed: FindQuery) -> AlgebraicQuery {
         cc: cc::ConjoiningClauses::default(),
     }
 }
+
+pub use cc::{
+    ConjoiningClauses,
+};
+
+pub use cc::{
+    DatomsColumn,
+    DatomsTable,
+    QualifiedAlias,
+    SourceAlias,
+    TableAlias,
+};
+

--- a/query-translator/Cargo.toml
+++ b/query-translator/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "mentat_query_translator"
+version = "0.0.1"
+
+[dependencies]
+[dependencies.mentat_sql]
+path = "../sql"
+
+[dependencies.mentat_query]
+path = "../query"
+
+[dependencies.mentat_query_algebrizer]
+path = "../query-algebrizer"

--- a/query-translator/src/lib.rs
+++ b/query-translator/src/lib.rs
@@ -1,0 +1,15 @@
+// Copyright 2016 Mozilla
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+extern crate mentat_query;
+extern crate mentat_query_algebrizer;
+extern crate mentat_sql;
+
+mod types;

--- a/query-translator/src/types.rs
+++ b/query-translator/src/types.rs
@@ -1,0 +1,271 @@
+// Copyright 2016 Mozilla
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#![allow(dead_code, unused_imports)]
+
+use mentat_query_algebrizer::{
+    AlgebraicQuery,
+    ConjoiningClauses,
+    DatomsColumn,
+    DatomsTable,
+    QualifiedAlias,
+    SourceAlias,
+};
+
+use mentat_sql::{
+    BuildQueryError,
+    BuildQueryResult,
+    QueryBuilder,
+    QueryFragment,
+    SQLiteQueryBuilder,
+};
+
+//---------------------------------------------------------
+// A Mentat-focused representation of a SQL query.
+
+enum ColumnOrExpression {
+    Column(QualifiedAlias),
+    Integer(i64),             // Because it's so common.
+}
+
+type Name = String;
+struct Projection (ColumnOrExpression, Name);
+
+#[derive(Clone)]
+struct Op(String);      // TODO
+enum Constraint {
+    Infix {
+        op: Op,
+        left: ColumnOrExpression,
+        right: ColumnOrExpression
+    }
+}
+
+enum JoinOp {
+    Inner,
+}
+
+// Short-hand for a list of tables all inner-joined.
+struct TableList(Vec<SourceAlias>);
+
+struct Join {
+    left: TableOrSubquery,
+    op: JoinOp,
+    right: TableOrSubquery,
+    // TODO: constraints (ON, USING).
+}
+enum TableOrSubquery {
+    Table(SourceAlias),
+    // TODO: Subquery.
+}
+
+enum FromClause {
+    TableList(TableList),      // Short-hand for a pile of inner joins.
+    Join(Join),
+}
+
+struct SelectQuery {
+    projection: Vec<Projection>,
+    from: FromClause,
+    constraints: Vec<Constraint>,
+}
+
+//---------------------------------------------------------
+// Turn that representation into SQL.
+
+impl QueryFragment for ColumnOrExpression {
+    fn to_sql(&self, out: &mut QueryBuilder) -> BuildQueryResult {
+        use self::ColumnOrExpression::*;
+        match self {
+            &Column(QualifiedAlias(ref table, ref column)) => {
+                out.push_identifier(table.as_str())?;
+                out.push_sql(".");
+                out.push_identifier(column.as_str())
+            },
+            &Integer(i) => {
+                out.push_sql(i.to_string().as_str());
+                Ok(())
+            }
+        }
+    }
+}
+
+impl QueryFragment for Projection {
+    fn to_sql(&self, out: &mut QueryBuilder) -> BuildQueryResult {
+        self.0.to_sql(out)?;
+        out.push_sql(" AS ");
+        out.push_identifier(self.1.as_str())
+    }
+}
+
+impl QueryFragment for Op {
+    fn to_sql(&self, out: &mut QueryBuilder) -> BuildQueryResult {
+        // No escaping needed.
+        out.push_sql(self.0.as_str());
+        Ok(())
+    }
+}
+
+impl QueryFragment for Constraint {
+    fn to_sql(&self, out: &mut QueryBuilder) -> BuildQueryResult {
+        use self::Constraint::*;
+        match self {
+            &Infix { ref op, ref left, ref right } => {
+                left.to_sql(out)?;
+                out.push_sql(" ");
+                op.to_sql(out)?;
+                out.push_sql(" ");
+                right.to_sql(out)
+            }
+        }
+    }
+}
+
+impl QueryFragment for JoinOp {
+    fn to_sql(&self, out: &mut QueryBuilder) -> BuildQueryResult {
+        out.push_sql(" JOIN ");
+        Ok(())
+    }
+}
+
+// We don't own SourceAlias or QueryFragment, so we can't implement the trait.
+fn source_alias_to_sql(out: &mut QueryBuilder, sa: &SourceAlias) -> BuildQueryResult {
+    let &SourceAlias(ref table, ref alias) = sa;
+    out.push_identifier(table.name())?;
+    out.push_sql(" AS ");
+    out.push_identifier(alias.as_str())
+}
+
+impl QueryFragment for TableList {
+    fn to_sql(&self, out: &mut QueryBuilder) -> BuildQueryResult {
+        if self.0.is_empty() {
+            return Ok(());
+        }
+
+        source_alias_to_sql(out, &self.0[0])?;
+
+        for sa in self.0[1..].iter() {
+            out.push_sql(", ");
+            source_alias_to_sql(out, sa)?;
+        }
+        Ok(())
+    }
+}
+
+impl QueryFragment for Join {
+    fn to_sql(&self, out: &mut QueryBuilder) -> BuildQueryResult {
+        self.left.to_sql(out)?;
+        self.op.to_sql(out)?;
+        self.right.to_sql(out)
+    }
+}
+
+impl QueryFragment for TableOrSubquery {
+    fn to_sql(&self, out: &mut QueryBuilder) -> BuildQueryResult {
+        use self::TableOrSubquery::*;
+        match self {
+            &Table(ref sa) => source_alias_to_sql(out, sa)
+        }
+    }
+}
+
+impl QueryFragment for FromClause {
+    fn to_sql(&self, out: &mut QueryBuilder) -> BuildQueryResult {
+        use self::FromClause::*;
+        match self {
+            &TableList(ref table_list) => table_list.to_sql(out),
+            &Join(ref join) => join.to_sql(out),
+        }
+    }
+}
+
+impl QueryFragment for SelectQuery {
+    fn to_sql(&self, out: &mut QueryBuilder) -> BuildQueryResult {
+        out.push_sql("SELECT ");
+        self.projection[0].to_sql(out)?;
+
+        for projection in self.projection[1..].iter() {
+            out.push_sql(", ");
+            projection.to_sql(out)?;
+        }
+
+        out.push_sql(" FROM ");
+        self.from.to_sql(out)?;
+
+        if self.constraints.is_empty() {
+            return Ok(());
+        }
+
+        out.push_sql(" WHERE ");
+        self.constraints[0].to_sql(out)?;
+
+        for constraint in self.constraints[1..].iter() {
+            out.push_sql(" AND ");
+            constraint.to_sql(out)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl SelectQuery {
+    fn to_sql_string(&self) -> Result<String, BuildQueryError> {
+        let mut builder = SQLiteQueryBuilder::new();
+        self.to_sql(&mut builder).map(|_| builder.finish())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_end_to_end() {
+
+        // [:find ?x :where [?x 65537 ?v] [?x 65536 ?v]]
+        let datoms00 = "datoms00".to_string();
+        let datoms01 = "datoms01".to_string();
+        let eq = Op("=".to_string());
+        let source_aliases = vec![
+            SourceAlias(DatomsTable::Datoms, datoms00.clone()),
+            SourceAlias(DatomsTable::Datoms, datoms01.clone()),
+        ];
+        let query = SelectQuery {
+            projection: vec![
+                Projection(
+                    ColumnOrExpression::Column(QualifiedAlias(datoms00.clone(), DatomsColumn::Entity)),
+                    "x".to_string(),
+                    ),
+            ],
+            from: FromClause::TableList(TableList(source_aliases)),
+            constraints: vec![
+                //ColumnOrExpression::Expression(TypedValue::Integer(15)),
+                Constraint::Infix {
+                    op: eq.clone(),
+                    left: ColumnOrExpression::Column(QualifiedAlias(datoms01.clone(), DatomsColumn::Value)),
+                    right: ColumnOrExpression::Column(QualifiedAlias(datoms00.clone(), DatomsColumn::Value)),
+                },
+                Constraint::Infix {
+                    op: eq.clone(),
+                    left: ColumnOrExpression::Column(QualifiedAlias(datoms00.clone(), DatomsColumn::Attribute)),
+                    right: ColumnOrExpression::Integer(65537),
+                },
+                Constraint::Infix {
+                    op: eq.clone(),
+                    left: ColumnOrExpression::Column(QualifiedAlias(datoms01.clone(), DatomsColumn::Attribute)),
+                    right: ColumnOrExpression::Integer(65536),
+                },
+            ],
+        };
+
+        let sql = query.to_sql_string().unwrap();
+        println!("{}", sql);
+    }
+}

--- a/sql/Cargo.toml
+++ b/sql/Cargo.toml
@@ -1,0 +1,3 @@
+[package]
+name = "mentat_sql"
+version = "0.0.1"

--- a/sql/README.md
+++ b/sql/README.md
@@ -1,0 +1,7 @@
+This is a tiny SQL query builder.
+
+The majority of this code was distilled from QueryBuilder in Diesel:
+
+https://github.com/diesel-rs/diesel/
+
+used under the Apache 2.0 license.

--- a/sql/src/lib.rs
+++ b/sql/src/lib.rs
@@ -1,0 +1,78 @@
+// Copyright 2016 Mozilla
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+use std::error::Error;
+
+pub type BuildQueryError = Box<Error+Send+Sync>;
+pub type BuildQueryResult = Result<(), BuildQueryError>;
+
+/// Gratefully based on Diesel's QueryBuilder trait:
+/// https://github.com/diesel-rs/diesel/blob/4885f61b8205f7f3c2cfa03837ed6714831abe6b/diesel/src/query_builder/mod.rs#L56
+pub trait QueryBuilder {
+    fn push_sql(&mut self, sql: &str);
+    fn push_identifier(&mut self, identifier: &str) -> BuildQueryResult;
+    fn push_bind_param(&mut self);
+    fn finish(self) -> String;
+}
+
+pub trait QueryFragment {
+    fn to_sql(&self, out: &mut QueryBuilder) -> BuildQueryResult;
+}
+
+impl QueryFragment for Box<QueryFragment> {
+    fn to_sql(&self, out: &mut QueryBuilder) -> BuildQueryResult {
+        QueryFragment::to_sql(&**self, out)
+    }
+}
+
+impl<'a> QueryFragment for &'a QueryFragment {
+    fn to_sql(&self, out: &mut QueryBuilder) -> BuildQueryResult {
+        QueryFragment::to_sql(&**self, out)
+    }
+}
+
+impl QueryFragment for () {
+    fn to_sql(&self, _out: &mut QueryBuilder) -> BuildQueryResult {
+        Ok(())
+    }
+}
+
+pub struct SQLiteQueryBuilder {
+    pub sql: String,
+}
+
+impl SQLiteQueryBuilder {
+    pub fn new() -> Self {
+        SQLiteQueryBuilder {
+            sql: String::new(),
+        }
+    }
+}
+
+impl QueryBuilder for SQLiteQueryBuilder {
+    fn push_sql(&mut self, sql: &str) {
+        self.sql.push_str(sql);
+    }
+
+    fn push_identifier(&mut self, identifier: &str) -> BuildQueryResult {
+        self.push_sql("`");
+        self.push_sql(&identifier.replace("`", "``"));
+        self.push_sql("`");
+        Ok(())
+    }
+
+    fn push_bind_param(&mut self) {
+        self.push_sql("?");
+    }
+
+    fn finish(self) -> String {
+        self.sql
+    }
+}


### PR DESCRIPTION
This is a little horrible, and entirely unoptimized, but it should do the trick for #273.

Not yet implemented is the conversion from an algebraic query to the SQL query representation (#301). That should be straightforward.

The output of the test query is:

```
SELECT `datoms00`.`e` AS `x` FROM `datoms` AS `datoms00`, `datoms` AS `datoms01` WHERE `datoms01`.`v` = `datoms00`.`v` AND `datoms00`.`a` = 65537 AND `datoms01`.`a` = 65536
```