### PR TITLE
Check sqlite version

### DIFF
--- a/db/src/db.rs
+++ b/db/src/db.rs
@@ -217,8 +217,6 @@ fn version_number_from_string(version_string: &'static str) -> i32 {
 
 // TODO: rename "SQL" functions to align with "datoms" functions.
 pub fn create_current_version(conn: &mut rusqlite::Connection) -> Result<DB> {
-    writeln!(&mut io::stderr(), "current rusqlite version is {}", rusqlite::version()).unwrap();
-
     if rusqlite::version_number() < version_number_from_string(MIN_SQLITE_VERSION) {
         writeln!(&mut io::stderr(), "Mentat requires at least sqlite {}", MIN_SQLITE_VERSION).unwrap();
         exit(1)

--- a/db/src/db.rs
+++ b/db/src/db.rs
@@ -1062,4 +1062,14 @@ mod tests {
         conn.set_limit(Limit::SQLITE_LIMIT_VARIABLE_NUMBER, 222);
         assert_eq!(222, conn.limit(Limit::SQLITE_LIMIT_VARIABLE_NUMBER));
     }
+
+    #[test]
+    fn test_version_number_from_string() {
+        assert_eq!(3000000, version_number_from_string("3.0.0"));
+        assert_eq!(3008000, version_number_from_string("3.8.0"));
+        assert_eq!(3017000, version_number_from_string("3.17.0"));
+        assert_eq!(3017008, version_number_from_string("3.17.8"));
+        assert_eq!(3017012, version_number_from_string("3.17.12"));
+        assert_eq!(13017012, version_number_from_string("13.17.12"));
+    }
 }

--- a/db/src/db.rs
+++ b/db/src/db.rs
@@ -72,13 +72,11 @@ pub fn new_connection<T>(uri: T) -> rusqlite::Result<rusqlite::Connection> where
 pub const CURRENT_VERSION: i32 = 2;
 
 /// MIN_SQLITE_VERSION should be changed when there's a new minimum version of sqlite required
-/// to build the project.
+/// for the project to work.
 const MIN_SQLITE_VERSION: i32 = 3008000;
 
 const TRUE: &'static bool = &true;
 const FALSE: &'static bool = &false;
-
-
 
 /// Turn an owned bool into a static reference to a bool.
 ///
@@ -197,9 +195,6 @@ fn get_user_version(conn: &rusqlite::Connection) -> Result<i32> {
 
 // TODO: rename "SQL" functions to align with "datoms" functions.
 pub fn create_current_version(conn: &mut rusqlite::Connection) -> Result<DB> {
-    if rusqlite::version_number() < MIN_SQLITE_VERSION {
-        panic!("Mentat requires at least sqlite {}", MIN_SQLITE_VERSION);
-    }
     let tx = conn.transaction()?;
 
     for statement in (&V2_STATEMENTS).iter() {
@@ -333,6 +328,10 @@ pub fn update_from_version(conn: &mut rusqlite::Connection, current_version: i32
 }
 
 pub fn ensure_current_version(conn: &mut rusqlite::Connection) -> Result<DB> {
+    if rusqlite::version_number() < MIN_SQLITE_VERSION {
+        panic!("Mentat requires at least sqlite {}", MIN_SQLITE_VERSION);
+    }
+
     let user_version = get_user_version(&conn)?;
     match user_version {
         0 => create_current_version(conn),


### PR DESCRIPTION
Fixes #366 

Checks whether current SQLite version is at least the minimum required version and force exits with an error message if not.

This might have been done much simpler by just having 2 constants, one for version string and one for version number but I wanted to remove the possibility of developer error by bad translation.