### PR TITLE
TypedValue::Keyword now wraps a NamespacedKeyword rather than a String. Fixes #203.

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -48,7 +48,7 @@ pub enum TypedValue {
     Double(OrderedFloat<f64>),
     // TODO: &str throughout?
     String(String),
-    Keyword(String),
+    Keyword(NamespacedKeyword),
 }
 
 impl TypedValue {

--- a/db/src/bootstrap.rs
+++ b/db/src/bootstrap.rs
@@ -10,7 +10,6 @@
 
 #![allow(dead_code)]
 
-use ::{to_namespaced_keyword};
 use edn;
 use errors::{ErrorKind, Result};
 use edn::types::Value;
@@ -200,11 +199,10 @@ fn symbolic_schema_to_triples(ident_map: &IdentMap, symbolic_schema: &Value) -> 
                             // bootstrap symbolic schema, or by representing the initial bootstrap
                             // schema directly as Rust data.
                             let typed_value = match TypedValue::from_edn_value(value) {
-                                Some(TypedValue::Keyword(ref s)) => {
-                                    to_namespaced_keyword(s)
-                                        .and_then(|ident| ident_map.get(&ident))
+                                Some(TypedValue::Keyword(ref k)) => {
+                                    ident_map.get(k)
                                         .map(|entid| TypedValue::Ref(*entid))
-                                        .ok_or(ErrorKind::UnrecognizedIdent(s.clone()))?
+                                        .ok_or(ErrorKind::UnrecognizedIdent(k.to_string()))?
                                 },
                                 Some(v) => v,
                                 _ => bail!(ErrorKind::BadBootstrapDefinition(format!("Expected Mentat typed value for value but got '{:?}'", value)))

--- a/db/tests/value_tests.rs
+++ b/db/tests/value_tests.rs
@@ -35,7 +35,7 @@ fn test_from_sql_value_pair() {
     assert_eq!(TypedValue::from_sql_value_pair(rusqlite::types::Value::Real(0.5), 5).unwrap(), TypedValue::Double(OrderedFloat(0.5)));
 
     assert_eq!(TypedValue::from_sql_value_pair(rusqlite::types::Value::Text(":db/keyword".into()), 10).unwrap(), TypedValue::String(":db/keyword".into()));
-    assert_eq!(TypedValue::from_sql_value_pair(rusqlite::types::Value::Text(":db/keyword".into()), 13).unwrap(), TypedValue::Keyword(":db/keyword".into()));
+    assert_eq!(TypedValue::from_sql_value_pair(rusqlite::types::Value::Text(":db/keyword".into()), 13).unwrap(), TypedValue::Keyword(symbols::NamespacedKeyword::new("db", "keyword")));
 }
 
 #[test]
@@ -52,5 +52,5 @@ fn test_to_edn_value_pair() {
     assert_eq!(TypedValue::Double(OrderedFloat(0.5)).to_edn_value_pair(), (edn::Value::Float(OrderedFloat(0.5)), ValueType::Double));
 
     assert_eq!(TypedValue::String(":db/keyword".into()).to_edn_value_pair(), (edn::Value::Text(":db/keyword".into()), ValueType::String));
-    assert_eq!(TypedValue::Keyword(":db/keyword".into()).to_edn_value_pair(), (edn::Value::NamespacedKeyword(symbols::NamespacedKeyword::new("db", "keyword")), ValueType::Keyword));
+    assert_eq!(TypedValue::Keyword(symbols::NamespacedKeyword::new("db", "keyword")).to_edn_value_pair(), (edn::Value::NamespacedKeyword(symbols::NamespacedKeyword::new("db", "keyword")), ValueType::Keyword));
 }


### PR DESCRIPTION
Only pay mind to 4634502, this is based off of #300 PR