### PR TITLE
Support a limited set of '.'-prefixed symbols. (#352)

### DIFF
--- a/edn/src/edn.rustpeg
+++ b/edn/src/edn.rustpeg
@@ -152,7 +152,7 @@ symbol_char_initial = [a-z] / [A-Z] / [0-9] / [*!_?$%&=<>]
 symbol_char_subsequent = [a-z] / [A-Z] / [0-9] / [-*!_?$%&=<>]
 
 symbol_namespace = symbol_char_initial symbol_char_subsequent* (namespace_divider symbol_char_subsequent+)*
-symbol_name = ( symbol_char_initial+ / "." ) ( symbol_char_subsequent* / "." )
+symbol_name = ( symbol_char_initial+ symbol_char_subsequent* ) / "..." / "."
 
 keyword_prefix = ":"
 

--- a/edn/tests/tests.rs
+++ b/edn/tests/tests.rs
@@ -313,6 +313,7 @@ fn test_span_text() {
 fn test_symbol() {
     assert_eq!(symbol("$").unwrap(), s_plain("$"));
     assert_eq!(symbol(".").unwrap(), s_plain("."));
+    assert_eq!(symbol("...").unwrap(), s_plain("..."));
 
     assert_eq!(symbol("hello/world").unwrap(), s_ns("hello", "world"));
     assert_eq!(symbol("foo-bar/baz-boz").unwrap(), s_ns("foo-bar", "baz-boz"));

--- a/query-translator/tests/translate.rs
+++ b/query-translator/tests/translate.rs
@@ -42,7 +42,6 @@ fn add_attribute(schema: &mut Schema, e: Entid, a: Attribute) {
 }
 
 #[test]
-#[should_panic(expected = "parse failed")]
 fn test_coll() {
     let mut schema = Schema::default();
     associate_ident(&mut schema, NamespacedKeyword::new("foo", "bar"), 99);

--- a/tests/query.rs
+++ b/tests/query.rs
@@ -137,6 +137,25 @@ fn test_tuple() {
 
 #[test]
 fn test_coll() {
-    // We can't test Coll yet, because the EDN parser is incomplete.
+    let mut c = new_connection("").expect("Couldn't open conn.");
+    let db = mentat_db::db::ensure_current_version(&mut c).expect("Couldn't open DB.");
+
+    // Coll.
+    let start = time::PreciseTime::now();
+    let results = q_once(&c, &db.schema,
+                         "[:find [?e ...] :where [?e :db/ident _]]", None)
+        .expect("Query failed");
+    let end = time::PreciseTime::now();
+
+    assert_eq!(37, results.len());
+
+    if let QueryResults::Coll(ref coll) = results {
+        assert!(coll.iter().all(|item| item.matches_type(ValueType::Ref)));
+    } else {
+        panic!("Expected coll.");
+    }
+
+    println!("{:?}", results);
+    println!("Coll took {}µs", start.to(end).num_microseconds().unwrap());
 }
 


### PR DESCRIPTION
This commit allows `.` and `...` to parse correctly as `PlainSymbol`.

Tests in edn, query-translator, and the top level have been added.

I opted for the minimal solution.