### PR TITLE
Use error_chain in sql, query-parser, query-translator.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ rustc_version = "0.1.7"
 
 [dependencies]
 clap = "2.19.3"
+error-chain = "0.9.0"
 nickel = "0.9.0"
 slog = "1.4.0"
 slog-scope = "0.2.2"

--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 workspace = ".."
 
 [dependencies]
-error-chain = "0.8.0"
+error-chain = "0.9.0"
 itertools = "0.5.9"
 lazy_static = "0.2.2"
 ordered-float = "0.4.0"

--- a/query-parser/Cargo.toml
+++ b/query-parser/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.1"
 workspace = ".."
 
 [dependencies]
+error-chain = "0.9.0"
 combine = "2.1.1"
 matches = "0.1"
 

--- a/query-parser/src/lib.rs
+++ b/query-parser/src/lib.rs
@@ -11,6 +11,9 @@
 #![allow(unused_imports)]
 
 #[macro_use]
+extern crate error_chain;
+
+#[macro_use]
 extern crate matches;
 
 #[macro_use]
@@ -26,9 +29,8 @@ pub use find::{
 };
 
 pub use parse::{
+    Result,
+    Error,
+    ErrorKind,
     QueryParseResult,
-    QueryParseError,
-    FindParseError,
-    WhereParseError,
-    NotAVariableError,
 };

--- a/query-translator/src/types.rs
+++ b/query-translator/src/types.rs
@@ -24,8 +24,9 @@ use mentat_query_algebrizer::{
     SourceAlias,
 };
 
+use mentat_sql;
+
 use mentat_sql::{
-    BuildQueryError,
     BuildQueryResult,
     QueryBuilder,
     QueryFragment,
@@ -268,7 +269,7 @@ impl QueryFragment for SelectQuery {
 }
 
 impl SelectQuery {
-    pub fn to_sql_query(&self) -> Result<SQLQuery, BuildQueryError> {
+    pub fn to_sql_query(&self) -> mentat_sql::Result<SQLQuery> {
         let mut builder = SQLiteQueryBuilder::new();
         self.push_sql(&mut builder).map(|_| builder.finish())
     }

--- a/sql/Cargo.toml
+++ b/sql/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.1"
 workspace = ".."
 
 [dependencies]
+error-chain = "0.9.0"
 ordered-float = "0.4.0"
 
 [dependencies.mentat_core]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -8,19 +8,26 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
-extern crate mentat_core;
-extern crate mentat_query;
-extern crate mentat_query_algebrizer;
-extern crate mentat_sql;
+use rusqlite;
 
-mod translate;
-mod types;
+use mentat_query_parser;
+use mentat_sql;
 
-pub use types::{
-    Projection,
-};
+error_chain! {
+    foreign_links {
+        Rusqlite(rusqlite::Error);
+    }
 
-pub use translate::{
-    cc_to_exists,
-    cc_to_select,
-};
+    links {
+        SqlError(mentat_sql::Error, mentat_sql::ErrorKind);
+        ParseError(mentat_query_parser::Error, mentat_query_parser::ErrorKind);
+    }
+
+    errors {
+        InvalidArgumentName(name: String) {
+            description("invalid argument name")
+            display("invalid argument name: '{}'", name)
+        }
+    }
+
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,9 @@
 // specific language governing permissions and limitations under the License.
 
 #[macro_use]
+extern crate error_chain;
+
+#[macro_use]
 extern crate slog;
 #[macro_use]
 extern crate slog_scope;
@@ -19,11 +22,14 @@ extern crate edn;
 extern crate mentat_core;
 extern crate mentat_db;
 extern crate mentat_query;
-extern crate mentat_query_parser;
 extern crate mentat_query_algebrizer;
+extern crate mentat_query_parser;
+extern crate mentat_query_translator;
+extern crate mentat_sql;
 
 use rusqlite::Connection;
 
+pub mod errors;
 pub mod ident;
 pub mod query;
 


### PR DESCRIPTION
Note that I bumped to 0.9.0, which appears to fix some bugs. I did this while trying to solve an obscure macro expansion error (complaining about an extra `;`, when the issue was a _missing_ `;` somewhere else).

The last commit is a coal-face; you only really need to worry about the Error bits.

@ncalexan knows most about error_chain. @victorporof, please also take a look.