### PR TITLE
Correctly generate DISTINCT and LIMIT. (#386)

### DIFF
--- a/query-algebrizer/src/lib.rs
+++ b/query-algebrizer/src/lib.rs
@@ -85,11 +85,12 @@ pub fn algebrize(schema: &Schema, parsed: FindQuery) -> Result<AlgebraicQuery> {
         }
     }
 
+    let limit = if parsed.find_spec.is_unit_limited() { Some(1) } else { None };
     Ok(AlgebraicQuery {
         default_source: parsed.default_source,
         find_spec: parsed.find_spec,
         has_aggregates: false,           // TODO: we don't parse them yet.
-        limit: None,
+        limit: limit,
         cc: cc,
     })
 }

--- a/query-translator/tests/translate.rs
+++ b/query-translator/tests/translate.rs
@@ -49,48 +49,63 @@ fn translate<T: Into<Option<u64>>>(schema: &Schema, input: &'static str, limit: 
     select.query.to_sql_query().unwrap()
 }
 
-#[test]
-fn test_coll() {
+fn prepopulated_schema() -> Schema {
     let mut schema = Schema::default();
     associate_ident(&mut schema, NamespacedKeyword::new("foo", "bar"), 99);
     add_attribute(&mut schema, 99, Attribute {
         value_type: ValueType::String,
         ..Default::default()
     });
+    schema
+}
+
+#[test]
+fn test_scalar() {
+    let schema = prepopulated_schema();
+
+    let input = r#"[:find ?x . :where [?x :foo/bar "yyy"]]"#;
+    let SQLQuery { sql, args } = translate(&schema, input, None);
+    assert_eq!(sql, "SELECT `datoms00`.e AS `?x` FROM `datoms` AS `datoms00` WHERE `datoms00`.a = 99 AND `datoms00`.v = $v0 LIMIT 1");
+    assert_eq!(args, vec![("$v0".to_string(), "yyy".to_string())]);
+}
+
+#[test]
+fn test_tuple() {
+    let schema = prepopulated_schema();
+
+    let input = r#"[:find [?x] :where [?x :foo/bar "yyy"]]"#;
+    let SQLQuery { sql, args } = translate(&schema, input, None);
+    assert_eq!(sql, "SELECT `datoms00`.e AS `?x` FROM `datoms` AS `datoms00` WHERE `datoms00`.a = 99 AND `datoms00`.v = $v0 LIMIT 1");
+    assert_eq!(args, vec![("$v0".to_string(), "yyy".to_string())]);
+}
+
+#[test]
+fn test_coll() {
+    let schema = prepopulated_schema();
 
     let input = r#"[:find [?x ...] :where [?x :foo/bar "yyy"]]"#;
     let SQLQuery { sql, args } = translate(&schema, input, None);
-    assert_eq!(sql, "SELECT `datoms00`.e AS `?x` FROM `datoms` AS `datoms00` WHERE `datoms00`.a = 99 AND `datoms00`.v = $v0");
+    assert_eq!(sql, "SELECT DISTINCT `datoms00`.e AS `?x` FROM `datoms` AS `datoms00` WHERE `datoms00`.a = 99 AND `datoms00`.v = $v0");
     assert_eq!(args, vec![("$v0".to_string(), "yyy".to_string())]);
 }
 
 #[test]
 fn test_rel() {
-    let mut schema = Schema::default();
-    associate_ident(&mut schema, NamespacedKeyword::new("foo", "bar"), 99);
-    add_attribute(&mut schema, 99, Attribute {
-        value_type: ValueType::String,
-        ..Default::default()
-    });
+    let schema = prepopulated_schema();
 
     let input = r#"[:find ?x :where [?x :foo/bar "yyy"]]"#;
     let SQLQuery { sql, args } = translate(&schema, input, None);
-    assert_eq!(sql, "SELECT `datoms00`.e AS `?x` FROM `datoms` AS `datoms00` WHERE `datoms00`.a = 99 AND `datoms00`.v = $v0");
+    assert_eq!(sql, "SELECT DISTINCT `datoms00`.e AS `?x` FROM `datoms` AS `datoms00` WHERE `datoms00`.a = 99 AND `datoms00`.v = $v0");
     assert_eq!(args, vec![("$v0".to_string(), "yyy".to_string())]);
 }
 
 #[test]
 fn test_limit() {
-    let mut schema = Schema::default();
-    associate_ident(&mut schema, NamespacedKeyword::new("foo", "bar"), 99);
-    add_attribute(&mut schema, 99, Attribute {
-        value_type: ValueType::String,
-        ..Default::default()
-    });
+    let schema = prepopulated_schema();
 
     let input = r#"[:find ?x :where [?x :foo/bar "yyy"]]"#;
     let SQLQuery { sql, args } = translate(&schema, input, 5);
-    assert_eq!(sql, "SELECT `datoms00`.e AS `?x` FROM `datoms` AS `datoms00` WHERE `datoms00`.a = 99 AND `datoms00`.v = $v0 LIMIT 5");
+    assert_eq!(sql, "SELECT DISTINCT `datoms00`.e AS `?x` FROM `datoms` AS `datoms00` WHERE `datoms00`.a = 99 AND `datoms00`.v = $v0 LIMIT 5");
     assert_eq!(args, vec![("$v0".to_string(), "yyy".to_string())]);
 }
 
@@ -102,7 +117,7 @@ fn test_unknown_attribute_keyword_value() {
     let SQLQuery { sql, args } = translate(&schema, input, None);
 
     // Only match keywords, not strings: tag = 13.
-    assert_eq!(sql, "SELECT `datoms00`.e AS `?x` FROM `datoms` AS `datoms00` WHERE `datoms00`.v = $v0 AND `datoms00`.value_type_tag = 13");
+    assert_eq!(sql, "SELECT DISTINCT `datoms00`.e AS `?x` FROM `datoms` AS `datoms00` WHERE `datoms00`.v = $v0 AND `datoms00`.value_type_tag = 13");
     assert_eq!(args, vec![("$v0".to_string(), ":ab/yyy".to_string())]);
 }
 
@@ -115,7 +130,7 @@ fn test_unknown_attribute_string_value() {
 
     // We expect all_datoms because we're querying for a string. Magic, that.
     // We don't want keywords etc., so tag = 10.
-    assert_eq!(sql, "SELECT `all_datoms00`.e AS `?x` FROM `all_datoms` AS `all_datoms00` WHERE `all_datoms00`.v = $v0 AND `all_datoms00`.value_type_tag = 10");
+    assert_eq!(sql, "SELECT DISTINCT `all_datoms00`.e AS `?x` FROM `all_datoms` AS `all_datoms00` WHERE `all_datoms00`.v = $v0 AND `all_datoms00`.value_type_tag = 10");
     assert_eq!(args, vec![("$v0".to_string(), "horses".to_string())]);
 }
 
@@ -128,7 +143,7 @@ fn test_unknown_attribute_double_value() {
 
     // In general, doubles _could_ be 1.0, which might match a boolean or a ref. Set tag = 5 to
     // make sure we only match numbers.
-    assert_eq!(sql, "SELECT `datoms00`.e AS `?x` FROM `datoms` AS `datoms00` WHERE `datoms00`.v = 9.95 AND `datoms00`.value_type_tag = 5");
+    assert_eq!(sql, "SELECT DISTINCT `datoms00`.e AS `?x` FROM `datoms` AS `datoms00` WHERE `datoms00`.v = 9.95 AND `datoms00`.value_type_tag = 5");
     assert_eq!(args, vec![]);
 }
 
@@ -143,22 +158,22 @@ fn test_unknown_attribute_integer_value() {
 
     // Can't match boolean; no need to filter it out.
     let SQLQuery { sql, args } = translate(&schema, negative, None);
-    assert_eq!(sql, "SELECT `datoms00`.e AS `?x` FROM `datoms` AS `datoms00` WHERE `datoms00`.v = -1");
+    assert_eq!(sql, "SELECT DISTINCT `datoms00`.e AS `?x` FROM `datoms` AS `datoms00` WHERE `datoms00`.v = -1");
     assert_eq!(args, vec![]);
 
     // Excludes booleans.
     let SQLQuery { sql, args } = translate(&schema, zero, None);
-    assert_eq!(sql, "SELECT `datoms00`.e AS `?x` FROM `datoms` AS `datoms00` WHERE (`datoms00`.v = 0 AND `datoms00`.value_type_tag <> 1)");
+    assert_eq!(sql, "SELECT DISTINCT `datoms00`.e AS `?x` FROM `datoms` AS `datoms00` WHERE (`datoms00`.v = 0 AND `datoms00`.value_type_tag <> 1)");
     assert_eq!(args, vec![]);
 
     // Excludes booleans.
     let SQLQuery { sql, args } = translate(&schema, one, None);
-    assert_eq!(sql, "SELECT `datoms00`.e AS `?x` FROM `datoms` AS `datoms00` WHERE (`datoms00`.v = 1 AND `datoms00`.value_type_tag <> 1)");
+    assert_eq!(sql, "SELECT DISTINCT `datoms00`.e AS `?x` FROM `datoms` AS `datoms00` WHERE (`datoms00`.v = 1 AND `datoms00`.value_type_tag <> 1)");
     assert_eq!(args, vec![]);
 
     // Can't match boolean; no need to filter it out.
     let SQLQuery { sql, args } = translate(&schema, two, None);
-    assert_eq!(sql, "SELECT `datoms00`.e AS `?x` FROM `datoms` AS `datoms00` WHERE `datoms00`.v = 2");
+    assert_eq!(sql, "SELECT DISTINCT `datoms00`.e AS `?x` FROM `datoms` AS `datoms00` WHERE `datoms00`.v = 2");
     assert_eq!(args, vec![]);
 }
 
@@ -188,7 +203,7 @@ fn test_numeric_less_than_unknown_attribute() {
 
     // Although we infer numericness from numeric predicates, we've already assigned a table to the
     // first pattern, and so this is _still_ `all_datoms`.
-    assert_eq!(sql, "SELECT `all_datoms00`.e AS `?x` FROM `all_datoms` AS `all_datoms00` WHERE `all_datoms00`.v < 10");
+    assert_eq!(sql, "SELECT DISTINCT `all_datoms00`.e AS `?x` FROM `all_datoms` AS `all_datoms00` WHERE `all_datoms00`.v < 10");
     assert_eq!(args, vec![]);
 }
 
@@ -203,7 +218,7 @@ fn test_numeric_gte_known_attribute() {
 
     let input = r#"[:find ?x :where [?x :foo/bar ?y] [(>= ?y 12.9)]]"#;
     let SQLQuery { sql, args } = translate(&schema, input, None);
-    assert_eq!(sql, "SELECT `datoms00`.e AS `?x` FROM `datoms` AS `datoms00` WHERE `datoms00`.a = 99 AND `datoms00`.v >= 12.9");
+    assert_eq!(sql, "SELECT DISTINCT `datoms00`.e AS `?x` FROM `datoms` AS `datoms00` WHERE `datoms00`.a = 99 AND `datoms00`.v >= 12.9");
     assert_eq!(args, vec![]);
 }
 
@@ -216,8 +231,8 @@ fn test_numeric_not_equals_known_attribute() {
         ..Default::default()
     });
 
