### PR TITLE
Db and errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ rustc_version = "0.1.7"
 
 [dependencies]
 clap = "2.19.3"
+error-chain = "0.9.0"
 nickel = "0.9.0"
 slog = "1.4.0"
 slog-scope = "0.2.2"

--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 workspace = ".."
 
 [dependencies]
-error-chain = "0.8.0"
+error-chain = "0.9.0"
 itertools = "0.5.9"
 lazy_static = "0.2.2"
 ordered-float = "0.4.0"

--- a/db/src/bootstrap.rs
+++ b/db/src/bootstrap.rs
@@ -96,8 +96,8 @@ lazy_static! {
     static ref V1_SYMBOLIC_SCHEMA: Value = {
         let s = r#"
 {:db/ident             {:db/valueType   :db.type/keyword
-                       :db/cardinality :db.cardinality/one
-                       :db/unique      :db.unique/identity}
+                        :db/cardinality :db.cardinality/one
+                        :db/unique      :db.unique/identity}
  :db.install/partition {:db/valueType   :db.type/ref
                         :db/cardinality :db.cardinality/many}
  :db.install/valueType {:db/valueType   :db.type/ref

--- a/db/src/db.rs
+++ b/db/src/db.rs
@@ -873,11 +873,11 @@ mod tests {
         let db = read_db(&conn).unwrap();
 
         // Does not include :db/txInstant.
-        let datoms = debug::datoms_after(&conn, &db, 0).unwrap();
+        let datoms = debug::datoms_after(&conn, &db.schema, 0).unwrap();
         assert_eq!(datoms.0.len(), 88);
 
         // Includes :db/txInstant.
-        let transactions = debug::transactions_after(&conn, &db, 0).unwrap();
+        let transactions = debug::transactions_after(&conn, &db.schema, 0).unwrap();
         assert_eq!(transactions.0.len(), 1);
         assert_eq!(transactions.0[0].0.len(), 89);
     }
@@ -920,7 +920,7 @@ mod tests {
                 let report = maybe_report.unwrap();
                 assert_eq!(report.tx_id, bootstrap::TX0 + index + 1);
 
-                let transactions = debug::transactions_after(&conn, &db, bootstrap::TX0 + index).unwrap();
+                let transactions = debug::transactions_after(&conn, &db.schema, bootstrap::TX0 + index).unwrap();
                 assert_eq!(transactions.0.len(), 1);
                 assert_eq!(*expected_transaction,
                            transactions.0[0].into_edn(),
@@ -928,7 +928,7 @@ mod tests {
             }
 
             if let Some(expected_datoms) = expected_datoms {
-                let datoms = debug::datoms_after(&conn, &db, bootstrap::TX0).unwrap();
+                let datoms = debug::datoms_after(&conn, &db.schema, bootstrap::TX0).unwrap();
                 assert_eq!(*expected_datoms,
                            datoms.into_edn(),
                            "\n{} - expected datoms:\n{}\nbut got datoms:\n{}", label, *expected_datoms, datoms.into_edn())
@@ -947,11 +947,11 @@ mod tests {
         let mut db = ensure_current_version(&mut conn).unwrap();
 
         // Does not include :db/txInstant.
-        let datoms = debug::datoms_after(&conn, &db, 0).unwrap();
+        let datoms = debug::datoms_after(&conn, &db.schema, 0).unwrap();
         assert_eq!(datoms.0.len(), 88);
 
         // Includes :db/txInstant.
-        let transactions = debug::transactions_after(&conn, &db, 0).unwrap();
+        let transactions = debug::transactions_after(&conn, &db.schema, 0).unwrap();
         assert_eq!(transactions.0.len(), 1);
         assert_eq!(transactions.0[0].0.len(), 89);
 
@@ -968,11 +968,11 @@ mod tests {
         let mut db = ensure_current_version(&mut conn).unwrap();
 
         // Does not include :db/txInstant.
-        let datoms = debug::datoms_after(&conn, &db, 0).unwrap();
+        let datoms = debug::datoms_after(&conn, &db.schema, 0).unwrap();
         assert_eq!(datoms.0.len(), 88);
 
         // Includes :db/txInstant.
-        let transactions = debug::transactions_after(&conn, &db, 0).unwrap();
+        let transactions = debug::transactions_after(&conn, &db.schema, 0).unwrap();
         assert_eq!(transactions.0.len(), 1);
         assert_eq!(transactions.0[0].0.len(), 89);
 
@@ -988,11 +988,11 @@ mod tests {
         let mut db = ensure_current_version(&mut conn).unwrap();
 
         // Does not include :db/txInstant.
-        let datoms = debug::datoms_after(&conn, &db, 0).unwrap();
+        let datoms = debug::datoms_after(&conn, &db.schema, 0).unwrap();
         assert_eq!(datoms.0.len(), 88);
 
         // Includes :db/txInstant.
-        let transactions = debug::transactions_after(&conn, &db, 0).unwrap();
+        let transactions = debug::transactions_after(&conn, &db.schema, 0).unwrap();
         assert_eq!(transactions.0.len(), 1);
         assert_eq!(transactions.0[0].0.len(), 89);
 

--- a/db/src/db.rs
+++ b/db/src/db.rs
@@ -22,7 +22,7 @@ use itertools::Itertools;
 use rusqlite;
 use rusqlite::types::{ToSql, ToSqlOutput};
 
-use ::{now, repeat_values, to_namespaced_keyword};
+use ::{repeat_values, to_namespaced_keyword};
 use bootstrap;
 use edn::types::Value;
 use edn::symbols;
@@ -35,7 +35,6 @@ use mentat_core::{
     TypedValue,
     ValueType,
 };
-use mentat_tx::entities::Entity;
 use errors::{ErrorKind, Result, ResultExt};
 use schema::SchemaBuilding;
 use types::{
@@ -44,9 +43,8 @@ use types::{
     DB,
     Partition,
     PartitionMap,
-    TxReport,
 };
-use tx::Tx;
+use tx::transact;
 
 pub fn new_connection<T>(uri: T) -> rusqlite::Result<rusqlite::Connection> where T: AsRef<Path> {
     let conn = match uri.as_ref().to_string_lossy().len() {
@@ -209,13 +207,20 @@ pub fn create_current_version(conn: &mut rusqlite::Connection) -> Result<DB> {
     }
 
     // TODO: return to transact_internal to self-manage the encompassing SQLite transaction.
-    let mut bootstrap_db = DB::new(bootstrap_partition_map, bootstrap::bootstrap_schema());
-    bootstrap_db.transact(&tx, bootstrap::bootstrap_entities())?;
+    let bootstrap_schema = bootstrap::bootstrap_schema();
+    let (_report, next_partition_map, next_schema) = transact(&tx, &bootstrap_partition_map, &bootstrap_schema, bootstrap::bootstrap_entities())?;
+    if next_schema.is_some() {
+        // TODO Use custom ErrorKind https://github.com/brson/error-chain/issues/117
+        bail!(ErrorKind::NotYetImplemented(format!("Initial bootstrap transaction did not produce expected bootstrap schema")));
+    }
 
     set_user_version(&tx, CURRENT_VERSION)?;
 
     // TODO: use the drop semantics to do this automagically?
     tx.commit()?;
+
+    // TODO: ensure that schema is not changed by bootstrap transaction.
+    let bootstrap_db = DB::new(next_partition_map, bootstrap_schema);
     Ok(bootstrap_db)
 }
 
@@ -457,8 +462,13 @@ pub enum SearchType {
     Inexact,
 }
 
-impl DB {
-
+/// `MentatStoring` will be the trait that encapsulates the storage layer.  It is consumed by the
+/// transaction processing layer.
+///
+/// Right now, the only implementation of `MentatStoring` is the SQLite-specific SQL schema.  In the
+/// future, we might consider other SQL engines (perhaps with different fulltext indexing), or
+/// entirely different data stores, say ones shaped like key-value stores.
+pub trait MentatStoring {
     /// Given a slice of [a v] lookup-refs, look up the corresponding [e a v] triples.
     ///
     /// It is assumed that the attribute `a` in each lookup-ref is `:db/unique`, so that at most one
@@ -466,8 +476,135 @@ impl DB {
     /// chosen non-deterministically, if one exists.)
     ///
     /// Returns a map &(a, v) -> e, to avoid cloning potentially large values.  The keys of the map
-    /// are exactly those (a, v) pairs that have an assertion [e a v] in the datom store.
-    pub fn resolve_avs<'a>(&self, conn: &rusqlite::Connection, avs: &'a [&'a AVPair]) -> Result<AVMap<'a>> {
+    /// are exactly those (a, v) pairs that have an assertion [e a v] in the store.
+    fn resolve_avs<'a>(&self, avs: &'a [&'a AVPair]) -> Result<AVMap<'a>>;
+
+    /// Begin (or prepare) the underlying storage layer for a new Mentat transaction.
+    ///
+    /// Use this to create temporary tables, prepare indices, set pragmas, etc, before the initial
+    /// `insert_non_fts_searches` invocation.
+    fn begin_transaction(&self) -> Result<()>;
+
+    // TODO: this is not a reasonable abstraction, but I don't want to really consider non-SQL storage just yet.
+    fn insert_non_fts_searches<'a>(&self, entities: &'a [ReducedEntity], search_type: SearchType) -> Result<()>;
+
+    /// Finalize the underlying storage layer after a Mentat transaction.
+    ///
+    /// Use this to finalize temporary tables, complete indices, revert pragmas, etc, after the
+    /// final `insert_non_fts_searches` invocation.
+    fn commit_transaction(&self, tx_id: Entid) -> Result<()>;
+}
+
+/// Take search rows and complete `temp.search_results`.
+///
+/// See https://github.com/mozilla/mentat/wiki/Transacting:-entity-to-SQL-translation.
+fn search(conn: &rusqlite::Connection) -> Result<()> {
+    // First is fast, only one table walk: lookup by exact eav.
+    // Second is slower, but still only one table walk: lookup old value by ea.
+    let s = r#"
+      INSERT INTO temp.search_results
+      SELECT t.e0, t.a0, t.v0, t.value_type_tag0, t.added0, t.flags0, ':db.cardinality/many', d.rowid, d.v
+      FROM temp.exact_searches AS t
+      LEFT JOIN datoms AS d
+      ON t.e0 = d.e AND
+         t.a0 = d.a AND
+         t.value_type_tag0 = d.value_type_tag AND
+         t.v0 = d.v
+
+      UNION ALL
+
+      SELECT t.e0, t.a0, t.v0, t.value_type_tag0, t.added0, t.flags0, ':db.cardinality/one', d.rowid, d.v
+      FROM temp.inexact_searches AS t
+      LEFT JOIN datoms AS d
+      ON t.e0 = d.e AND
+         t.a0 = d.a"#;
+
+    let mut stmt = conn.prepare_cached(s)?;
+    stmt.execute(&[])
+        .map(|_c| ())
+        .chain_err(|| "Could not search!")
+}
+
+/// Insert the new transaction into the `transactions` table.
+///
+/// This turns the contents of `search_results` into a new transaction.
+///
+/// See https://github.com/mozilla/mentat/wiki/Transacting:-entity-to-SQL-translation.
+fn insert_transaction(conn: &rusqlite::Connection, tx: Entid) -> Result<()> {
+    let s = r#"
+      INSERT INTO transactions (e, a, v, tx, added, value_type_tag)
+      SELECT e0, a0, v0, ?, 1, value_type_tag0
+      FROM temp.search_results
+      WHERE added0 IS 1 AND ((rid IS NULL) OR ((rid IS NOT NULL) AND (v0 IS NOT v)))"#;
+
+    let mut stmt = conn.prepare_cached(s)?;
+    stmt.execute(&[&tx])
+        .map(|_c| ())
+        .chain_err(|| "Could not insert transaction: failed to add datoms not already present")?;
+
+    let s = r#"
+      INSERT INTO transactions (e, a, v, tx, added, value_type_tag)
+      SELECT e0, a0, v, ?, 0, value_type_tag0
+      FROM temp.search_results
+      WHERE rid IS NOT NULL AND
+            ((added0 IS 0) OR
+             (added0 IS 1 AND search_type IS ':db.cardinality/one' AND v0 IS NOT v))"#;
+
+    let mut stmt = conn.prepare_cached(s)?;
+    stmt.execute(&[&tx])
+        .map(|_c| ())
+        .chain_err(|| "Could not insert transaction: failed to retract datoms already present")?;
+
+    Ok(())
+}
+
+/// Update the contents of the `datoms` materialized view with the new transaction.
+///
+/// This applies the contents of `search_results` to the `datoms` table (in place).
+///
+/// See https://github.com/mozilla/mentat/wiki/Transacting:-entity-to-SQL-translation.
+fn update_datoms(conn: &rusqlite::Connection, tx: Entid) -> Result<()> {
+    // Delete datoms that were retracted, or those that were :db.cardinality/one and will be
+    // replaced.
+    let s = r#"
+        WITH ids AS (SELECT rid
+                     FROM temp.search_results
+                     WHERE rid IS NOT NULL AND
+                           ((added0 IS 0) OR
+                            (added0 IS 1 AND search_type IS ':db.cardinality/one' AND v0 IS NOT v)))
+        DELETE FROM datoms WHERE rowid IN ids"#;
+
+    let mut stmt = conn.prepare_cached(s)?;
+    stmt.execute(&[])
+        .map(|_c| ())
+        .chain_err(|| "Could not update datoms: failed to retract datoms already present")?;
+
+    // Insert datoms that were added and not already present. We also must
+    // expand our bitfield into flags.
+    let s = format!(r#"
+      INSERT INTO datoms (e, a, v, tx, value_type_tag, index_avet, index_vaet, index_fulltext, unique_value)
+      SELECT e0, a0, v0, ?, value_type_tag0,
+             flags0 & {} IS NOT 0,
+             flags0 & {} IS NOT 0,
+             flags0 & {} IS NOT 0,
+             flags0 & {} IS NOT 0
+      FROM temp.search_results
+      WHERE added0 IS 1 AND ((rid IS NULL) OR ((rid IS NOT NULL) AND (v0 IS NOT v)))"#,
+      AttributeBitFlags::IndexAVET as u8,
+      AttributeBitFlags::IndexVAET as u8,
+      AttributeBitFlags::IndexFulltext as u8,
+      AttributeBitFlags::UniqueValue as u8);
+
+    let mut stmt = conn.prepare_cached(&s)?;
+    stmt.execute(&[&tx])
+        .map(|_c| ())
+        .chain_err(|| "Could not update datoms: failed to add datoms not already present")?;
+
+    Ok(())
+}
+
+impl MentatStoring for rusqlite::Connection {
+    fn resolve_avs<'a>(&self, avs: &'a [&'a AVPair]) -> Result<AVMap<'a>> {
         // Start search_id's at some identifiable number.
         let initial_search_id = 2000;
         let bindings_per_statement = 4;
@@ -511,7 +648,7 @@ impl DB {
                                      FROM t, all_datoms AS d \
                                      WHERE d.index_avet IS NOT 0 AND d.a = t.a AND d.value_type_tag = t.value_type_tag AND d.v = t.v",
                                     values);
-            let mut stmt: rusqlite::Statement = conn.prepare(s.as_str())?;
+            let mut stmt: rusqlite::Statement = self.prepare(s.as_str())?;
 
             let m: Result<Vec<(i64, Entid)>> = stmt.query_and_then(&params, |row| -> Result<(i64, Entid)> {
                 Ok((row.get_checked(0)?, row.get_checked(1)?))
@@ -531,7 +668,7 @@ impl DB {
     }
 
     /// Create empty temporary tables for search parameters and search results.
-    fn create_temp_tables(&self, conn: &rusqlite::Connection) -> Result<()> {
+    fn begin_transaction(&self) -> Result<()> {
         // We can't do this in one shot, since we can't prepare a batch statement.
         let statements = [
             r#"DROP TABLE IF EXISTS temp.exact_searches"#,
@@ -578,7 +715,7 @@ impl DB {
         ];
 
         for statement in &statements {
-            let mut stmt = conn.prepare_cached(statement)?;
+            let mut stmt = self.prepare_cached(statement)?;
             stmt.execute(&[])
                 .map(|_c| ())
                 .chain_err(|| "Failed to create temporary tables")?;
@@ -591,7 +728,7 @@ impl DB {
     ///
     /// Eventually, the details of this approach will be captured in
     /// https://github.com/mozilla/mentat/wiki/Transacting:-entity-to-SQL-translation.
-    pub fn insert_non_fts_searches<'a>(&self, conn: &rusqlite::Connection, entities: &'a [ReducedEntity<'a>], search_type: SearchType) -> Result<()> {
+    fn insert_non_fts_searches<'a>(&self, entities: &'a [ReducedEntity<'a>], search_type: SearchType) -> Result<()> {
         let bindings_per_statement = 6;
 
         let chunks: itertools::IntoChunks<_> = entities.into_iter().chunks(::SQLITE_MAX_VARIABLE_NUMBER / bindings_per_statement);
@@ -639,7 +776,7 @@ impl DB {
             };
 
             // TODO: consider ensuring we inserted the expected number of rows.
-            let mut stmt = conn.prepare_cached(s.as_str())?;
+            let mut stmt = self.prepare_cached(s.as_str())?;
             stmt.execute(&params)
                 .map(|_c| ())
                 .chain_err(|| "Could not insert non-fts one statements into temporary search table!")
@@ -648,132 +785,11 @@ impl DB {
         results.map(|_| ())
     }
 
-    /// Take search rows and complete `temp.search_results`.
-    ///
-    /// See https://github.com/mozilla/mentat/wiki/Transacting:-entity-to-SQL-translation.
-    pub fn search(&self, conn: &rusqlite::Connection) -> Result<()> {
-        // First is fast, only one table walk: lookup by exact eav.
-        // Second is slower, but still only one table walk: lookup old value by ea.
-        let s = r#"
-          INSERT INTO temp.search_results
-          SELECT t.e0, t.a0, t.v0, t.value_type_tag0, t.added0, t.flags0, ':db.cardinality/many', d.rowid, d.v
-          FROM temp.exact_searches AS t
-          LEFT JOIN datoms AS d
-          ON t.e0 = d.e AND
-             t.a0 = d.a AND
-             t.value_type_tag0 = d.value_type_tag AND
-             t.v0 = d.v
-
-          UNION ALL
-
-          SELECT t.e0, t.a0, t.v0, t.value_type_tag0, t.added0, t.flags0, ':db.cardinality/one', d.rowid, d.v
-          FROM temp.inexact_searches AS t
-          LEFT JOIN datoms AS d
-          ON t.e0 = d.e AND
-             t.a0 = d.a"#;
-
-        let mut stmt = conn.prepare_cached(s)?;
-        stmt.execute(&[])
-            .map(|_c| ())
-            .chain_err(|| "Could not search!")
-    }
-
-    /// Insert the new transaction into the `transactions` table.
-    ///
-    /// This turns the contents of `search_results` into a new transaction.
-    ///
-    /// See https://github.com/mozilla/mentat/wiki/Transacting:-entity-to-SQL-translation.
-    // TODO: capture `conn` in a `TxInternal` structure.
-    pub fn insert_transaction(&self, conn: &rusqlite::Connection, tx: Entid) -> Result<()> {
-        let s = r#"
-          INSERT INTO transactions (e, a, v, tx, added, value_type_tag)
-          SELECT e0, a0, v0, ?, 1, value_type_tag0
-          FROM temp.search_results
-          WHERE added0 IS 1 AND ((rid IS NULL) OR ((rid IS NOT NULL) AND (v0 IS NOT v)))"#;
-
-        let mut stmt = conn.prepare_cached(s)?;
-        stmt.execute(&[&tx])
-            .map(|_c| ())
-            .chain_err(|| "Could not insert transaction: failed to add datoms not already present")?;
-
-        let s = r#"
-          INSERT INTO transactions (e, a, v, tx, added, value_type_tag)
-          SELECT e0, a0, v, ?, 0, value_type_tag0
-          FROM temp.search_results
-          WHERE rid IS NOT NULL AND
-                ((added0 IS 0) OR
-                 (added0 IS 1 AND search_type IS ':db.cardinality/one' AND v0 IS NOT v))"#;
-
-        let mut stmt = conn.prepare_cached(s)?;
-        stmt.execute(&[&tx])
-            .map(|_c| ())
-            .chain_err(|| "Could not insert transaction: failed to retract datoms already present")?;
-
+    fn commit_transaction(&self, tx_id: Entid) -> Result<()> {
+        search(&self)?;
+        insert_transaction(&self, tx_id)?;
+        update_datoms(&self, tx_id)?;
         Ok(())
-    }
-
-    /// Update the contents of the `datoms` materialized view with the new transaction.
-    ///
-    /// This applies the contents of `search_results` to the `datoms` table (in place).
-    ///
-    /// See https://github.com/mozilla/mentat/wiki/Transacting:-entity-to-SQL-translation.
-    // TODO: capture `conn` in a `TxInternal` structure.
-    pub fn update_datoms(&self, conn: &rusqlite::Connection, tx: Entid) -> Result<()> {
-        // Delete datoms that were retracted, or those that were :db.cardinality/one and will be
-        // replaced.
-        let s = r#"
-            WITH ids AS (SELECT rid
-                         FROM temp.search_results
-                         WHERE rid IS NOT NULL AND
-                               ((added0 IS 0) OR
-                                (added0 IS 1 AND search_type IS ':db.cardinality/one' AND v0 IS NOT v)))
-            DELETE FROM datoms WHERE rowid IN ids"#;
-
-        let mut stmt = conn.prepare_cached(s)?;
-        stmt.execute(&[])
-            .map(|_c| ())
-            .chain_err(|| "Could not update datoms: failed to retract datoms already present")?;
-
-        // Insert datoms that were added and not already present. We also must
-        // expand our bitfield into flags.
-        let s = format!(r#"
-          INSERT INTO datoms (e, a, v, tx, value_type_tag, index_avet, index_vaet, index_fulltext, unique_value)
-          SELECT e0, a0, v0, ?, value_type_tag0,
-                 flags0 & {} IS NOT 0,
-                 flags0 & {} IS NOT 0,
-                 flags0 & {} IS NOT 0,
-                 flags0 & {} IS NOT 0
-          FROM temp.search_results
-          WHERE added0 IS 1 AND ((rid IS NULL) OR ((rid IS NOT NULL) AND (v0 IS NOT v)))"#,
-          AttributeBitFlags::IndexAVET as u8,
-          AttributeBitFlags::IndexVAET as u8,
-          AttributeBitFlags::IndexFulltext as u8,
-          AttributeBitFlags::UniqueValue as u8);
-
-        let mut stmt = conn.prepare_cached(&s)?;
-        stmt.execute(&[&tx])
-            .map(|_c| ())
-            .chain_err(|| "Could not update datoms: failed to add datoms not already present")?;
-
-        Ok(())
-    }
-
-    /// Transact the given `entities` against the given SQLite `conn`, using the metadata in
-    /// `self.DB`.
-    ///
-    /// This approach is explained in https://github.com/mozilla/mentat/wiki/Transacting.
-    // TODO: move this to the transactor layer.
-    pub fn transact<I>(&mut self, conn: &rusqlite::Connection, entities: I) -> Result<TxReport> where I: IntoIterator<Item=Entity> {
-        // Eventually, this function will be responsible for managing a SQLite transaction.  For
-        // now, it's just about the tx details.
-
-        let tx_instant = now(); // Label the transaction with the timestamp when we first see it: leading edge.
-        let tx_id = self.partition_map.allocate_entid(":db.part/tx");
-
-        self.create_temp_tables(conn)?;
-
-        let mut tx = Tx::new(self, conn, tx_id, tx_instant);
-        tx.transact_entities(entities)
     }
 }
 
@@ -838,6 +854,7 @@ mod tests {
     use edn::symbols;
     use mentat_tx_parser;
     use rusqlite;
+    use tx::transact;
 
     #[test]
     fn test_open_current_version() {
@@ -871,7 +888,8 @@ mod tests {
     /// There is some magic here about transaction numbering that I don't want to commit to or
     /// document just yet.  The end state might be much more general pattern matching syntax, rather
     /// than the targeted transaction ID and timestamp replacement we have right now.
-    fn assert_transactions(conn: &rusqlite::Connection, db: &mut DB, transactions: &Vec<edn::Value>) {
+    // TODO: accept a `Conn`.
+    fn assert_transactions<'a>(conn: &rusqlite::Connection, partition_map: &mut PartitionMap, schema: &mut Schema, transactions: &Vec<edn::Value>) {
         let mut index: i64 = bootstrap::TX0;
 
         for transaction in transactions {
@@ -884,7 +902,7 @@ mod tests {
 
             let entities: Vec<_> = mentat_tx_parser::Tx::parse(&[assertions][..]).unwrap();
 
-            let maybe_report = db.transact(&conn, entities);
+            let maybe_report = transact(&conn, partition_map, schema, entities);
 
             if let Some(expected_transaction) = expected_transaction {
                 if !expected_transaction.is_nil() {
@@ -901,11 +919,17 @@ mod tests {
                     continue
                 }
 
-                let report = maybe_report.unwrap();
+                // TODO: test schema changes in the EDN format.
+                let (report, next_partition_map, next_schema) = maybe_report.unwrap();
+                *partition_map = next_partition_map;
+                if let Some(next_schema) = next_schema {
+                    *schema = next_schema;
+                }
+
                 assert_eq!(index, report.tx_id,
                            "\n{} - expected tx_id {} but got tx_id {}", label, index, report.tx_id);
 
-                let transactions = debug::transactions_after(&conn, &db.schema, index - 1).unwrap();
+                let transactions = debug::transactions_after(&conn, &schema, index - 1).unwrap();
                 assert_eq!(transactions.0.len(), 1);
                 assert_eq!(*expected_transaction,
                            transactions.0[0].into_edn(),
@@ -913,7 +937,7 @@ mod tests {
             }
 
             if let Some(expected_datoms) = expected_datoms {
-                let datoms = debug::datoms_after(&conn, &db.schema, bootstrap::TX0).unwrap();
+                let datoms = debug::datoms_after(&conn, &schema, bootstrap::TX0).unwrap();
                 assert_eq!(*expected_datoms,
                            datoms.into_edn(),
                            "\n{} - expected datoms:\n{}\nbut got datoms:\n{}", label, *expected_datoms, datoms.into_edn())
@@ -944,7 +968,8 @@ mod tests {
         let value = edn::parse::value(include_str!("../../tx/fixtures/test_add.edn")).unwrap().without_spans();
 
         let transactions = value.as_vector().unwrap();
-        assert_transactions(&conn, &mut db, transactions);
+
+        assert_transactions(&conn, &mut db.partition_map, &mut db.schema, transactions);
     }
 
     #[test]
@@ -964,7 +989,7 @@ mod tests {
         let value = edn::parse::value(include_str!("../../tx/fixtures/test_retract.edn")).unwrap().without_spans();
 
         let transactions = value.as_vector().unwrap();
-        assert_transactions(&conn, &mut db, transactions);
+        assert_transactions(&conn, &mut db.partition_map, &mut db.schema, transactions);
     }
 
     #[test]
@@ -984,6 +1009,6 @@ mod tests {
         let value = edn::parse::value(include_str!("../../tx/fixtures/test_upsert_vector.edn")).unwrap().without_spans();
 
         let transactions = value.as_vector().unwrap();
-        assert_transactions(&conn, &mut db, transactions);
+        assert_transactions(&conn, &mut db.partition_map, &mut db.schema, transactions);
     }
 }

--- a/db/src/db.rs
+++ b/db/src/db.rs
@@ -458,32 +458,6 @@ pub enum SearchType {
 }
 
 impl DB {
-    /// Do schema-aware typechecking and coercion.
-    ///
-    /// Either assert that the given value is in the attribute's value set, or (in limited cases)
-    /// coerce the given value into the attribute's value set.
-    pub fn to_typed_value(&self, value: &Value, attribute: &Attribute) -> Result<TypedValue> {
-        // TODO: encapsulate entid-ident-attribute for better error messages.
-        match TypedValue::from_edn_value(value) {
-            // We don't recognize this EDN at all.  Get out!
-            None => bail!(ErrorKind::BadEDNValuePair(value.clone(), attribute.value_type.clone())),
-            Some(typed_value) => match (&attribute.value_type, typed_value) {
-                // Most types don't coerce at all.
-                (&ValueType::Boolean, tv @ TypedValue::Boolean(_)) => Ok(tv),
-                (&ValueType::Long, tv @ TypedValue::Long(_)) => Ok(tv),
-                (&ValueType::Double, tv @ TypedValue::Double(_)) => Ok(tv),
-                (&ValueType::String, tv @ TypedValue::String(_)) => Ok(tv),
-                (&ValueType::Keyword, tv @ TypedValue::Keyword(_)) => Ok(tv),
-                // Ref coerces a little: we interpret some things depending on the schema as a Ref.
-                (&ValueType::Ref, TypedValue::Long(x)) => Ok(TypedValue::Ref(x)),
-                (&ValueType::Ref, TypedValue::Keyword(ref x)) => {
-                    self.schema.require_entid(&x).map(|entid| TypedValue::Ref(entid))
-                }
-                // Otherwise, we have a type mismatch.
-                (value_type, _) => bail!(ErrorKind::BadEDNValuePair(value.clone(), value_type.clone())),
-            }
-        }
-    }
 
     /// Given a slice of [a v] lookup-refs, look up the corresponding [e a v] triples.
     ///

--- a/db/src/debug.rs
+++ b/db/src/debug.rs
@@ -28,7 +28,7 @@ use entids;
 use mentat_core::TypedValue;
 use mentat_tx::entities::{Entid};
 use db::TypedSQLValue;
-use types::DB;
+use types::Schema;
 use errors::Result;
 
 /// Represents a *datom* (assertion) in the store.
@@ -106,21 +106,21 @@ impl Transactions {
 }
 
 /// Convert a numeric entid to an ident `Entid` if possible, otherwise a numeric `Entid`.
-fn to_entid(db: &DB, entid: i64) -> Entid {
-    db.schema.get_ident(entid).map_or(Entid::Entid(entid), |ident| Entid::Ident(ident.clone()))
+fn to_entid(schema: &Schema, entid: i64) -> Entid {
+    schema.get_ident(entid).map_or(Entid::Entid(entid), |ident| Entid::Ident(ident.clone()))
 }
 
 /// Return the set of datoms in the store, ordered by (e, a, v, tx), but not including any datoms of
 /// the form [... :db/txInstant ...].
-pub fn datoms(conn: &rusqlite::Connection, db: &DB) -> Result<Datoms> {
-    datoms_after(conn, db, bootstrap::TX0 - 1)
+pub fn datoms(conn: &rusqlite::Connection, schema: &Schema) -> Result<Datoms> {
+    datoms_after(conn, schema, bootstrap::TX0 - 1)
 }
 
 /// Return the set of datoms in the store with transaction ID strictly greater than the given `tx`,
 /// ordered by (e, a, v, tx).
 ///
 /// The datom set returned does not include any datoms of the form [... :db/txInstant ...].
-pub fn datoms_after(conn: &rusqlite::Connection, db: &DB, tx: i64) -> Result<Datoms> {
+pub fn datoms_after(conn: &rusqlite::Connection, schema: &Schema, tx: i64) -> Result<Datoms> {
     let mut stmt: rusqlite::Statement = conn.prepare("SELECT e, a, v, value_type_tag, tx FROM datoms WHERE tx > ? ORDER BY e ASC, a ASC, v ASC, tx ASC")?;
 
     let r: Result<Vec<_>> = stmt.query_and_then(&[&tx], |row| {
@@ -140,8 +140,8 @@ pub fn datoms_after(conn: &rusqlite::Connection, db: &DB, tx: i64) -> Result<Dat
         let tx: i64 = row.get_checked(4)?;
 
         Ok(Some(Datom {
-            e: to_entid(db, e),
-            a: to_entid(db, a),
+            e: to_entid(schema, e),
+            a: to_entid(schema, a),
             v: value,
             tx: tx,
             added: None,
@@ -155,7 +155,7 @@ pub fn datoms_after(conn: &rusqlite::Connection, db: &DB, tx: i64) -> Result<Dat
 /// given `tx`, ordered by (tx, e, a, v).
 ///
 /// Each transaction returned includes the [:db/tx :db/txInstant ...] datom.
-pub fn transactions_after(conn: &rusqlite::Connection, db: &DB, tx: i64) -> Result<Transactions> {
+pub fn transactions_after(conn: &rusqlite::Connection, schema: &Schema, tx: i64) -> Result<Transactions> {
     let mut stmt: rusqlite::Statement = conn.prepare("SELECT e, a, v, value_type_tag, tx, added FROM transactions WHERE tx > ? ORDER BY tx ASC, e ASC, a ASC, v ASC, added ASC")?;
 
     let r: Result<Vec<_>> = stmt.query_and_then(&[&tx], |row| {
@@ -172,8 +172,8 @@ pub fn transactions_after(conn: &rusqlite::Connection, db: &DB, tx: i64) -> Resu
         let added: bool = row.get_checked(5)?;
 
         Ok(Datom {
-            e: to_entid(db, e),
-            a: to_entid(db, a),
+            e: to_entid(schema, e),
+            a: to_entid(schema, a),
             v: value,
             tx: tx,
             added: Some(added),

--- a/db/src/debug.rs
+++ b/db/src/debug.rs
@@ -140,9 +140,10 @@ pub fn datoms_after<S: Borrow<Schema>>(conn: &rusqlite::Connection, schema: &S, 
 
         let tx: i64 = row.get_checked(4)?;
 
+        let borrowed_schema = schema.borrow();
         Ok(Some(Datom {
-            e: to_entid(schema.borrow(), e),
-            a: to_entid(schema.borrow(), a),
+            e: to_entid(borrowed_schema, e),
+            a: to_entid(borrowed_schema, a),
             v: value,
             tx: tx,
             added: None,
@@ -172,9 +173,10 @@ pub fn transactions_after<S: Borrow<Schema>>(conn: &rusqlite::Connection, schema
         let tx: i64 = row.get_checked(4)?;
         let added: bool = row.get_checked(5)?;
 
+        let borrowed_schema = schema.borrow();
         Ok(Datom {
-            e: to_entid(schema.borrow(), e),
-            a: to_entid(schema.borrow(), a),
+            e: to_entid(borrowed_schema, e),
+            a: to_entid(borrowed_schema, a),
             v: value,
             tx: tx,
             added: Some(added),

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -30,9 +30,9 @@ use errors::{ErrorKind, Result};
 
 pub mod db;
 mod bootstrap;
-mod debug;
+pub mod debug;
 mod entids;
-mod errors;
+pub mod errors;
 mod schema;
 mod types;
 mod internal_types;
@@ -40,7 +40,13 @@ mod upsert_resolution;
 mod values;
 mod tx;
 
-pub use types::DB;
+pub use tx::transact;
+pub use types::{
+    DB,
+    PartitionMap,
+    TxReport,
+};
+pub use errors::*;
 
 use edn::symbols;
 

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -26,7 +26,7 @@ extern crate mentat_tx_parser;
 
 use itertools::Itertools;
 use std::iter::repeat;
-use errors::{ErrorKind, Result};
+pub use errors::{Error, ErrorKind, ResultExt, Result};
 
 pub mod db;
 mod bootstrap;
@@ -46,7 +46,6 @@ pub use types::{
     PartitionMap,
     TxReport,
 };
-pub use errors::*;
 
 use edn::symbols;
 

--- a/db/src/schema.rs
+++ b/db/src/schema.rs
@@ -10,6 +10,8 @@
 
 #![allow(dead_code)]
 
+use db::TypedSQLValue;
+use edn;
 use entids;
 use errors::{ErrorKind, Result};
 use edn::symbols;
@@ -175,5 +177,36 @@ impl SchemaBuilding for Schema {
         };
 
         Schema::from_ident_map_and_schema_map(ident_map.clone(), schema_map)
+    }
+}
+
+pub trait SchemaTypeChecking {
+    /// Do schema-aware typechecking and coercion.
+    ///
+    /// Either assert that the given value is in the attribute's value set, or (in limited cases)
+    /// coerce the given value into the attribute's value set.
+    fn to_typed_value(&self, value: &edn::Value, attribute: &Attribute) -> Result<TypedValue>;
+}
+
+impl SchemaTypeChecking for Schema {
+    fn to_typed_value(&self, value: &edn::Value, attribute: &Attribute) -> Result<TypedValue> {
+        // TODO: encapsulate entid-ident-attribute for better error messages.
+        match TypedValue::from_edn_value(value) {
+            // We don't recognize this EDN at all.  Get out!
+            None => bail!(ErrorKind::BadEDNValuePair(value.clone(), attribute.value_type.clone())),
+            Some(typed_value) => match (&attribute.value_type, typed_value) {
+                // Most types don't coerce at all.
+                (&ValueType::Boolean, tv @ TypedValue::Boolean(_)) => Ok(tv),
+                (&ValueType::Long, tv @ TypedValue::Long(_)) => Ok(tv),
+                (&ValueType::Double, tv @ TypedValue::Double(_)) => Ok(tv),
+                (&ValueType::String, tv @ TypedValue::String(_)) => Ok(tv),
+                (&ValueType::Keyword, tv @ TypedValue::Keyword(_)) => Ok(tv),
+                // Ref coerces a little: we interpret some things depending on the schema as a Ref.
+                (&ValueType::Ref, TypedValue::Long(x)) => Ok(TypedValue::Ref(x)),
+                (&ValueType::Ref, TypedValue::Keyword(ref x)) => self.require_entid(&x).map(|entid| TypedValue::Ref(entid)),
+                // Otherwise, we have a type mismatch.
+                (value_type, _) => bail!(ErrorKind::BadEDNValuePair(value.clone(), value_type.clone())),
+            }
+        }
     }
 }

--- a/db/src/tx.rs
+++ b/db/src/tx.rs
@@ -233,6 +233,7 @@ impl<'conn> Tx<'conn> {
         // TODO: allow this to be present in the transaction data.
         non_fts_one.push((self.tx_id,
                           entids::DB_TX_INSTANT,
+                          self.db.schema.require_attribute_for_entid(self.db.schema.require_entid(&":db/txInstant".to_string())?)?,
                           TypedValue::Long(self.tx_instant),
                           true));
 
@@ -286,9 +287,9 @@ impl<'conn> Tx<'conn> {
 
                     let added = op == OpType::Add;
                     if attribute.multival {
-                        non_fts_many.push((e, a, v, added));
+                        non_fts_many.push((e, a, attribute, v, added));
                     } else {
-                        non_fts_one.push((e, a, v, added));
+                        non_fts_one.push((e, a, attribute, v, added));
                     }
                 },
             }

--- a/db/src/tx.rs
+++ b/db/src/tx.rs
@@ -295,11 +295,11 @@ impl<'conn> Tx<'conn> {
         }
 
         if !non_fts_one.is_empty() {
-            self.db.insert_non_fts_searches(self.conn, &non_fts_one[..], self.tx_id, SearchType::Inexact)?;
+            self.db.insert_non_fts_searches(self.conn, &non_fts_one[..], SearchType::Inexact)?;
         }
 
         if !non_fts_many.is_empty() {
-            self.db.insert_non_fts_searches(self.conn, &non_fts_many[..], self.tx_id, SearchType::Exact)?;
+            self.db.insert_non_fts_searches(self.conn, &non_fts_many[..], SearchType::Exact)?;
         }
 
         self.db.search(self.conn)?;

--- a/db/src/tx.rs
+++ b/db/src/tx.rs
@@ -68,7 +68,10 @@ use mentat_core::intern_set;
 use mentat_tx::entities as entmod;
 use mentat_tx::entities::{Entity, OpType};
 use rusqlite;
-use schema::SchemaBuilding;
+use schema::{
+    SchemaBuilding,
+    SchemaTypeChecking,
+};
 use types::{
     Attribute,
     AVPair,
@@ -190,7 +193,7 @@ impl<'conn> Tx<'conn> {
                                 // Here is where we do schema-aware typechecking: we either assert that
                                 // the given value is in the attribute's value set, or (in limited
                                 // cases) coerce the value into the attribute's value set.
-                                let typed_value: TypedValue = self.db.to_typed_value(&v, &attribute)?;
+                                let typed_value: TypedValue = self.db.schema.to_typed_value(&v, &attribute)?;
 
                                 std::result::Result::Ok(typed_value)
                             }

--- a/db/src/tx.rs
+++ b/db/src/tx.rs
@@ -49,7 +49,9 @@ use std;
 use std::collections::BTreeSet;
 
 use ::{to_namespaced_keyword};
+use db;
 use db::{
+    PartitionMapping,
     ReducedEntity,
     SearchType,
 };
@@ -264,7 +266,7 @@ impl<'conn> Tx<'conn> {
         let unresolved_temp_ids: BTreeSet<TempId> = generation.temp_ids_in_allocations();
 
         // TODO: track partitions for temporary IDs.
-        let entids = self.db.allocate_entids(":db.part/user", unresolved_temp_ids.len());
+        let entids = self.db.partition_map.allocate_entids(":db.part/user", unresolved_temp_ids.len());
 
         let temp_id_allocations: TempIdMap = unresolved_temp_ids.into_iter().zip(entids).collect();
 
@@ -317,7 +319,7 @@ impl<'conn> Tx<'conn> {
         self.db.update_datoms(self.conn, self.tx_id)?;
 
         // TODO: update idents and schema materialized views.
-        self.db.update_partition_map(self.conn)?;
+        db::update_partition_map(self.conn, &self.db.partition_map)?;
 
         Ok(TxReport {
             tx_id: self.tx_id,

--- a/parser-utils/Cargo.toml
+++ b/parser-utils/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Victor Porof <vporof@mozilla.com>", "Richard Newman <rnewman@mozilla
 workspace = ".."
 
 [dependencies]
-combine = "2.1.1"
+combine = "2.2.2"
 
 [dependencies.edn]
   path = "../edn"

--- a/query-parser/Cargo.toml
+++ b/query-parser/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 workspace = ".."
 
 [dependencies]
-combine = "2.1.1"
+combine = "2.2.2"
 matches = "0.1"
 
 [dependencies.edn]

--- a/query-parser/Cargo.toml
+++ b/query-parser/Cargo.toml
@@ -5,6 +5,7 @@ workspace = ".."
 
 [dependencies]
 combine = "2.2.2"
+error-chain = "0.9.0"
 matches = "0.1"
 
 [dependencies.edn]

--- a/query-parser/src/errors.rs
+++ b/query-parser/src/errors.rs
@@ -8,34 +8,28 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
-#![allow(unused_imports)]
+#![allow(dead_code)]
 
-#[macro_use]
-extern crate error_chain;
-#[macro_use]
-extern crate matches;
+use edn;
+use mentat_parser_utils::ValueParseError;
 
-extern crate edn;
-#[macro_use]
-extern crate mentat_parser_utils;
+error_chain! {
+    types {
+        Error, ErrorKind, ResultExt, Result;
+    }
 
-mod util;
-mod parse;
-pub mod errors;
-pub mod find;
+    foreign_links {
+        EdnParseError(edn::ParseError);
+    }
 
-pub use errors::{
-    Error,
-    ErrorKind,
-    ResultExt,
-    Result,
-};
+    links {
+    }
 
-pub use find::{
-    parse_find,
-    parse_find_string,
-};
-
-pub use parse::{
-    QueryParseResult,
-};
+    errors {
+        NotAVariableError(value: edn::Value) {}
+        InvalidInput(value: edn::Value) {}
+        FindParseError(value_parse_error: ValueParseError) {}
+        WhereParseError(value_parse_error: ValueParseError) {}
+        MissingField(field: edn::Keyword) {}
+    }
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,35 @@
+// Copyright 2016 Mozilla
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#![allow(dead_code)]
+
+use rusqlite;
+
+use edn;
+use mentat_db;
+use mentat_query_parser;
+use mentat_tx_parser;
+
+error_chain! {
+    types {
+        Error, ErrorKind, ResultExt, Result;
+    }
+
+    foreign_links {
+        EdnParseError(edn::ParseError);
+        Rusqlite(rusqlite::Error);
+    }
+
+    links {
+        DbError(mentat_db::Error, mentat_db::ErrorKind);
+        QueryParseError(mentat_query_parser::Error, mentat_query_parser::ErrorKind);
+        TxParseError(mentat_tx_parser::Error, mentat_tx_parser::ErrorKind);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,8 @@
 // specific language governing permissions and limitations under the License.
 
 #[macro_use]
+extern crate error_chain;
+#[macro_use]
 extern crate slog;
 #[macro_use]
 extern crate slog_scope;
@@ -21,9 +23,11 @@ extern crate mentat_db;
 extern crate mentat_query;
 extern crate mentat_query_parser;
 extern crate mentat_query_algebrizer;
+extern crate mentat_tx_parser;
 
 use rusqlite::Connection;
 
+pub mod errors;
 pub mod ident;
 pub mod query;
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -18,7 +18,10 @@ use mentat_db::DB;
 
 use mentat_query_parser::{
     parse_find_string,
-    QueryParseError,
+};
+
+use errors::{
+    Result,
 };
 
 // TODO
@@ -31,19 +34,6 @@ pub enum QueryResults {
     Rel(Vec<Vec<TypedValue>>),
 }
 
-pub enum QueryExecutionError {
-    ParseError(QueryParseError),
-    InvalidArgumentName(String),
-}
-
-impl From<QueryParseError> for QueryExecutionError {
-    fn from(err: QueryParseError) -> QueryExecutionError {
-        QueryExecutionError::ParseError(err)
-    }
-}
-
-pub type QueryExecutionResult = Result<QueryResults, QueryExecutionError>;
-
 /// Take an EDN query string, a reference to a open SQLite connection, a Mentat DB, and an optional
 /// collection of input bindings (which should be keyed by `"?varname"`), and execute the query
 /// immediately, blocking the current thread.
@@ -53,7 +43,7 @@ pub type QueryExecutionResult = Result<QueryResults, QueryExecutionError>;
 pub fn q_once(sqlite: SQLiteConnection,
               db: DB,
               query: &str,
-              inputs: Option<HashMap<String, TypedValue>>) -> QueryExecutionResult {
+              inputs: Option<HashMap<String, TypedValue>>) -> Result<QueryResults> {
     // TODO: validate inputs.
     let parsed = parse_find_string(query)?;
     Ok(QueryResults::Scalar(Some(TypedValue::Boolean(true))))

--- a/tx-parser/Cargo.toml
+++ b/tx-parser/Cargo.toml
@@ -4,13 +4,14 @@ version = "0.0.1"
 workspace = ".."
 
 [dependencies]
-combine = "2.1.1"
+combine = "2.2.2"
+error-chain = "0.9.0"
 
 [dependencies.edn]
-  path = "../edn"
+path = "../edn"
 
 [dependencies.mentat_tx]
-  path = "../tx"
+path = "../tx"
 
 [dependencies.mentat_parser_utils]
-  path = "../parser-utils"
+path = "../parser-utils"

--- a/tx-parser/src/errors.rs
+++ b/tx-parser/src/errors.rs
@@ -8,23 +8,19 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
-extern crate itertools;
-extern crate num;
-extern crate ordered_float;
-extern crate pretty;
+#![allow(dead_code)]
 
-pub mod symbols;
-pub mod types;
-pub mod pretty_print;
-pub mod utils;
-pub mod matcher;
+use mentat_parser_utils::ValueParseError;
 
-pub mod parse {
-    include!(concat!(env!("OUT_DIR"), "/edn.rs"));
+error_chain! {
+    types {
+        Error, ErrorKind, ResultExt, Result;
+    }
+
+    errors {
+        ParseError(value_parse_error: ValueParseError) {
+            description("error parsing edn values")
+            display("error parsing edn values:\n{}", value_parse_error)
+        }
+    }
 }
-
-pub use num::BigInt;
-pub use ordered_float::OrderedFloat;
-pub use parse::ParseError;
-pub use types::Value;
-pub use symbols::{Keyword, NamespacedKeyword, PlainSymbol, NamespacedSymbol};

--- a/tx-parser/tests/parser.rs
+++ b/tx-parser/tests/parser.rs
@@ -30,8 +30,8 @@ fn test_entities() {
     let input = [edn];
 
     let result = Tx::parse(&input[..]);
-    assert_eq!(result,
-               Ok(vec![
+    assert_eq!(result.unwrap(),
+               vec![
                    Entity::AddOrRetract {
                        op: OpType::Add,
                        e: EntidOrLookupRefOrTempId::Entid(Entid::Entid(101)),
@@ -50,7 +50,7 @@ fn test_entities() {
                        a: Entid::Ident(NamespacedKeyword::new("test", "b")),
                        v: Value::Text("w".into()),
                    },
-                   ]));
+               ]);
 }
 
 // TODO: test error handling in select cases.

--- a/tx/fixtures/test_upsert_vector.edn
+++ b/tx/fixtures/test_upsert_vector.edn
@@ -74,7 +74,7 @@
    ;; This ref doesn't exist, so the assertion will be ignored.
    [:db/retract "t1" :db.schema/attribute 103]]
   :test/expected-transaction
-  #{[?tx6 :db/txInstant ?ms6 ?tx6 true]}
+  #{[?tx5 :db/txInstant ?ms5 ?tx5 true]}
   :test/expected-error-message
   ""
   :test/expected-tempids
@@ -94,9 +94,9 @@
   [[:db/add "t1" :db/ident :name/Josef]
    [:db/add "t2" :db.schema/attribute "t1"]]
   :test/expected-transaction
-  #{[65538 :db/ident :name/Josef ?tx8 true]
-    [65539 :db.schema/attribute 65538 ?tx8 true]
-    [?tx8 :db/txInstant ?ms8 ?tx8 true]}
+  #{[65538 :db/ident :name/Josef ?tx6 true]
+    [65539 :db.schema/attribute 65538 ?tx6 true]
+    [?tx6 :db/txInstant ?ms6 ?tx6 true]}
   :test/expected-error-message
   ""
   :test/expected-tempids


### PR DESCRIPTION
This commit sequence is a bit all over the place.  It's all preparatory work for a top-level `Conn`, as tracked by #296.  That's still in progress in my tree.

The first series of  commits, up to and including https://github.com/ncalexan/mentat/commit/201ffc712cf2b1189903a12d16d3190a13293476, are about separating the SQLite bits from the `DB` type.  See the comments around the `MentatStoring` trait.

The last few commits, including and following https://github.com/ncalexan/mentat/commit/b8a7c84ea47b5e0d9b0cc27b85faab55c4ff1c00, are about moving the existing code to `error-chain`.  You can see the chaining (a little), and unifying some error types.  This also surfaces errors out of `combine`; see some of the commit messages for notes.