### PR TITLE
Remove most uses of `use foo::*`

### DIFF
--- a/db/src/db.rs
+++ b/db/src/db.rs
@@ -865,7 +865,6 @@ mod tests {
     use edn::symbols;
     use mentat_tx_parser;
     use rusqlite;
-    use types::*;
 
     #[test]
     fn test_open_current_version() {

--- a/db/src/internal_types.rs
+++ b/db/src/internal_types.rs
@@ -18,7 +18,12 @@ use std::rc::Rc;
 
 use errors;
 use errors::ErrorKind;
-use types::*;
+use types::{
+    AVMap,
+    AVPair,
+    Entid,
+    TypedValue,
+};
 use mentat_tx::entities::OpType;
 
 #[derive(Clone,Debug,Eq,Hash,Ord,PartialOrd,PartialEq)]

--- a/db/src/tx.rs
+++ b/db/src/tx.rs
@@ -50,7 +50,7 @@ use std::collections::BTreeSet;
 
 use db::{ReducedEntity, SearchType};
 use entids;
-use errors::*;
+use errors::{ErrorKind, Result};
 use internal_types::{
     LookupRefOrTempId,
     TempId,
@@ -65,7 +65,16 @@ use mentat_tx::entities as entmod;
 use mentat_tx::entities::{Entity, OpType};
 use rusqlite;
 use schema::SchemaBuilding;
-use types::*;
+use types::{
+    Attribute,
+    AVPair,
+    AVMap,
+    DB,
+    Entid,
+    TypedValue,
+    TxReport,
+    ValueType,
+};
 use upsert_resolution::Generation;
 
 /// A transaction on its way to being applied.

--- a/db/src/upsert_resolution.rs
+++ b/db/src/upsert_resolution.rs
@@ -18,8 +18,21 @@ use std::collections::BTreeSet;
 use mentat_tx::entities::OpType;
 use errors;
 use errors::ErrorKind;
-use types::{Attribute, AVPair, Entid, Schema, TypedValue};
-use internal_types::*;
+use types::{
+    Attribute,
+    AVPair,
+    Entid,
+    Schema,
+    TypedValue,
+};
+use internal_types::{
+    Population,
+    TempId,
+    TempIdMap,
+    Term,
+    TermWithoutTempIds,
+    TermWithTempIds,
+};
 use schema::SchemaBuilding;
 
 /// A "Simple upsert" that looks like [:db/add TEMPID a v], where a is :db.unique/identity.

--- a/query-parser/tests/find_tests.rs
+++ b/query-parser/tests/find_tests.rs
@@ -12,7 +12,7 @@ extern crate mentat_query_parser;
 extern crate mentat_query;
 extern crate edn;
 
-use mentat_query::FindSpec::*;
+use mentat_query::FindSpec::FindScalar;
 use mentat_query::Element;
 use mentat_query::Variable;
 use edn::PlainSymbol;


### PR DESCRIPTION
Not expanded are nested instances of `use super::*`, but maybe we should add those too. I held off just because that would be code that breaks itself.