### PR TITLE
Mark every project as being part of the workspace.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,3 @@
 language: rust
 script:
-  - cargo build --verbose
-  - cargo test --verbose
-  - cargo test --verbose -p edn
-  - cargo test --verbose -p mentat_parser_utils
-  - cargo test --verbose -p mentat_core
-  - cargo test --verbose -p mentat_db
-  - cargo test --verbose -p mentat_query
-  - cargo test --verbose -p mentat_query_parser
-  - cargo test --verbose -p mentat_query_algebrizer
-  - cargo test --verbose -p mentat_query_translator
-  - cargo test --verbose -p mentat_sql
-  - cargo test --verbose -p mentat_tx_parser
+  - cargo test --verbose --all

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ name = "mentat"
 version = "0.4.0"
 build = "build/version.rs"
 
+[workspace]
+members = []
+
 [build-dependencies]
 rustc_version = "0.1.7"
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "mentat_core"
 version = "0.0.1"
+workspace = ".."
 
 [dependencies]
 num = "0.1.35"

--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "mentat_db"
 version = "0.0.1"
+workspace = ".."
 
 [dependencies]
 error-chain = "0.8.0"

--- a/edn/Cargo.toml
+++ b/edn/Cargo.toml
@@ -2,6 +2,7 @@
 name = "edn"
 version = "0.1.0"
 authors = ["Joe Walker <jwalker@mozilla.com>"]
+workspace = ".."
 
 license = "Apache-2.0"
 repository = "https://github.com/mozilla/mentat"

--- a/parser-utils/Cargo.toml
+++ b/parser-utils/Cargo.toml
@@ -2,6 +2,7 @@
 name = "mentat_parser_utils"
 version = "0.1.0"
 authors = ["Victor Porof <vporof@mozilla.com>", "Richard Newman <rnewman@mozilla.com>"]
+workspace = ".."
 
 [dependencies]
 combine = "2.1.1"

--- a/query-algebrizer/Cargo.toml
+++ b/query-algebrizer/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "mentat_query_algebrizer"
 version = "0.0.1"
+workspace = ".."
 
 [dependencies]
 [dependencies.mentat_core]

--- a/query-parser/Cargo.toml
+++ b/query-parser/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "mentat_query_parser"
 version = "0.0.1"
+workspace = ".."
 
 [dependencies]
 combine = "2.1.1"

--- a/query-translator/Cargo.toml
+++ b/query-translator/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "mentat_query_translator"
 version = "0.0.1"
+workspace = ".."
 
 [dependencies]
 [dependencies.mentat_sql]

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "mentat_query"
 version = "0.0.1"
+workspace = ".."
 
 [dependencies]
 

--- a/sql/Cargo.toml
+++ b/sql/Cargo.toml
@@ -1,3 +1,4 @@
 [package]
 name = "mentat_sql"
 version = "0.0.1"
+workspace = ".."

--- a/tx-parser/Cargo.toml
+++ b/tx-parser/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "mentat_tx_parser"
 version = "0.0.1"
+workspace = ".."
 
 [dependencies]
 combine = "2.1.1"

--- a/tx/Cargo.toml
+++ b/tx/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "mentat_tx"
 version = "0.0.1"
+workspace = ".."
 
 [dependencies]
 [dependencies.edn]


### PR DESCRIPTION
This allows `cargo test --all` to work.