### PR TITLE
Ensure that variable bindings are used when selecting a table.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,5 +15,13 @@
     ".sw*": true,
     "target": true,          // Top-level build output.
     "*/target": true         // Sub-crate build output.
-  }
+  },
+  "rust.customTestConfigurations": [
+    {
+      "title": "All Crates",
+      "args": [
+        "--all"
+      ]
+    }
+  ]
 }

--- a/query-algebrizer/src/cc.rs
+++ b/query-algebrizer/src/cc.rs
@@ -478,6 +478,9 @@ impl ConjoiningClauses {
 
     fn mark_known_empty(&mut self, why: EmptyBecause) {
         self.is_known_empty = true;
+        if self.empty_because.is_some() {
+            return;
+        }
         println!("CC known empty: {:?}.", &why);                   // TODO: proper logging.
         self.empty_because = Some(why);
     }


### PR DESCRIPTION
This PR ensures that a query like

```
[:find ?x :where [?x ?a ?v]]
```

with a binding for `?a`, is algebrized with knowledge of `?a`.