### PR TITLE
Parse, algebrize, and translate basic numeric predicate patterns

### DIFF
--- a/query-algebrizer/Cargo.toml
+++ b/query-algebrizer/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.0.1"
 workspace = ".."
 
 [dependencies]
+error-chain = "0.9.0"
+
 [dependencies.mentat_core]
 path = "../core"
 

--- a/query-algebrizer/src/cc.rs
+++ b/query-algebrizer/src/cc.rs
@@ -14,8 +14,8 @@ extern crate mentat_query;
 use std::fmt::{
     Debug,
     Formatter,
-    Result,
 };
+
 use std::collections::{
     BTreeMap,
     BTreeSet,
@@ -37,6 +37,12 @@ use self::mentat_query::{
     PatternValuePlace,
     SrcVar,
     Variable,
+};
+
+use errors::{
+    Error,
+    ErrorKind,
+    Result,
 };
 
 use types::{
@@ -192,7 +198,7 @@ pub enum EmptyBecause {
 }
 
 impl Debug for EmptyBecause {
-    fn fmt(&self, f: &mut Formatter) -> Result {
+    fn fmt(&self, f: &mut Formatter) -> ::std::fmt::Result {
         use self::EmptyBecause::*;
         match self {
             &TypeMismatch(ref var, ref existing, ref desired) => {
@@ -223,7 +229,7 @@ impl Debug for EmptyBecause {
 }
 
 impl Debug for ConjoiningClauses {
-    fn fmt(&self, fmt: &mut Formatter) -> Result {
+    fn fmt(&self, fmt: &mut Formatter) -> ::std::fmt::Result {
         fmt.debug_struct("ConjoiningClauses")
             .field("is_known_empty", &self.is_known_empty)
             .field("from", &self.from)

--- a/query-algebrizer/src/cc.rs
+++ b/query-algebrizer/src/cc.rs
@@ -19,7 +19,10 @@ use std::fmt::{
 use std::collections::{
     BTreeMap,
     BTreeSet,
+    HashSet,
 };
+
+use std::collections::btree_map::Entry;
 
 use self::mentat_core::{
     Attribute,
@@ -36,6 +39,7 @@ use self::mentat_query::{
     Pattern,
     PatternNonValuePlace,
     PatternValuePlace,
+    PlainSymbol,
     Predicate,
     SrcVar,
     Variable,
@@ -81,6 +85,12 @@ impl<T> OptionEffect<T> for Option<T> {
         }
         self
     }
+}
+
+fn unit_type_set(t: ValueType) -> HashSet<ValueType> {
+    let mut s = HashSet::with_capacity(1);
+    s.insert(t);
+    s
 }
 
 /// A `ConjoiningClauses` (CC) is a collection of clauses that are combined with `JOIN`.
@@ -143,7 +153,7 @@ pub struct ConjoiningClauses {
     /// A map from var to type. Whenever a var maps unambiguously to two different types, it cannot
     /// yield results, so we don't represent that case here. If a var isn't present in the map, it
     /// means that its type is not known in advance.
-    pub known_types: BTreeMap<Variable, ValueType>,
+    pub known_types: BTreeMap<Variable, HashSet<ValueType>>,
 
     /// A mapping, similar to `column_bindings`, but used to pull type tags out of the store at runtime.
     /// If a var isn't present in `known_types`, it should be present here.
@@ -153,7 +163,8 @@ pub struct ConjoiningClauses {
 #[derive(PartialEq)]
 pub enum EmptyBecause {
     // Var, existing, desired.
-    TypeMismatch(Variable, ValueType, ValueType),
+    TypeMismatch(Variable, HashSet<ValueType>, ValueType),
+    NonNumericArgument,
     UnresolvedIdent(NamespacedKeyword),
     InvalidAttributeIdent(NamespacedKeyword),
     InvalidAttributeEntid(Entid),
@@ -169,6 +180,9 @@ impl Debug for EmptyBecause {
             &TypeMismatch(ref var, ref existing, ref desired) => {
                 write!(f, "Type mismatch: {:?} can't be {:?}, because it's already {:?}",
                        var, desired, existing)
+            },
+            &NonNumericArgument => {
+                write!(f, "Non-numeric argument in numeric place")
             },
             &UnresolvedIdent(ref kw) => {
                 write!(f, "Couldn't resolve keyword {}", kw)
@@ -237,7 +251,7 @@ impl ConjoiningClauses {
         // Pre-fill our type mappings with the types of the input bindings.
         cc.known_types
           .extend(cc.value_bindings.iter()
-                    .map(|(k, v)| (k.clone(), v.value_type())));
+                    .map(|(k, v)| (k.clone(), unit_type_set(v.value_type()))));
         cc
     }
 }
@@ -245,6 +259,16 @@ impl ConjoiningClauses {
 impl ConjoiningClauses {
     fn bound_value(&self, var: &Variable) -> Option<TypedValue> {
         self.value_bindings.get(var).cloned()
+    }
+
+    /// Return a single `ValueType` if the given variable is known to have a precise type.
+    /// Returns `None` if the type of the variable is known but not precise -- "double
+    /// or integer" isn't good enough.
+    pub fn known_type(&self, var: &Variable) -> Option<ValueType> {
+        match self.known_types.get(var) {
+            Some(types) if types.len() == 1 => types.iter().next().cloned(),
+            _ => None,
+        }
     }
 
     pub fn bind_column_to_var(&mut self, schema: &Schema, table: TableAlias, column: DatomsColumn, var: Variable) {
@@ -291,7 +315,7 @@ impl ConjoiningClauses {
         let needs_type_extraction =
             !late_binding &&                           // Never need to extract for bound vars.
             column == DatomsColumn::Value &&           // Never need to extract types for refs.
-            !self.known_types.contains_key(&var) &&    // We know the type!
+            self.known_type(&var).is_none() &&         // Don't need to extract if we know a single type.
             !self.extracted_types.contains_key(&var);  // We're already extracting the type.
 
         let alias = QualifiedAlias(table, column);
@@ -322,6 +346,36 @@ impl ConjoiningClauses {
             QueryValue::PrimitiveLong(value)))
     }
 
+    /// Mark the given value as one of the set of numeric types.
+    fn constrain_var_to_numeric(&mut self, variable: Variable) {
+        let mut numeric_types = HashSet::with_capacity(2);
+        numeric_types.insert(ValueType::Double);
+        numeric_types.insert(ValueType::Long);
+
+        let entry = self.known_types.entry(variable);
+        match entry {
+            Entry::Vacant(vacant) => {
+                vacant.insert(numeric_types);
+            },
+            Entry::Occupied(mut occupied) => {
+                let narrowed: HashSet<ValueType> = numeric_types.intersection(occupied.get()).cloned().collect();
+                match narrowed.len() {
+                    0 => {
+                        // TODO: can't borrow as mutable more than once!
+                        //self.mark_known_empty(EmptyBecause::TypeMismatch(occupied.key().clone(), occupied.get().clone(), ValueType::Double));   // I know…
+                    },
+                    1 => {
+                        // Hooray!
+                        self.extracted_types.remove(occupied.key());
+                    },
+                    _ => {
+                    },
+                };
+                occupied.insert(narrowed);
+            },
+        }
+    }
+
     /// Constrains the var if there's no existing type.
     /// Marks as known-empty if it's impossible for this type to apply because there's a conflicting
     /// type already known.
@@ -343,13 +397,17 @@ impl ConjoiningClauses {
         // spot it here.
         if let Some(existing) = self.known_types.get(&variable).cloned() {
             // If so, the types must match.
-            if existing != this_type {
+            if !existing.contains(&this_type) {
                 self.mark_known_empty(EmptyBecause::TypeMismatch(variable, existing, this_type));
+            } else {
+                if existing.len() > 1 {
+                    // Narrow.
+                    self.known_types.insert(variable, unit_type_set(this_type));
+                }
             }
         } else {
             // If not, record the one we just determined.
-            self.known_types.insert(variable, this_type);
-
+            self.known_types.insert(variable, unit_type_set(this_type));
         }
     }
 
@@ -424,8 +482,14 @@ impl ConjoiningClauses {
             match value {
                 // TODO: see if the variable is projected, aggregated, or compared elsewhere in
                 // the query. If it's not, we don't need to use all_datoms here.
-                &PatternValuePlace::Variable(_) =>
-                    DatomsTable::AllDatoms,       // TODO: check types.
+                &PatternValuePlace::Variable(ref v) => {
+                    // Do we know that this variable can't be a string? If so, we don't need
+                    // AllDatoms. None or String means it could be or definitely is.
+                    match self.known_types.get(v).map(|types| types.contains(&ValueType::String)) {
+                        Some(false) => DatomsTable::Datoms,
+                        _           => DatomsTable::AllDatoms,
+                    }
+                }
                 &PatternValuePlace::Constant(NonIntegerConstant::Text(_)) =>
                     DatomsTable::AllDatoms,
                 _ =>
@@ -792,6 +856,38 @@ impl ConjoiningClauses {
 
     /// Take a function argument and turn it into a `QueryValue` suitable for use in a concrete
     /// constraint.
+    /// Additionally, do two things:
+    /// - Mark the pattern as known-empty if any argument is known non-numeric.
+    /// - Mark any variables encountered as numeric.
+    fn resolve_numeric_argument(&mut self, function: &PlainSymbol, position: usize, arg: FnArg) -> Result<QueryValue> {
+        use self::FnArg::*;
+        match arg {
+            FnArg::Variable(var) => {
+                self.constrain_var_to_numeric(var.clone());
+                self.column_bindings
+                    .get(&var)
+                    .and_then(|cols| cols.first().map(|col| QueryValue::Column(col.clone())))
+                    .ok_or_else(|| Error::from_kind(ErrorKind::UnboundVariable(var)))
+            },
+            // Can't be an entid.
+            EntidOrInteger(i) => Ok(QueryValue::TypedValue(TypedValue::Long(i))),
+            Ident(_) |
+            SrcVar(_) |
+            Constant(NonIntegerConstant::Boolean(_)) |
+            Constant(NonIntegerConstant::Text(_)) |
+            Constant(NonIntegerConstant::BigInteger(_)) => {
+                self.mark_known_empty(EmptyBecause::NonNumericArgument);
+                // We use Double because… well, we only have one slot!
+                bail!(ErrorKind::NonNumericArgument(function.clone(), position));
+            },
+            Constant(NonIntegerConstant::Float(f)) => Ok(QueryValue::TypedValue(TypedValue::Double(f))),
+        }
+    }
+
+
+    /// Take a function argument and turn it into a `QueryValue` suitable for use in a concrete
+    /// constraint.
+    #[allow(dead_code)]
     fn resolve_argument(&self, arg: FnArg) -> Result<QueryValue> {
         use self::FnArg::*;
         match arg {
@@ -843,8 +939,8 @@ impl ConjoiningClauses {
         // Any variables that aren't bound by this point in the linear processing of clauses will
         // cause the application of the predicate to fail.
         let mut args = predicate.args.into_iter();
-        let left = self.resolve_argument(args.next().unwrap())?;
-        let right = self.resolve_argument(args.next().unwrap())?;
+        let left = self.resolve_numeric_argument(&predicate.operator, 0, args.next().unwrap())?;
+        let right = self.resolve_numeric_argument(&predicate.operator, 1, args.next().unwrap())?;
 
         // These arguments must be variables or numeric constants.
         // TODO: generalize argument resolution and validation for different kinds of predicates:
@@ -945,7 +1041,7 @@ mod testing {
         assert_eq!(cc.from, vec![SourceAlias(DatomsTable::Datoms, "datoms00".to_string())]);
 
         // ?x must be a ref.
-        assert_eq!(cc.known_types.get(&x).unwrap(), &ValueType::Ref);
+        assert_eq!(cc.known_type(&x).unwrap(), ValueType::Ref);
 
         // ?x is bound to datoms0.e.
         assert_eq!(cc.column_bindings.get(&x).unwrap(), &vec![d0_e.clone()]);
@@ -983,7 +1079,7 @@ mod testing {
         assert_eq!(cc.from, vec![SourceAlias(DatomsTable::Datoms, "datoms00".to_string())]);
 
         // ?x must be a ref.
-        assert_eq!(cc.known_types.get(&x).unwrap(), &ValueType::Ref);
+        assert_eq!(cc.known_type(&x).unwrap(), ValueType::Ref);
 
         // ?x is bound to datoms0.e.
         assert_eq!(cc.column_bindings.get(&x).unwrap(), &vec![d0_e.clone()]);
@@ -1032,7 +1128,7 @@ mod testing {
         assert_eq!(cc.from, vec![SourceAlias(DatomsTable::Datoms, "datoms00".to_string())]);
 
         // ?x must be a ref.
-        assert_eq!(cc.known_types.get(&x).unwrap(), &ValueType::Ref);
+        assert_eq!(cc.known_type(&x).unwrap(), ValueType::Ref);
 
         // ?x is bound to datoms0.e.
         assert_eq!(cc.column_bindings.get(&x).unwrap(), &vec![d0_e.clone()]);
@@ -1092,7 +1188,7 @@ mod testing {
         assert_eq!(cc.from, vec![SourceAlias(DatomsTable::AllDatoms, "all_datoms00".to_string())]);
 
         // ?x must be a ref.
-        assert_eq!(cc.known_types.get(&x).unwrap(), &ValueType::Ref);
+        assert_eq!(cc.known_type(&x).unwrap(), ValueType::Ref);
 
         // ?x is bound to datoms0.e.
         assert_eq!(cc.column_bindings.get(&x).unwrap(), &vec![d0_e.clone()]);
@@ -1123,7 +1219,7 @@ mod testing {
         assert_eq!(cc.from, vec![SourceAlias(DatomsTable::AllDatoms, "all_datoms00".to_string())]);
 
         // ?x must be a ref.
-        assert_eq!(cc.known_types.get(&x).unwrap(), &ValueType::Ref);
+        assert_eq!(cc.known_type(&x).unwrap(), ValueType::Ref);
 
         // ?x is bound to datoms0.e.
         assert_eq!(cc.column_bindings.get(&x).unwrap(), &vec![d0_e.clone()]);
@@ -1189,7 +1285,7 @@ mod testing {
         ]);
 
         // ?x must be a ref.
-        assert_eq!(cc.known_types.get(&x).unwrap(), &ValueType::Ref);
+        assert_eq!(cc.known_type(&x).unwrap(), ValueType::Ref);
 
         // ?x is bound to datoms0.e and datoms1.e.
         assert_eq!(cc.column_bindings.get(&x).unwrap(),
@@ -1318,6 +1414,63 @@ mod testing {
     }
 
     #[test]
+    /// Apply three patterns: an unbound pattern to establish a value var,
+    /// a predicate to constrain the val to numeric types, and a third pattern to conflict with the
+    /// numeric types and cause the pattern to fail.
+    fn test_apply_conflict_with_numeric_range() {
+        let mut cc = ConjoiningClauses::default();
+        let mut schema = Schema::default();
+
+        associate_ident(&mut schema, NamespacedKeyword::new("foo", "bar"), 99);
+        associate_ident(&mut schema, NamespacedKeyword::new("foo", "roz"), 98);
+        add_attribute(&mut schema, 99, Attribute {
+            value_type: ValueType::Long,
+            ..Default::default()
+        });
+        add_attribute(&mut schema, 98, Attribute {
+            value_type: ValueType::String,
+            unique: Some(Unique::Identity),
+            ..Default::default()
+        });
+
+        let x = Variable(PlainSymbol::new("?x"));
+        let y = Variable(PlainSymbol::new("?y"));
+        cc.apply_pattern(&schema, Pattern {
+            source: None,
+            entity: PatternNonValuePlace::Variable(x.clone()),
+            attribute: PatternNonValuePlace::Placeholder,
+            value: PatternValuePlace::Variable(y.clone()),
+            tx: PatternNonValuePlace::Placeholder,
+        });
+        assert!(!cc.is_known_empty);
+
+        assert!(cc.apply_numeric_predicate(&schema, NumericComparison::GreaterThan, Predicate {
+             operator: PlainSymbol::new(">="),
+             args: vec![
+                FnArg::Variable(Variable(PlainSymbol::new("?y"))), FnArg::EntidOrInteger(10),
+            ]}).is_ok());
+
+        assert!(!cc.is_known_empty);
+        cc.apply_pattern(&schema, Pattern {
+            source: None,
+            entity: PatternNonValuePlace::Variable(x.clone()),
+            attribute: PatternNonValuePlace::Ident(NamespacedKeyword::new("foo", "roz")),
+            value: PatternValuePlace::Variable(y.clone()),
+            tx: PatternNonValuePlace::Placeholder,
+        });
+
+        // Finally, expand column bindings to get the overlaps for ?x.
+        cc.expand_column_bindings();
+
+        assert!(cc.is_known_empty);
+        assert_eq!(cc.empty_because.unwrap(),
+                   EmptyBecause::TypeMismatch(y.clone(),
+                                              vec![ValueType::Double, ValueType::Long].into_iter()
+                                                                                      .collect(),
+                                              ValueType::String));
+    }
+
+    #[test]
     /// Apply two patterns with differently typed attributes, but sharing a variable in the value
     /// place. No value can bind to a variable and match both types, so the CC is known to return
     /// no results.
@@ -1359,7 +1512,7 @@ mod testing {
 
         assert!(cc.is_known_empty);
         assert_eq!(cc.empty_because.unwrap(),
-                   EmptyBecause::TypeMismatch(y.clone(), ValueType::String, ValueType::Boolean));
+                   EmptyBecause::TypeMismatch(y.clone(), unit_type_set(ValueType::String), ValueType::Boolean));
     }
 
     #[test]
@@ -1397,6 +1550,6 @@ mod testing {
 
         assert!(cc.is_known_empty);
         assert_eq!(cc.empty_because.unwrap(),
-                   EmptyBecause::TypeMismatch(x.clone(), ValueType::Ref, ValueType::Boolean));
+                   EmptyBecause::TypeMismatch(x.clone(), unit_type_set(ValueType::Ref), ValueType::Boolean));
     }
 }

--- a/query-algebrizer/src/cc.rs
+++ b/query-algebrizer/src/cc.rs
@@ -8,8 +8,6 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
-#![allow(dead_code, unused_imports)]
-
 extern crate mentat_core;
 extern crate mentat_query;
 
@@ -23,8 +21,6 @@ use std::collections::{
     BTreeSet,
 };
 
-use std::collections::btree_map::Entry;
-
 use self::mentat_core::{
     Attribute,
     Entid,
@@ -34,13 +30,11 @@ use self::mentat_core::{
 };
 
 use self::mentat_query::{
-    IdentOrEntid,
     NamespacedKeyword,
     NonIntegerConstant,
     Pattern,
     PatternNonValuePlace,
     PatternValuePlace,
-    PlainSymbol,
     SrcVar,
     Variable,
 };
@@ -262,6 +256,7 @@ impl Default for ConjoiningClauses {
 }
 
 impl ConjoiningClauses {
+    #[allow(dead_code)]
     fn with_value_bindings(bindings: BTreeMap<Variable, TypedValue>) -> ConjoiningClauses {
         let mut cc = ConjoiningClauses {
             value_bindings: bindings,
@@ -826,6 +821,7 @@ impl ConjoiningClauses {
 #[cfg(test)]
 mod testing {
     use super::*;
+    use mentat_query::PlainSymbol;
 
     fn associate_ident(schema: &mut Schema, i: NamespacedKeyword, e: Entid) {
         schema.entid_map.insert(e, i.clone());

--- a/query-algebrizer/src/cc.rs
+++ b/query-algebrizer/src/cc.rs
@@ -804,7 +804,7 @@ impl ConjoiningClauses {
 
     }
 
-    pub fn apply_pattern<'s, 'p>(&mut self, schema: &'s Schema, pattern: &'p Pattern) {
+    pub fn apply_pattern<'s, 'p>(&mut self, schema: &'s Schema, pattern: Pattern) {
         // For now we only support the default source.
         match pattern.source {
             Some(SrcVar::DefaultSrc) | None => (),
@@ -812,7 +812,7 @@ impl ConjoiningClauses {
         };
 
         if let Some(alias) = self.alias_table(schema, &pattern) {
-            self.apply_pattern_clause_for_alias(schema, pattern, &alias);
+            self.apply_pattern_clause_for_alias(schema, &pattern, &alias);
             self.from.push(alias);
         } else {
             // We didn't determine a table, likely because there was a mismatch
@@ -844,7 +844,7 @@ mod testing {
         let mut cc = ConjoiningClauses::default();
         let schema = Schema::default();
 
-        cc.apply_pattern(&schema, &Pattern {
+        cc.apply_pattern(&schema, Pattern {
             source: None,
             entity: PatternNonValuePlace::Variable(Variable(PlainSymbol::new("?x"))),
             attribute: PatternNonValuePlace::Ident(NamespacedKeyword::new("foo", "bar")),
@@ -862,7 +862,7 @@ mod testing {
 
         associate_ident(&mut schema, NamespacedKeyword::new("foo", "bar"), 99);
 
-        cc.apply_pattern(&schema, &Pattern {
+        cc.apply_pattern(&schema, Pattern {
             source: None,
             entity: PatternNonValuePlace::Variable(Variable(PlainSymbol::new("?x"))),
             attribute: PatternNonValuePlace::Ident(NamespacedKeyword::new("foo", "bar")),
@@ -885,7 +885,7 @@ mod testing {
         });
 
         let x = Variable(PlainSymbol::new("?x"));
-        cc.apply_pattern(&schema, &Pattern {
+        cc.apply_pattern(&schema, Pattern {
             source: None,
             entity: PatternNonValuePlace::Variable(x.clone()),
             attribute: PatternNonValuePlace::Ident(NamespacedKeyword::new("foo", "bar")),
@@ -925,7 +925,7 @@ mod testing {
         let schema = Schema::default();
 
         let x = Variable(PlainSymbol::new("?x"));
-        cc.apply_pattern(&schema, &Pattern {
+        cc.apply_pattern(&schema, Pattern {
             source: None,
             entity: PatternNonValuePlace::Variable(x.clone()),
             attribute: PatternNonValuePlace::Placeholder,
@@ -974,7 +974,7 @@ mod testing {
 
         cc.input_variables.insert(a.clone());
         cc.value_bindings.insert(a.clone(), TypedValue::Keyword(NamespacedKeyword::new("foo", "bar")));
-        cc.apply_pattern(&schema, &Pattern {
+        cc.apply_pattern(&schema, Pattern {
             source: None,
             entity: PatternNonValuePlace::Variable(x.clone()),
             attribute: PatternNonValuePlace::Variable(a.clone()),
@@ -1013,7 +1013,7 @@ mod testing {
 
         cc.input_variables.insert(a.clone());
         cc.value_bindings.insert(a.clone(), hello.clone());
-        cc.apply_pattern(&schema, &Pattern {
+        cc.apply_pattern(&schema, Pattern {
             source: None,
             entity: PatternNonValuePlace::Variable(x.clone()),
             attribute: PatternNonValuePlace::Variable(a.clone()),
@@ -1035,7 +1035,7 @@ mod testing {
         let x = Variable(PlainSymbol::new("?x"));
         let a = Variable(PlainSymbol::new("?a"));
         let v = Variable(PlainSymbol::new("?v"));
-        cc.apply_pattern(&schema, &Pattern {
+        cc.apply_pattern(&schema, Pattern {
             source: None,
             entity: PatternNonValuePlace::Variable(x.clone()),
             attribute: PatternNonValuePlace::Variable(a.clone()),
@@ -1065,7 +1065,7 @@ mod testing {
         let schema = Schema::default();
 
         let x = Variable(PlainSymbol::new("?x"));
-        cc.apply_pattern(&schema, &Pattern {
+        cc.apply_pattern(&schema, Pattern {
             source: None,
             entity: PatternNonValuePlace::Variable(x.clone()),
             attribute: PatternNonValuePlace::Placeholder,
@@ -1115,14 +1115,14 @@ mod testing {
 
         let x = Variable(PlainSymbol::new("?x"));
         let y = Variable(PlainSymbol::new("?y"));
-        cc.apply_pattern(&schema, &Pattern {
+        cc.apply_pattern(&schema, Pattern {
             source: None,
             entity: PatternNonValuePlace::Variable(x.clone()),
             attribute: PatternNonValuePlace::Ident(NamespacedKeyword::new("foo", "roz")),
             value: PatternValuePlace::Constant(NonIntegerConstant::Text("idgoeshere".to_string())),
             tx: PatternNonValuePlace::Placeholder,
         });
-        cc.apply_pattern(&schema, &Pattern {
+        cc.apply_pattern(&schema, Pattern {
             source: None,
             entity: PatternNonValuePlace::Variable(x.clone()),
             attribute: PatternNonValuePlace::Ident(NamespacedKeyword::new("foo", "bar")),
@@ -1187,7 +1187,7 @@ mod testing {
             vec![(y.clone(), TypedValue::Boolean(true))].into_iter().collect();
         let mut cc = ConjoiningClauses::with_value_bindings(b);
 
-        cc.apply_pattern(&schema, &Pattern {
+        cc.apply_pattern(&schema, Pattern {
             source: None,
             entity: PatternNonValuePlace::Variable(x.clone()),
             attribute: PatternNonValuePlace::Ident(NamespacedKeyword::new("foo", "bar")),
@@ -1232,7 +1232,7 @@ mod testing {
             vec![(y.clone(), TypedValue::Long(42))].into_iter().collect();
         let mut cc = ConjoiningClauses::with_value_bindings(b);
 
-        cc.apply_pattern(&schema, &Pattern {
+        cc.apply_pattern(&schema, Pattern {
             source: None,
             entity: PatternNonValuePlace::Variable(x.clone()),
             attribute: PatternNonValuePlace::Ident(NamespacedKeyword::new("foo", "bar")),
@@ -1264,7 +1264,7 @@ mod testing {
             vec![(y.clone(), TypedValue::Long(42))].into_iter().collect();
         let mut cc = ConjoiningClauses::with_value_bindings(b);
 
-        cc.apply_pattern(&schema, &Pattern {
+        cc.apply_pattern(&schema, Pattern {
             source: None,
             entity: PatternNonValuePlace::Variable(x.clone()),
             attribute: PatternNonValuePlace::Ident(NamespacedKeyword::new("foo", "bar")),
@@ -1298,14 +1298,14 @@ mod testing {
 
         let x = Variable(PlainSymbol::new("?x"));
         let y = Variable(PlainSymbol::new("?y"));
-        cc.apply_pattern(&schema, &Pattern {
+        cc.apply_pattern(&schema, Pattern {
             source: None,
             entity: PatternNonValuePlace::Variable(x.clone()),
             attribute: PatternNonValuePlace::Ident(NamespacedKeyword::new("foo", "roz")),
             value: PatternValuePlace::Variable(y.clone()),
             tx: PatternNonValuePlace::Placeholder,
         });
-        cc.apply_pattern(&schema, &Pattern {
+        cc.apply_pattern(&schema, Pattern {
             source: None,
             entity: PatternNonValuePlace::Variable(x.clone()),
             attribute: PatternNonValuePlace::Ident(NamespacedKeyword::new("foo", "bar")),
@@ -1336,14 +1336,14 @@ mod testing {
         let x = Variable(PlainSymbol::new("?x"));
         let y = Variable(PlainSymbol::new("?y"));
         let z = Variable(PlainSymbol::new("?z"));
-        cc.apply_pattern(&schema, &Pattern {
+        cc.apply_pattern(&schema, Pattern {
             source: None,
             entity: PatternNonValuePlace::Variable(x.clone()),
             attribute: PatternNonValuePlace::Variable(y.clone()),
             value: PatternValuePlace::Constant(NonIntegerConstant::Boolean(true)),
             tx: PatternNonValuePlace::Placeholder,
         });
-        cc.apply_pattern(&schema, &Pattern {
+        cc.apply_pattern(&schema, Pattern {
             source: None,
             entity: PatternNonValuePlace::Variable(z.clone()),
             attribute: PatternNonValuePlace::Variable(y.clone()),

--- a/query-algebrizer/src/cc.rs
+++ b/query-algebrizer/src/cc.rs
@@ -625,7 +625,63 @@ impl ConjoiningClauses {
     }
 }
 
-/// Application.
+/// Argument resolution.
+impl ConjoiningClauses {
+    /// Take a function argument and turn it into a `QueryValue` suitable for use in a concrete
+    /// constraint.
+    /// Additionally, do two things:
+    /// - Mark the pattern as known-empty if any argument is known non-numeric.
+    /// - Mark any variables encountered as numeric.
+    fn resolve_numeric_argument(&mut self, function: &PlainSymbol, position: usize, arg: FnArg) -> Result<QueryValue> {
+        use self::FnArg::*;
+        match arg {
+            FnArg::Variable(var) => {
+                self.constrain_var_to_numeric(var.clone());
+                self.column_bindings
+                    .get(&var)
+                    .and_then(|cols| cols.first().map(|col| QueryValue::Column(col.clone())))
+                    .ok_or_else(|| Error::from_kind(ErrorKind::UnboundVariable(var)))
+            },
+            // Can't be an entid.
+            EntidOrInteger(i) => Ok(QueryValue::TypedValue(TypedValue::Long(i))),
+            Ident(_) |
+            SrcVar(_) |
+            Constant(NonIntegerConstant::Boolean(_)) |
+            Constant(NonIntegerConstant::Text(_)) |
+            Constant(NonIntegerConstant::BigInteger(_)) => {
+                self.mark_known_empty(EmptyBecause::NonNumericArgument);
+                // We use Double because… well, we only have one slot!
+                bail!(ErrorKind::NonNumericArgument(function.clone(), position));
+            },
+            Constant(NonIntegerConstant::Float(f)) => Ok(QueryValue::TypedValue(TypedValue::Double(f))),
+        }
+    }
+
+
+    /// Take a function argument and turn it into a `QueryValue` suitable for use in a concrete
+    /// constraint.
+    #[allow(dead_code)]
+    fn resolve_argument(&self, arg: FnArg) -> Result<QueryValue> {
+        use self::FnArg::*;
+        match arg {
+            FnArg::Variable(var) => {
+                self.column_bindings
+                    .get(&var)
+                    .and_then(|cols| cols.first().map(|col| QueryValue::Column(col.clone())))
+                    .ok_or_else(|| Error::from_kind(ErrorKind::UnboundVariable(var)))
+            },
+            EntidOrInteger(i) => Ok(QueryValue::PrimitiveLong(i)),
+            Ident(ref i) => unimplemented!(),     // TODO
+            Constant(NonIntegerConstant::Boolean(val)) => Ok(QueryValue::TypedValue(TypedValue::Boolean(val))),
+            Constant(NonIntegerConstant::Float(f)) => Ok(QueryValue::TypedValue(TypedValue::Double(f))),
+            Constant(NonIntegerConstant::Text(s)) => Ok(QueryValue::TypedValue(TypedValue::String(s.clone()))),
+            Constant(NonIntegerConstant::BigInteger(_)) => unimplemented!(),
+            SrcVar(_) => unimplemented!(),
+        }
+    }
+}
+
+/// Application of patterns.
 impl ConjoiningClauses {
 
     /// Apply the constraints in the provided pattern to this CC.
@@ -853,60 +909,10 @@ impl ConjoiningClauses {
             return;
         }
     }
+}
 
-    /// Take a function argument and turn it into a `QueryValue` suitable for use in a concrete
-    /// constraint.
-    /// Additionally, do two things:
-    /// - Mark the pattern as known-empty if any argument is known non-numeric.
-    /// - Mark any variables encountered as numeric.
-    fn resolve_numeric_argument(&mut self, function: &PlainSymbol, position: usize, arg: FnArg) -> Result<QueryValue> {
-        use self::FnArg::*;
-        match arg {
-            FnArg::Variable(var) => {
-                self.constrain_var_to_numeric(var.clone());
-                self.column_bindings
-                    .get(&var)
-                    .and_then(|cols| cols.first().map(|col| QueryValue::Column(col.clone())))
-                    .ok_or_else(|| Error::from_kind(ErrorKind::UnboundVariable(var)))
-            },
-            // Can't be an entid.
-            EntidOrInteger(i) => Ok(QueryValue::TypedValue(TypedValue::Long(i))),
-            Ident(_) |
-            SrcVar(_) |
-            Constant(NonIntegerConstant::Boolean(_)) |
-            Constant(NonIntegerConstant::Text(_)) |
-            Constant(NonIntegerConstant::BigInteger(_)) => {
-                self.mark_known_empty(EmptyBecause::NonNumericArgument);
-                // We use Double because… well, we only have one slot!
-                bail!(ErrorKind::NonNumericArgument(function.clone(), position));
-            },
-            Constant(NonIntegerConstant::Float(f)) => Ok(QueryValue::TypedValue(TypedValue::Double(f))),
-        }
-    }
-
-
-    /// Take a function argument and turn it into a `QueryValue` suitable for use in a concrete
-    /// constraint.
-    #[allow(dead_code)]
-    fn resolve_argument(&self, arg: FnArg) -> Result<QueryValue> {
-        use self::FnArg::*;
-        match arg {
-            FnArg::Variable(var) => {
-                self.column_bindings
-                    .get(&var)
-                    .and_then(|cols| cols.first().map(|col| QueryValue::Column(col.clone())))
-                    .ok_or_else(|| Error::from_kind(ErrorKind::UnboundVariable(var)))
-            },
-            EntidOrInteger(i) => Ok(QueryValue::PrimitiveLong(i)),
-            Ident(ref i) => unimplemented!(),     // TODO
-            Constant(NonIntegerConstant::Boolean(val)) => Ok(QueryValue::TypedValue(TypedValue::Boolean(val))),
-            Constant(NonIntegerConstant::Float(f)) => Ok(QueryValue::TypedValue(TypedValue::Double(f))),
-            Constant(NonIntegerConstant::Text(s)) => Ok(QueryValue::TypedValue(TypedValue::String(s.clone()))),
-            Constant(NonIntegerConstant::BigInteger(_)) => unimplemented!(),
-            SrcVar(_) => unimplemented!(),
-        }
-    }
-
+/// Application of predicates.
+impl ConjoiningClauses {
     /// There are several kinds of predicates/functions in our Datalog:
     /// - A limited set of binary comparison operators: < > <= >= !=.
     ///   These are converted into SQLite binary comparisons and some type constraints.

--- a/query-algebrizer/src/cc.rs
+++ b/query-algebrizer/src/cc.rs
@@ -45,84 +45,13 @@ use self::mentat_query::{
     Variable,
 };
 
-/// This enum models the fixed set of default tables we have -- two
-/// tables and two views.
-#[derive(PartialEq, Eq, Clone, Copy, Debug)]
-pub enum DatomsTable {
-    Datoms,             // The non-fulltext datoms table.
-    FulltextValues,     // The virtual table mapping IDs to strings.
-    FulltextDatoms,     // The fulltext-datoms view.
-    AllDatoms,          // Fulltext and non-fulltext datoms.
-}
-
-impl DatomsTable {
-    pub fn name(&self) -> &'static str {
-        match *self {
-            DatomsTable::Datoms => "datoms",
-            DatomsTable::FulltextValues => "fulltext_values",
-            DatomsTable::FulltextDatoms => "fulltext_datoms",
-            DatomsTable::AllDatoms => "all_datoms",
-        }
-    }
-}
-
-/// One of the named columns of our tables.
-#[derive(PartialEq, Eq, Clone, Debug)]
-pub enum DatomsColumn {
-    Entity,
-    Attribute,
-    Value,
-    Tx,
-    ValueTypeTag,
-}
-
-impl DatomsColumn {
-    pub fn as_str(&self) -> &'static str {
-        use DatomsColumn::*;
-        match *self {
-            Entity => "e",
-            Attribute => "a",
-            Value => "v",
-            Tx => "tx",
-            ValueTypeTag => "value_type_tag",
-        }
-    }
-}
-
-
-/// A specific instance of a table within a query. E.g., "datoms123".
-pub type TableAlias = String;
-
-/// The association between a table and its alias. E.g., AllDatoms, "all_datoms123".
-#[derive(PartialEq, Eq, Clone)]
-pub struct SourceAlias(pub DatomsTable, pub TableAlias);
-
-impl Debug for SourceAlias {
-    fn fmt(&self, f: &mut Formatter) -> Result {
-        write!(f, "SourceAlias({:?}, {})", self.0, self.1)
-    }
-}
-
-/// A particular column of a particular aliased table. E.g., "datoms123", Attribute.
-#[derive(PartialEq, Eq, Clone)]
-pub struct QualifiedAlias(pub TableAlias, pub DatomsColumn);
-
-impl Debug for QualifiedAlias {
-    fn fmt(&self, f: &mut Formatter) -> Result {
-        write!(f, "{}.{}", self.0, self.1.as_str())
-    }
-}
-
-impl QualifiedAlias {
-    fn for_type_tag(&self) -> QualifiedAlias {
-        QualifiedAlias(self.0.clone(), DatomsColumn::ValueTypeTag)
-    }
-
-    #[inline]
-    fn is_value(&self) -> bool {
-        self.1 == DatomsColumn::Value
-    }
-}
+use types::{
+    DatomsColumn,
+    DatomsTable,
+    QualifiedAlias,
+    SourceAlias,
+    TableAlias,
+};
 
 /// A thing that's capable of aliasing a table name for us.
 /// This exists so that we can obtain predictable names in tests.

--- a/query-algebrizer/src/errors.rs
+++ b/query-algebrizer/src/errors.rs
@@ -35,6 +35,11 @@ error_chain! {
             description("unbound variable in function call")
             display("unbound variable: {}", var.0)
         }
+
+        NonNumericArgument(function: PlainSymbol, position: usize) {
+            description("invalid argument")
+            display("invalid argument to {}: expected numeric in position {}.", function, position)
+        }
     }
 }
 

--- a/query-algebrizer/src/errors.rs
+++ b/query-algebrizer/src/errors.rs
@@ -1,0 +1,40 @@
+// Copyright 2016 Mozilla
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+extern crate mentat_query;
+
+use self::mentat_query::{
+    PlainSymbol,
+    Variable,
+};
+
+error_chain! {
+    types {
+        Error, ErrorKind, ResultExt, Result;
+    }
+
+    errors {
+        UnknownFunction(name: PlainSymbol) {
+            description("no such function")
+            display("no function named {}", name)
+        }
+    
+        InvalidNumberOfArguments(name: PlainSymbol, number: usize, expected: usize) {
+            description("invalid number of arguments")
+            display("invalid number of arguments to {}: expected {}, got {}.", name, expected, number)
+        }
+
+        UnboundVariable(var: Variable) {
+            description("unbound variable in function call")
+            display("unbound variable: {}", var.0)
+        }
+    }
+}
+

--- a/query-algebrizer/src/lib.rs
+++ b/query-algebrizer/src/lib.rs
@@ -69,7 +69,7 @@ pub fn algebrize(schema: &Schema, parsed: FindQuery) -> AlgebraicQuery {
     let where_clauses = parsed.where_clauses;
     for where_clause in where_clauses {
         if let WhereClause::Pattern(p) = where_clause {
-            cc.apply_pattern(schema, &p);
+            cc.apply_pattern(schema, p);
         } else {
             unimplemented!();
         }

--- a/query-algebrizer/src/lib.rs
+++ b/query-algebrizer/src/lib.rs
@@ -11,6 +11,7 @@
 extern crate mentat_core;
 extern crate mentat_query;
 
+mod types;
 mod cc;
 
 use mentat_core::{
@@ -84,7 +85,7 @@ pub use cc::{
     ConjoiningClauses,
 };
 
-pub use cc::{
+pub use types::{
     DatomsColumn,
     DatomsTable,
     QualifiedAlias,

--- a/query-algebrizer/src/lib.rs
+++ b/query-algebrizer/src/lib.rs
@@ -29,6 +29,12 @@ use mentat_query::{
     WhereClause,
 };
 
+pub use errors::{
+    Error,
+    ErrorKind,
+    Result,
+};
+
 #[allow(dead_code)]
 pub struct AlgebraicQuery {
     default_source: SrcVar,
@@ -62,37 +68,42 @@ impl AlgebraicQuery {
 }
 
 #[allow(dead_code)]
-pub fn algebrize(schema: &Schema, parsed: FindQuery) -> AlgebraicQuery {
+pub fn algebrize(schema: &Schema, parsed: FindQuery) -> Result<AlgebraicQuery> {
     // TODO: integrate default source into pattern processing.
     // TODO: flesh out the rest of find-into-context.
     let mut cc = cc::ConjoiningClauses::default();
     let where_clauses = parsed.where_clauses;
     for where_clause in where_clauses {
-        if let WhereClause::Pattern(p) = where_clause {
-            cc.apply_pattern(schema, p);
-        } else {
-            unimplemented!();
+        match where_clause {
+            WhereClause::Pattern(p) => {
+                cc.apply_pattern(schema, p);
+            },
+            WhereClause::Pred(p) => {
+                cc.apply_predicate(schema, p)?;
+            },
+            _ => unimplemented!(),
         }
     }
 
-    AlgebraicQuery {
+    Ok(AlgebraicQuery {
         default_source: parsed.default_source,
         find_spec: parsed.find_spec,
         has_aggregates: false,           // TODO: we don't parse them yet.
         limit: None,
         cc: cc,
-    }
+    })
 }
 
 pub use cc::{
-    ColumnConstraint,
     ConjoiningClauses,
 };
 
 pub use types::{
+    ColumnConstraint,
     DatomsColumn,
     DatomsTable,
     QualifiedAlias,
+    QueryValue,
     SourceAlias,
     TableAlias,
 };

--- a/query-algebrizer/src/lib.rs
+++ b/query-algebrizer/src/lib.rs
@@ -8,9 +8,13 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
+#[macro_use]
+extern crate error_chain;
+
 extern crate mentat_core;
 extern crate mentat_query;
 
+mod errors;
 mod types;
 mod cc;
 

--- a/query-algebrizer/src/types.rs
+++ b/query-algebrizer/src/types.rs
@@ -1,0 +1,88 @@
+// Copyright 2016 Mozilla
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+use std::fmt::{
+    Debug,
+    Formatter,
+    Result,
+};
+
+/// This enum models the fixed set of default tables we have -- two
+/// tables and two views.
+#[derive(PartialEq, Eq, Clone, Copy, Debug)]
+pub enum DatomsTable {
+    Datoms,             // The non-fulltext datoms table.
+    FulltextValues,     // The virtual table mapping IDs to strings.
+    FulltextDatoms,     // The fulltext-datoms view.
+    AllDatoms,          // Fulltext and non-fulltext datoms.
+}
+
+impl DatomsTable {
+    pub fn name(&self) -> &'static str {
+        match *self {
+            DatomsTable::Datoms => "datoms",
+            DatomsTable::FulltextValues => "fulltext_values",
+            DatomsTable::FulltextDatoms => "fulltext_datoms",
+            DatomsTable::AllDatoms => "all_datoms",
+        }
+    }
+}
+
+/// One of the named columns of our tables.
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub enum DatomsColumn {
+    Entity,
+    Attribute,
+    Value,
+    Tx,
+    ValueTypeTag,
+}
+
+impl DatomsColumn {
+    pub fn as_str(&self) -> &'static str {
+        use self::DatomsColumn::*;
+        match *self {
+            Entity => "e",
+            Attribute => "a",
+            Value => "v",
+            Tx => "tx",
+            ValueTypeTag => "value_type_tag",
+        }
+    }
+}
+
+/// A specific instance of a table within a query. E.g., "datoms123".
+pub type TableAlias = String;
+
+/// The association between a table and its alias. E.g., AllDatoms, "all_datoms123".
+#[derive(PartialEq, Eq, Clone)]
+pub struct SourceAlias(pub DatomsTable, pub TableAlias);
+
+impl Debug for SourceAlias {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        write!(f, "SourceAlias({:?}, {})", self.0, self.1)
+    }
+}
+
+/// A particular column of a particular aliased table. E.g., "datoms123", Attribute.
+#[derive(PartialEq, Eq, Clone)]
+pub struct QualifiedAlias(pub TableAlias, pub DatomsColumn);
+
+impl Debug for QualifiedAlias {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        write!(f, "{}.{}", self.0, self.1.as_str())
+    }
+}
+
+impl QualifiedAlias {
+    pub fn for_type_tag(&self) -> QualifiedAlias {
+        QualifiedAlias(self.0.clone(), DatomsColumn::ValueTypeTag)
+    }
+}

--- a/query-algebrizer/src/types.rs
+++ b/query-algebrizer/src/types.rs
@@ -14,6 +14,11 @@ use std::fmt::{
     Result,
 };
 
+use mentat_core::{
+    Entid,
+    TypedValue,
+    ValueType,
+};
 /// This enum models the fixed set of default tables we have -- two
 /// tables and two views.
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
@@ -84,5 +89,118 @@ impl Debug for QualifiedAlias {
 impl QualifiedAlias {
     pub fn for_type_tag(&self) -> QualifiedAlias {
         QualifiedAlias(self.0.clone(), DatomsColumn::ValueTypeTag)
+    }
+}
+
+#[derive(PartialEq, Eq)]
+pub enum QueryValue {
+    Column(QualifiedAlias),
+    Entid(Entid),
+    TypedValue(TypedValue),
+
+    // This is different: a numeric value can only apply to the 'v' column, and it implicitly
+    // constrains the `value_type_tag` column. For instance, a primitive long on `datoms00` of `5`
+    // cannot be a boolean, so `datoms00.value_type_tag` must be in the set `#{0, 4, 5}`.
+    // Note that `5 = 5.0` in SQLite, and we preserve that here.
+    PrimitiveLong(i64),
+}
+
+impl Debug for QueryValue {
+    fn fmt(&self, f: &mut Formatter) -> ::std::fmt::Result {
+        use self::QueryValue::*;
+        match self {
+            &Column(ref qa) => {
+                write!(f, "{:?}", qa)
+            },
+            &Entid(ref entid) => {
+                write!(f, "entity({:?})", entid)
+            },
+            &TypedValue(ref typed_value) => {
+                write!(f, "value({:?})", typed_value)
+            },
+            &PrimitiveLong(value) => {
+                write!(f, "primitive({:?})", value)
+            },
+
+        }
+    }
+}
+
+#[derive(Copy, Clone, PartialEq, Eq)]
+/// Define the different numeric inequality operators that we support.
+/// Note that we deliberately don't just use "<=" and friends as strings:
+/// Datalog and SQL don't use the same operators (e.g., `<>` and `!=`).
+pub enum NumericComparison {
+    LessThan,
+    LessThanOrEquals,
+    GreaterThan,
+    GreaterThanOrEquals,
+    NotEquals,
+}
+
+impl NumericComparison {
+    pub fn to_sql_operator(self) -> &'static str {
+        use self::NumericComparison::*;
+        match self {
+            LessThan            => "<",
+            LessThanOrEquals    => "<=",
+            GreaterThan         => ">",
+            GreaterThanOrEquals => ">=",
+            NotEquals           => "<>",
+        }
+    }
+
+    pub fn from_datalog_operator(s: &str) -> Option<NumericComparison> {
+        match s {
+            "<"  => Some(NumericComparison::LessThan),
+            "<=" => Some(NumericComparison::LessThanOrEquals),
+            ">"  => Some(NumericComparison::GreaterThan),
+            ">=" => Some(NumericComparison::GreaterThanOrEquals),
+            "!=" => Some(NumericComparison::NotEquals),
+            _    => None,
+        }
+    }
+}
+
+impl Debug for NumericComparison {
+    fn fmt(&self, f: &mut Formatter) -> ::std::fmt::Result {
+        use self::NumericComparison::*;
+        f.write_str(match self {
+            &LessThan => "<",
+            &LessThanOrEquals => "<=",
+            &GreaterThan => ">",
+            &GreaterThanOrEquals => ">=",
+            &NotEquals => "!=",                // Datalog uses !=. SQL uses <>.
+        })
+    }
+}
+
+#[derive(PartialEq, Eq)]
+pub enum ColumnConstraint {
+    Equals(QualifiedAlias, QueryValue),
+    NumericInequality {
+        operator: NumericComparison,
+        left: QueryValue,
+        right: QueryValue,
+    },
+    HasType(TableAlias, ValueType),
+}
+
+impl Debug for ColumnConstraint {
+    fn fmt(&self, f: &mut Formatter) -> ::std::fmt::Result {
+        use self::ColumnConstraint::*;
+        match self {
+            &Equals(ref qa1, ref thing) => {
+                write!(f, "{:?} = {:?}", qa1, thing)
+            },
+
+            &NumericInequality { operator, ref left, ref right } => {
+                write!(f, "{:?} {:?} {:?}", left, operator, right)
+            },
+
+            &HasType(ref qa, value_type) => {
+                write!(f, "{:?}.value_type_tag = {:?}", qa, value_type)
+            },
+        }
     }
 }

--- a/query-parser/src/find.rs
+++ b/query-parser/src/find.rs
@@ -41,16 +41,20 @@ use std::collections::BTreeMap;
 
 use self::mentat_query::{
     FindQuery,
+    FnArg,
     FromValue,
+    Predicate,
+    PredicateFn,
     SrcVar,
     Variable,
 };
+
 use self::mentat_parser_utils::ValueParseError;
 
 use super::parse::{
-    Result,
     ErrorKind,
     QueryParseResult,
+    Result,
     clause_seq_to_patterns,
 };
 
@@ -106,8 +110,8 @@ fn parse_find_parts(find: &[edn::Value],
                 find_spec: spec,
                 default_source: source,
                 with: with_vars,
-                in_vars: vec!(),       // TODO
-                in_sources: vec!(),    // TODO
+                in_vars: vec![],       // TODO
+                in_sources: vec![],    // TODO
                 where_clauses: where_clauses,
             }
         })
@@ -230,6 +234,26 @@ mod test_parse {
                        value: PatternValuePlace::Variable(Variable(PlainSymbol::new("?y"))),
                        tx: PatternNonValuePlace::Placeholder,
                    })]);
+    }
 
+    #[test]
+    fn test_parse_predicate() {
+        let input = "[:find ?x :where [?x :foo/bar ?y] [[< ?y 10]]]";
+        let parsed = parse_find_string(input).unwrap();
+        assert_eq!(parsed.where_clauses,
+                   vec![
+                      WhereClause::Pattern(Pattern {
+                          source: None,
+                          entity: PatternNonValuePlace::Variable(Variable(PlainSymbol::new("?x"))),
+                          attribute: PatternNonValuePlace::Ident(NamespacedKeyword::new("foo", "bar")),
+                          value: PatternValuePlace::Variable(Variable(PlainSymbol::new("?y"))),
+                          tx: PatternNonValuePlace::Placeholder,
+                      }),
+                      WhereClause::Pred(Predicate {
+                          operator: PlainSymbol::new("<"),
+                          args: vec![FnArg::Variable(Variable(PlainSymbol::new("?y"))),
+                                     FnArg::EntidOrInteger(10)],
+                      }),
+                  ]);
     }
 }

--- a/query-parser/src/find.rs
+++ b/query-parser/src/find.rs
@@ -201,25 +201,21 @@ mod test_parse {
         let truncated_input = edn::Value::Vector(vec![Value::from_keyword(None, "find")]);
         assert!(parse_find(truncated_input).is_err());
 
-        let input = edn::Value::Vector(vec![
-                                       Value::from_keyword(None, "find"),
-                                       Value::from_symbol(None, "?x"),
-                                       Value::from_symbol(None, "?y"),
-                                       Value::from_keyword(None, "where"),
-                                       edn::Value::Vector(vec![
-                                                          Value::from_symbol(None, "?x"),
-                                                          Value::from_keyword("foo", "bar"),
-                                                          Value::from_symbol(None, "?y"),
-                                       ]),
-        ]);
+        let input =
+            edn::Value::Vector(vec![Value::from_keyword(None, "find"),
+                                    Value::from_symbol(None, "?x"),
+                                    Value::from_symbol(None, "?y"),
+                                    Value::from_keyword(None, "where"),
+                                    edn::Value::Vector(vec![Value::from_symbol(None, "?x"),
+                                                            Value::from_keyword("foo", "bar"),
+                                                            Value::from_symbol(None, "?y")])]);
 
         let parsed = parse_find(input).unwrap();
         if let FindSpec::FindRel(elems) = parsed.find_spec {
             assert_eq!(2, elems.len());
-            assert_eq!(vec![
-                       Element::Variable(Variable(edn::PlainSymbol::new("?x"))),
-                       Element::Variable(Variable(edn::PlainSymbol::new("?y"))),
-            ], elems);
+            assert_eq!(vec![Element::Variable(Variable(edn::PlainSymbol::new("?x"))),
+                            Element::Variable(Variable(edn::PlainSymbol::new("?y")))],
+                       elems);
         } else {
             panic!("Expected FindRel.");
         }

--- a/query-parser/tests/find_tests.rs
+++ b/query-parser/tests/find_tests.rs
@@ -12,24 +12,45 @@ extern crate mentat_query_parser;
 extern crate mentat_query;
 extern crate edn;
 
-use mentat_query::FindSpec::FindScalar;
-use mentat_query::Element;
-use mentat_query::Variable;
 use edn::PlainSymbol;
+
+use mentat_query::{
+    Element,
+    FindSpec,
+    FnArg,
+    Pattern,
+    PatternNonValuePlace,
+    PatternValuePlace,
+    Predicate,
+    Variable,
+    WhereClause,
+};
+
+use mentat_query_parser::parse_find_string;
 
 ///! N.B., parsing a query can be done without reference to a DB.
 ///! Processing the parsed query into something we can work with
 ///! for planning involves interrogating the schema and idents in
 ///! the store.
 ///! See <https://github.com/mozilla/mentat/wiki/Querying> for more.
-
 #[test]
-fn can_parse_trivial_find() {
-    let find = FindScalar(Element::Variable(Variable(PlainSymbol("?foo".to_string()))));
+fn can_parse_predicates() {
+    let s = "[:find [?x ...] :where [?x _ ?y] [(< ?y 10)]]";
+    let p = parse_find_string(s).unwrap();
 
-    if let FindScalar(Element::Variable(Variable(PlainSymbol(name)))) = find {
-        assert_eq!("?foo", name);
-    } else {
-        panic!()
-    }
+    assert_eq!(p.find_spec,
+               FindSpec::FindColl(Element::Variable(Variable(PlainSymbol::new("?x")))));
+    assert_eq!(p.where_clauses,
+               vec![
+                   WhereClause::Pattern(Pattern {
+                       source: None,
+                       entity: PatternNonValuePlace::Variable(Variable(PlainSymbol::new("?x"))),
+                       attribute: PatternNonValuePlace::Placeholder,
+                       value: PatternValuePlace::Variable(Variable(PlainSymbol::new("?y"))),
+                       tx: PatternNonValuePlace::Placeholder,
+                   }),
+                   WhereClause::Pred(Predicate { operator: PlainSymbol::new("<"), args: vec![
+                       FnArg::Variable(Variable(PlainSymbol::new("?y"))), FnArg::EntidOrInteger(10),
+                   ]}),
+               ]);
 }

--- a/query-projector/src/lib.rs
+++ b/query-projector/src/lib.rs
@@ -219,7 +219,7 @@ fn project_elements<'a, I: IntoIterator<Item = &'a Element>>(
                 let qa = columns[0].clone();
                 let name = column_name(var);
 
-                if let Some(t) = query.cc.known_types.get(var) {
+                if let Some(t) = query.cc.known_type(var) {
                     cols.push(ProjectedColumn(ColumnOrExpression::Column(qa), name));
                     let tag = t.value_type_tag();
                     templates.push(TypedIndex::Known(i, tag));

--- a/query-translator/tests/translate.rs
+++ b/query-translator/tests/translate.rs
@@ -186,9 +186,8 @@ fn test_numeric_less_than_unknown_attribute() {
     let input = r#"[:find ?x :where [?x _ ?y] [(< ?y 10)]]"#;
     let SQLQuery { sql, args } = translate(&schema, input, None);
 
-    // TODO: we don't infer numeric types from numeric predicates, because the _SQL_ type code
-    // is a single value (5), but the Datalog types are a set (Double and Long).
-    // When we do, this will correctly use `datoms` instead of `all_datoms`.
+    // Although we infer numericness from numeric predicates, we've already assigned a table to the
+    // first pattern, and so this is _still_ `all_datoms`.
     assert_eq!(sql, "SELECT `all_datoms00`.e AS `?x` FROM `all_datoms` AS `all_datoms00` WHERE `all_datoms00`.v < 10");
     assert_eq!(args, vec![]);
 }

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -158,6 +158,7 @@ impl FromValue<FnArg> for FnArg {
                  .or_else(||
             match v {
                 &edn::Value::Integer(i) => Some(FnArg::EntidOrInteger(i)),
+                &edn::Value::Float(f) => Some(FnArg::Constant(NonIntegerConstant::Float(f))),
                 _ => unimplemented!(),
             })
     }

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -75,6 +75,26 @@ impl fmt::Debug for Variable {
     }
 }
 
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct PredicateFn(pub PlainSymbol);
+
+impl FromValue<PredicateFn> for PredicateFn {
+    fn from_value(v: &edn::Value) -> Option<PredicateFn> {
+        if let edn::Value::PlainSymbol(ref s) = *v {
+            PredicateFn::from_symbol(s)
+        } else {
+            None
+        }
+    }
+}
+
+impl PredicateFn {
+    pub fn from_symbol(sym: &PlainSymbol) -> Option<PredicateFn> {
+        // TODO: validate the acceptable set of function names.
+        Some(PredicateFn(sym.clone()))
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum SrcVar {
     DefaultSrc,
@@ -121,12 +141,26 @@ impl NonIntegerConstant {
     }
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum FnArg {
     Variable(Variable),
     SrcVar(SrcVar),
     EntidOrInteger(i64),
     Ident(NamespacedKeyword),
     Constant(NonIntegerConstant),
+}
+
+impl FromValue<FnArg> for FnArg {
+    fn from_value(v: &edn::Value) -> Option<FnArg> {
+        // TODO: support SrcVars.
+        Variable::from_value(v)
+                 .and_then(|v| Some(FnArg::Variable(v)))
+                 .or_else(||
+            match v {
+                &edn::Value::Integer(i) => Some(FnArg::EntidOrInteger(i)),
+                _ => unimplemented!(),
+            })
+    }
 }
 
 /// e, a, tx can't be values -- no strings, no floats -- and so
@@ -433,6 +467,11 @@ impl Pattern {
     }
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Predicate {
+    pub operator: PlainSymbol,
+    pub args: Vec<FnArg>,
+}
 
 #[allow(dead_code)]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -441,7 +480,7 @@ pub enum WhereClause {
     NotJoin,
     Or,
     OrJoin,
-    Pred,
+    Pred(Predicate),
     WhereFn,
     RuleExpr,
     Pattern(Pattern),

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -14,6 +14,7 @@ use rusqlite;
 
 use edn;
 use mentat_db;
+use mentat_query_algebrizer;
 use mentat_query_parser;
 use mentat_query_projector;
 use mentat_sql;
@@ -31,6 +32,7 @@ error_chain! {
 
     links {
         DbError(mentat_db::Error, mentat_db::ErrorKind);
+        QueryError(mentat_query_algebrizer::Error, mentat_query_algebrizer::ErrorKind);   // Let's not leak the term 'algebrizer'.
         QueryParseError(mentat_query_parser::Error, mentat_query_parser::ErrorKind);
         ProjectorError(mentat_query_projector::Error, mentat_query_projector::ErrorKind);
         SqlError(mentat_sql::Error, mentat_sql::ErrorKind);

--- a/src/query.rs
+++ b/src/query.rs
@@ -65,7 +65,7 @@ pub fn q_once<'sqlite, 'schema, 'query, T, U>
     // TODO: validate inputs.
 
     let parsed = parse_find_string(query)?;
-    let mut algebrized = algebrize(schema, parsed);
+    let mut algebrized = algebrize(schema, parsed)?;
 
     if algebrized.is_known_empty() {
         // We don't need to do any SQL work at all.


### PR DESCRIPTION
This PR starts to split up `cc.rs` a little, as well as doing some cleanup. (I left in some reformatting that VSCode did on its own, mostly in their own commits.)

I then added a test for some things that CC isn't smart enough to do yet (see #373), and finally moved on to the meat of the PR: extending the parser to handle predicates.

Right now `edn::Value::List` isn't 'spreadable' into a slice, which our parsing approach relies on. That means we don't yet support the syntax you usually see for predicates:

```
[(< ?x 10)]
```

Instead we partly follow the Datomic query grammar (!!):

```
[] = list or vector
…
pred-expr = [ [pred fn-arg+] ]
```

and support only vectors: `[[< ?x 10]]` is valid, and that's what we handle. I'll expand that next.