### PR TITLE
Moar SQL

### DIFF
--- a/query-algebrizer/src/cc.rs
+++ b/query-algebrizer/src/cc.rs
@@ -85,7 +85,7 @@ impl DatomsColumn {
 pub type TableAlias = String;
 
 /// The association between a table and its alias. E.g., AllDatoms, "all_datoms123".
-#[derive(PartialEq, Eq, Debug)]
+#[derive(PartialEq, Eq, Clone, Debug)]
 pub struct SourceAlias(pub DatomsTable, pub TableAlias);
 
 /// A particular column of a particular aliased table. E.g., "datoms123", Attribute.
@@ -153,10 +153,10 @@ pub struct ConjoiningClauses {
     aliaser: TableAliaser,
 
     /// A vector of source/alias pairs used to construct a SQL `FROM` list.
-    from: Vec<SourceAlias>,
+    pub from: Vec<SourceAlias>,
 
     /// A list of fragments that can be joined by `AND`.
-    wheres: Vec<ColumnConstraint>,
+    pub wheres: Vec<ColumnConstraint>,
 
     /// A map from var to qualified columns. Used to project.
     bindings: BTreeMap<Variable, Vec<QualifiedAlias>>,

--- a/query-translator/Cargo.toml
+++ b/query-translator/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.0.1"
 workspace = ".."
 
 [dependencies]
+[dependencies.mentat_core]
+path = "../core"
+
 [dependencies.mentat_sql]
 path = "../sql"
 
@@ -12,3 +15,7 @@ path = "../query"
 
 [dependencies.mentat_query_algebrizer]
 path = "../query-algebrizer"
+
+# Only for tests.
+[dev-dependencies.mentat_query_parser]
+path = "../query-parser"

--- a/query-translator/src/lib.rs
+++ b/query-translator/src/lib.rs
@@ -8,8 +8,15 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
+extern crate mentat_core;
 extern crate mentat_query;
 extern crate mentat_query_algebrizer;
 extern crate mentat_sql;
 
+mod translate;
 mod types;
+
+pub use translate::{
+    cc_to_exists,
+    cc_to_select,
+};

--- a/query-translator/src/translate.rs
+++ b/query-translator/src/translate.rs
@@ -1,0 +1,76 @@
+// Copyright 2016 Mozilla
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#![allow(dead_code, unused_imports)]
+
+use mentat_query_algebrizer::{
+    AlgebraicQuery,
+    ColumnConstraint,
+    ConjoiningClauses,
+    DatomsColumn,
+    DatomsTable,
+    QualifiedAlias,
+    SourceAlias,
+};
+
+use types::{
+    ColumnOrExpression,
+    Constraint,
+    FromClause,
+    Projection,
+    SelectQuery,
+    TableList,
+};
+
+trait ToConstraint {
+    fn to_constraint(self) -> Constraint;
+}
+
+trait ToColumn {
+    fn to_column(self) -> ColumnOrExpression;
+}
+
+impl ToColumn for QualifiedAlias {
+    fn to_column(self) -> ColumnOrExpression {
+        ColumnOrExpression::Column(self)
+    }
+}
+
+impl ToConstraint for ColumnConstraint {
+    fn to_constraint(self) -> Constraint {
+        use self::ColumnConstraint::*;
+        match self {
+            EqualsEntity(qa, entid) =>
+                Constraint::equal(qa.to_column(), ColumnOrExpression::Integer(entid)),
+            EqualsValue(qa, tv) =>
+                Constraint::equal(qa.to_column(), ColumnOrExpression::Value(tv)),
+            EqualsColumn(left, right) =>
+                Constraint::equal(left.to_column(), right.to_column()),
+        }
+    }
+}
+
+
+/// Consume a provided `ConjoiningClauses` to yield a new
+/// `SelectQuery`. A projection list must also be provided.
+pub fn cc_to_select(projection: Projection, cc: ConjoiningClauses) -> SelectQuery {
+    SelectQuery {
+        projection: projection,
+        from: FromClause::TableList(TableList(cc.from)),
+        constraints: cc.wheres
+                       .into_iter()
+                       .map(|c| c.to_constraint())
+                       .collect(),
+    }
+}
+
+pub fn cc_to_exists(cc: ConjoiningClauses) -> SelectQuery {
+    cc_to_select(Projection::One, cc)
+}

--- a/query-translator/src/types.rs
+++ b/query-translator/src/types.rs
@@ -142,6 +142,7 @@ impl QueryFragment for Projection {
                 out.push_identifier(alias.as_str())?;
 
                 for &ProjectedColumn(ref col, ref alias) in &cols[1..] {
+                    out.push_sql(", ");
                     col.push_sql(out)?;
                     out.push_sql(" AS ");
                     out.push_identifier(alias.as_str())?;

--- a/query-translator/tests/translate.rs
+++ b/query-translator/tests/translate.rs
@@ -1,0 +1,61 @@
+// Copyright 2016 Mozilla
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+extern crate mentat_core;
+extern crate mentat_query;
+extern crate mentat_query_algebrizer;
+extern crate mentat_query_parser;
+extern crate mentat_query_translator;
+extern crate mentat_sql;
+
+use mentat_query::NamespacedKeyword;
+
+use mentat_core::{
+    Attribute,
+    Entid,
+    Schema,
+    ValueType,
+};
+
+use mentat_query_parser::parse_find_string;
+use mentat_query_algebrizer::algebrize;
+use mentat_query_translator::{
+    cc_to_exists,
+};
+
+use mentat_sql::SQLQuery;
+
+fn associate_ident(schema: &mut Schema, i: NamespacedKeyword, e: Entid) {
+    schema.entid_map.insert(e, i.clone());
+    schema.ident_map.insert(i.clone(), e);
+}
+
+fn add_attribute(schema: &mut Schema, e: Entid, a: Attribute) {
+    schema.schema_map.insert(e, a);
+}
+
+#[test]
+fn test_exists() {
+    let mut schema = Schema::default();
+    associate_ident(&mut schema, NamespacedKeyword::new("foo", "bar"), 99);
+    add_attribute(&mut schema, 99, Attribute {
+        value_type: ValueType::String,
+        ..Default::default()
+    });
+
+    let input = r#"[:find ?x :where [?x :foo/bar "yyy"]]"#;
+    let parsed = parse_find_string(input).unwrap();
+    let algebrized = algebrize(&schema, parsed);
+    let select = cc_to_exists(algebrized.cc);
+    let SQLQuery { sql, args } = select.to_sql_query().unwrap();
+    assert_eq!(sql, "SELECT 1 FROM `datoms` AS `datoms00` WHERE `datoms00`.a = 99 AND `datoms00`.v = $v0");
+    assert_eq!(args, vec![("$v0".to_string(), "yyy".to_string())]);
+}
+

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -6,7 +6,7 @@ workspace = ".."
 [dependencies]
 
 [dependencies.edn]
-  path = "../edn"
+path = "../edn"
 
 [dependencies.mentat_core]
-  path = "../core"
+path = "../core"

--- a/sql/Cargo.toml
+++ b/sql/Cargo.toml
@@ -2,3 +2,9 @@
 name = "mentat_sql"
 version = "0.0.1"
 workspace = ".."
+
+[dependencies]
+ordered-float = "0.4.0"
+
+[dependencies.mentat_core]
+path = "../core"

--- a/sql/src/lib.rs
+++ b/sql/src/lib.rs
@@ -8,18 +8,40 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
+extern crate ordered_float;
+extern crate mentat_core;
+
 use std::error::Error;
+
+use ordered_float::OrderedFloat;
+
+use mentat_core::TypedValue;
 
 pub type BuildQueryError = Box<Error + Send + Sync>;
 pub type BuildQueryResult = Result<(), BuildQueryError>;
+
+pub enum BindParamError {
+    InvalidParameterName(String),
+    BindParamCouldBeGenerated(String),
+}
+
+/// We want to accumulate values that will later be substituted into a SQL statement execution.
+/// This struct encapsulates the generated string and the _initial_ argument list.
+pub struct SQLQuery {
+    pub sql: String,
+
+    /// These will eventually perhaps be rusqlite `ToSql` instances.
+    pub args: Vec<(String, String)>,
+}
 
 /// Gratefully based on Diesel's QueryBuilder trait:
 /// https://github.com/diesel-rs/diesel/blob/4885f61b8205f7f3c2cfa03837ed6714831abe6b/diesel/src/query_builder/mod.rs#L56
 pub trait QueryBuilder {
     fn push_sql(&mut self, sql: &str);
     fn push_identifier(&mut self, identifier: &str) -> BuildQueryResult;
-    fn push_bind_param(&mut self);
-    fn finish(self) -> String;
+    fn push_typed_value(&mut self, value: &TypedValue) -> BuildQueryResult;
+    fn push_bind_param(&mut self, name: &str) -> Result<(), BindParamError>;
+    fn finish(self) -> SQLQuery;
 }
 
 pub trait QueryFragment {
@@ -47,13 +69,35 @@ impl QueryFragment for () {
 /// A QueryBuilder that implements SQLite's specific escaping rules.
 pub struct SQLiteQueryBuilder {
     pub sql: String,
+
+    arg_prefix: String,
+    arg_counter: i64,
+    args: Vec<(String, String)>,
 }
 
 impl SQLiteQueryBuilder {
     pub fn new() -> Self {
+        SQLiteQueryBuilder::with_prefix("$v".to_string())
+    }
+
+    pub fn with_prefix(prefix: String) -> Self {
         SQLiteQueryBuilder {
             sql: String::new(),
+            arg_prefix: prefix,
+            arg_counter: 0,
+            args: vec![],
         }
+    }
+
+    fn push_static_arg(&mut self, val: String) {
+        let arg = format!("{}{}", self.arg_prefix, self.arg_counter);
+        self.arg_counter = self.arg_counter + 1;
+        self.push_named_arg(arg.as_str());
+        self.args.push((arg, val));
+    }
+
+    fn push_named_arg(&mut self, arg: &str) {
+        self.push_sql(arg);
     }
 }
 
@@ -69,11 +113,70 @@ impl QueryBuilder for SQLiteQueryBuilder {
         Ok(())
     }
 
-    fn push_bind_param(&mut self) {
-        self.push_sql("?");
+    fn push_typed_value(&mut self, value: &TypedValue) -> BuildQueryResult {
+        use TypedValue::*;
+        match value {
+            &Ref(entid) => self.push_sql(entid.to_string().as_str()),
+            &Boolean(v) => self.push_sql(if v { "1" } else { "0" }),
+            &Long(v) => self.push_sql(v.to_string().as_str()),
+            &Double(OrderedFloat(v)) => self.push_sql(v.to_string().as_str()),
+            &String(ref s) => self.push_static_arg(s.clone()),
+            &Keyword(ref s) => self.push_static_arg(s.to_string()),
+        }
+        Ok(())
     }
 
-    fn finish(self) -> String {
-        self.sql
+    /// Our bind parameters will be interleaved with pushed `TypedValue` instances. That means we
+    /// need to use named parameters, not positional parameters.
+    /// The `name` argument to this method is expected to be alphanumeric. If not, this method
+    /// returns an `InvalidParameterName` error result.
+    /// Callers should make sure that the name doesn't overlap with generated parameter names. If
+    /// it does, `BindParamCouldBeGenerated` is the error.
+    fn push_bind_param(&mut self, name: &str) -> Result<(), BindParamError> {
+        // Do some validation first.
+        // This is not free, but it's probably worth it for now.
+        if !name.chars().all(char::is_alphanumeric) {
+            return Err(BindParamError::InvalidParameterName(name.to_string()));
+        }
+
+        if name.starts_with(self.arg_prefix.as_str()) &&
+           name.chars().skip(self.arg_prefix.len()).all(char::is_numeric) {
+               return Err(BindParamError::BindParamCouldBeGenerated(name.to_string()));
+        }
+
+        self.push_sql("$");
+        self.push_sql(name);
+        Ok(())
+    }
+
+    fn finish(self) -> SQLQuery {
+        SQLQuery {
+            sql: self.sql,
+            args: self.args,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sql() {
+        let mut s = SQLiteQueryBuilder::new();
+        s.push_sql("SELECT ");
+        s.push_identifier("foo").unwrap();
+        s.push_sql(" WHERE ");
+        s.push_identifier("bar").unwrap();
+        s.push_sql(" = ");
+        s.push_static_arg("frobnicate".to_string());
+        s.push_sql(" OR ");
+        s.push_static_arg("swoogle".to_string());
+        let q = s.finish();
+
+        assert_eq!(q.sql.as_str(), "SELECT `foo` WHERE `bar` = $v0 OR $v1");
+        assert_eq!(q.args,
+                   vec![("$v0".to_string(), "frobnicate".to_string()),
+                        ("$v1".to_string(), "swoogle".to_string())]);
     }
 }


### PR DESCRIPTION
The bulk of this PR is about accumulating values into SQL.

When faced with a Datalog query like:

```clojure
[:find … [?x _ "foo bar"]]
```

We have a choice: try to expand those literals into the query, escaping appropriately, reserving the parameter list for user-supplied parameters… or we can not solve the escaping problem and instead use bindings.

I took the latter approach for all non-numeric values. But that means we can end up with a SQL query that interleaves user parameter inputs with query literals:

```clojure
[:find ?x :in ?foo [?x :foo/baz "something"] [?x :foo/bar ?foo]]
```

turns into something like

```sql
SELECT datoms00.e AS x
FROM datoms AS datoms00, datoms AS datoms01
WHERE datoms00.a = 65591
  AND datoms00.v = ?                -- This needs to be "something"
  AND datoms01.a = 65592
  AND datoms01.v = ?                 -- This needs to be ?foo
```

Using positional arguments for `?foo` would be difficult: we might have positions 0, 1, and 3 be pre-bound and positions 2 and 4 being inputs.

The obvious solution is to use named parameters. That's the approach taken here: we use named parameters for these 'synthetic' value bindings, and also named parameters for input variables.

This handily also avoids the need to ever duplicate an argument: SQLite will take care of looking them up multiple times.

On top of this work, I've implemented rudimentary algebrizing and rudimentary translation into SQL, culminating in a simple end-to-end query example.