-    let input = r#"[:find ?x :where [?x :foo/bar ?y] [(!= ?y 12)]]"#;
+    let input = r#"[:find ?x . :where [?x :foo/bar ?y] [(!= ?y 12)]]"#;
     let SQLQuery { sql, args } = translate(&schema, input, None);
-    assert_eq!(sql, "SELECT `datoms00`.e AS `?x` FROM `datoms` AS `datoms00` WHERE `datoms00`.a = 99 AND `datoms00`.v <> 12");
+    assert_eq!(sql, "SELECT `datoms00`.e AS `?x` FROM `datoms` AS `datoms00` WHERE `datoms00`.a = 99 AND `datoms00`.v <> 12 LIMIT 1");
     assert_eq!(args, vec![]);
 }


### PR DESCRIPTION
- The projector figures out whether distinct is needed from the find spec. Scalar and tuple don't need distinct. Rel and coll do.
- If an external limit was provided, and it's `1`, we don't need distinct.
- The translator pulls the value out of the projector and into the SQL intermediate format.
- The SQL outputter writes out the right string.

If, in the future, we add a form of projection for which there is no 1:1 correspondence between SQL rows and Datalog results (_e.g._, in-memory programmatic aggregation), then we will need to revise some of this — user-provided limits can no longer be used in the SQL query. That work can be driven quite easily by tests, and we don't know if we'll ever reach that point.