### PR TITLE
Change to_namespaced_keyword(s) to return a Result

### DIFF
--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -26,6 +26,7 @@ extern crate mentat_tx_parser;
 
 use itertools::Itertools;
 use std::iter::repeat;
+use errors::{ErrorKind, Result};
 
 pub mod db;
 mod bootstrap;
@@ -46,13 +47,16 @@ use edn::symbols;
 // TODO: replace with sqlite3_limit. #288.
 pub const SQLITE_MAX_VARIABLE_NUMBER: usize = 999;
 
-pub fn to_namespaced_keyword(s: &str) -> Option<symbols::NamespacedKeyword> {
+pub fn to_namespaced_keyword(s: &str) -> Result<symbols::NamespacedKeyword> {
     let splits = [':', '/'];
     let mut i = s.split(&splits[..]);
-    match (i.next(), i.next(), i.next(), i.next()) {
+    let nsk = match (i.next(), i.next(), i.next(), i.next()) {
         (Some(""), Some(namespace), Some(name), None) => Some(symbols::NamespacedKeyword::new(namespace, name)),
-        _ => None
-    }
+        _ => None,
+    };
+
+    // TODO Use custom ErrorKind https://github.com/brson/error-chain/issues/117
+    nsk.ok_or(ErrorKind::NotYetImplemented(format!("InvalidNamespacedKeyword: {}", s)).into())
 }
 
 /// Prepare an SQL `VALUES` block, like (?, ?, ?), (?, ?, ?).

--- a/db/src/schema.rs
+++ b/db/src/schema.rs
@@ -11,7 +11,7 @@
 #![allow(dead_code)]
 
 use entids;
-use errors::*;
+use errors::{ErrorKind, Result};
 use edn::symbols;
 use mentat_core::{
     Attribute,


### PR DESCRIPTION
Change to_namespaced_keyword(s) to return a Result rather than Option to reduce error handling throughout db code. Fixes #331. I think this is a good approach for reducing the to-be-implemented custom ErrorKind throughout code. You mentioned combining it into `schema.require_entid`, but that's a different usage (it checks the ident_map).