### PR TITLE
Crudely parse `or` and `or-join`. (#388)

### DIFF
--- a/query-algebrizer/Cargo.toml
+++ b/query-algebrizer/Cargo.toml
@@ -11,3 +11,7 @@ path = "../core"
 
 [dependencies.mentat_query]
 path = "../query"
+
+# Only for tests.
+[dev-dependencies.mentat_query_parser]
+path = "../query-parser"

--- a/query-algebrizer/src/cc.rs
+++ b/query-algebrizer/src/cc.rs
@@ -8,9 +8,6 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
-extern crate mentat_core;
-extern crate mentat_query;
-
 use std::fmt::{
     Debug,
     Formatter,
@@ -24,7 +21,7 @@ use std::collections::{
 
 use std::collections::btree_map::Entry;
 
-use self::mentat_core::{
+use mentat_core::{
     Attribute,
     Entid,
     Schema,
@@ -32,7 +29,7 @@ use self::mentat_core::{
     ValueType,
 };
 
-use self::mentat_query::{
+use mentat_query::{
     FnArg,
     NamespacedKeyword,
     NonIntegerConstant,

--- a/query-algebrizer/src/cc.rs
+++ b/query-algebrizer/src/cc.rs
@@ -40,6 +40,7 @@ use mentat_query::{
     Predicate,
     SrcVar,
     Variable,
+    WhereClause,
 };
 
 use errors::{
@@ -952,6 +953,23 @@ impl ConjoiningClauses {
         };
         self.wheres.push(constraint);
         Ok(())
+    }
+}
+
+impl ConjoiningClauses {
+    // This is here, rather than in `lib.rs`, because it's recursive: `or` can contain `or`,
+    // and so on.
+    pub fn apply_clause(&mut self, schema: &Schema, where_clause: WhereClause) -> Result<()> {
+        match where_clause {
+            WhereClause::Pattern(p) => {
+                self.apply_pattern(schema, p);
+                Ok(())
+            },
+            WhereClause::Pred(p) => {
+                self.apply_predicate(schema, p)
+            },
+            _ => unimplemented!(),
+        }
     }
 }
 

--- a/query-algebrizer/src/cc.rs
+++ b/query-algebrizer/src/cc.rs
@@ -60,6 +60,8 @@ use types::{
     TableAlias,
 };
 
+use validate::validate_or_join;
+
 /// A thing that's capable of aliasing a table name for us.
 /// This exists so that we can obtain predictable names in tests.
 pub type TableAliaser = Box<FnMut(DatomsTable) -> TableAlias>;
@@ -967,6 +969,10 @@ impl ConjoiningClauses {
             },
             WhereClause::Pred(p) => {
                 self.apply_predicate(schema, p)
+            },
+            WhereClause::OrJoin(o) => {
+                validate_or_join(&o)
+                // TODO: apply.
             },
             _ => unimplemented!(),
         }

--- a/query-algebrizer/src/errors.rs
+++ b/query-algebrizer/src/errors.rs
@@ -40,6 +40,12 @@ error_chain! {
             description("invalid argument")
             display("invalid argument to {}: expected numeric in position {}.", function, position)
         }
+
+        NonMatchingVariablesInOrClause {
+            // TODO: flesh out.
+            description("non-matching variables in 'or' clause")
+            display("non-matching variables in 'or' clause")
+        }
     }
 }
 

--- a/query-algebrizer/src/lib.rs
+++ b/query-algebrizer/src/lib.rs
@@ -75,7 +75,7 @@ pub fn algebrize(schema: &Schema, parsed: FindQuery) -> Result<AlgebraicQuery> {
     let mut cc = cc::ConjoiningClauses::default();
     let where_clauses = parsed.where_clauses;
     for where_clause in where_clauses {
-        cc.apply_clause(schema, where_clause);
+        cc.apply_clause(schema, where_clause)?;
     }
 
     let limit = if parsed.find_spec.is_unit_limited() { Some(1) } else { None };

--- a/query-algebrizer/src/lib.rs
+++ b/query-algebrizer/src/lib.rs
@@ -75,15 +75,7 @@ pub fn algebrize(schema: &Schema, parsed: FindQuery) -> Result<AlgebraicQuery> {
     let mut cc = cc::ConjoiningClauses::default();
     let where_clauses = parsed.where_clauses;
     for where_clause in where_clauses {
-        match where_clause {
-            WhereClause::Pattern(p) => {
-                cc.apply_pattern(schema, p);
-            },
-            WhereClause::Pred(p) => {
-                cc.apply_predicate(schema, p)?;
-            },
-            _ => unimplemented!(),
-        }
+        cc.apply_clause(schema, where_clause);
     }
 
     let limit = if parsed.find_spec.is_unit_limited() { Some(1) } else { None };

--- a/query-algebrizer/src/lib.rs
+++ b/query-algebrizer/src/lib.rs
@@ -16,6 +16,7 @@ extern crate mentat_query;
 
 mod errors;
 mod types;
+mod validate;
 mod cc;
 
 use mentat_core::{

--- a/query-algebrizer/src/validate.rs
+++ b/query-algebrizer/src/validate.rs
@@ -13,7 +13,6 @@ use std::collections::BTreeSet;
 use mentat_query::{
     ContainsVariables,
     OrJoin,
-    Pattern,
     Variable,
     WhereClause,
     UnifyVars,
@@ -54,9 +53,9 @@ pub fn validate_or_join(or_join: &OrJoin) -> Result<()> {
                 Ok(())
             } else {
                 let mut clauses = or_join.clauses.iter();
-                let template = clauses.next().unwrap().mentioned_variables();
+                let template = clauses.next().unwrap().collect_mentioned_variables();
                 for clause in clauses {
-                    if template != clause.mentioned_variables() {
+                    if template != clause.collect_mentioned_variables() {
                         bail!(ErrorKind::NonMatchingVariablesInOrClause);
                     }
                 }
@@ -67,7 +66,7 @@ pub fn validate_or_join(or_join: &OrJoin) -> Result<()> {
             // Each leg must use the joined vars.
             let var_set: BTreeSet<Variable> = vars.iter().cloned().collect();
             for clause in &or_join.clauses {
-                if !var_set.is_subset(&clause.mentioned_variables()) {
+                if !var_set.is_subset(&clause.collect_mentioned_variables()) {
                     bail!(ErrorKind::NonMatchingVariablesInOrClause);
                 }
             }

--- a/query-algebrizer/src/validate.rs
+++ b/query-algebrizer/src/validate.rs
@@ -125,15 +125,13 @@ mod tests {
                         :where (or [?artist :artist/type :artist.type/group]
                                    (and [?artist :artist/type :artist.type/person]
                                         [?artist :artist/gender :artist.gender/female]))]"#;
-        let parsed = parse_find_string(query).unwrap();
+        let parsed = parse_find_string(query).expect("expected successful parse");
         let clauses = valid_or_join(parsed, UnifyVars::Implicit);
 
         // Let's do some detailed parse checks.
         let mut arms = clauses.into_iter();
         match (arms.next(), arms.next(), arms.next()) {
-            (Some(left),
-            Some(right),
-            None) => {
+            (Some(left), Some(right), None) => {
                 assert_eq!(
                     left,
                     OrWhereClause::Clause(WhereClause::Pattern(Pattern {
@@ -173,8 +171,8 @@ mod tests {
         let query = r#"[:find [?artist ...]
                         :where (or [?artist :artist/type :artist.type/group]
                                    [?artist :artist/type ?type])]"#;
-        let parsed = parse_find_string(query).unwrap();
-        match parsed.where_clauses.into_iter().next().unwrap() {
+        let parsed = parse_find_string(query).expect("expected successful parse");
+        match parsed.where_clauses.into_iter().next().expect("expected at least one clause") {
             WhereClause::OrJoin(or_join) => assert!(validate_or_join(&or_join).is_err()),
             _ => panic!(),
         }
@@ -189,15 +187,13 @@ mod tests {
                                    [?artist :artist/type :artist.type/group]
                                    (and [?artist :artist/type ?type]
                                         [?type :artist/role :artist.role/parody]))]"#;
-        let parsed = parse_find_string(query).unwrap();
+        let parsed = parse_find_string(query).expect("expected successful parse");
         let clauses = valid_or_join(parsed, UnifyVars::Explicit(vec![Variable(PlainSymbol::new("?artist"))]));
 
         // Let's do some detailed parse checks.
         let mut arms = clauses.into_iter();
         match (arms.next(), arms.next(), arms.next()) {
-            (Some(left),
-            Some(right),
-            None) => {
+            (Some(left), Some(right), None) => {
                 assert_eq!(
                     left,
                     OrWhereClause::Clause(WhereClause::Pattern(Pattern {

--- a/query-algebrizer/src/validate.rs
+++ b/query-algebrizer/src/validate.rs
@@ -1,0 +1,234 @@
+// Copyright 2016 Mozilla
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+use std::collections::BTreeSet;
+
+use mentat_query::{
+    ContainsVariables,
+    OrJoin,
+    Pattern,
+    Variable,
+    WhereClause,
+    UnifyVars,
+};
+
+use errors::{
+    ErrorKind,
+    Result,
+};
+
+/// In an `or` expression, every mentioned var is considered 'free'.
+/// In an `or-join` expression, every var in the var list is 'required'.
+///
+/// Every extracted variable must be used in the clauses.
+/// The extracted var list cannot be empty.
+///
+/// The original Datomic docs are poorly worded:
+///
+/// "All clauses used in an or clause must use the same set of variables, which will unify with the
+/// surrounding query. This includes both the arguments to nested expression clauses as well as any
+/// bindings made by nested function expressions. Datomic will attempt to push the or clause down
+/// until all necessary variables are bound, and will throw an exception if that is not possible."
+///
+/// What this really means is: each pattern in the `or-join` clause must use the var list and unify
+/// with the surrounding query. It does not mean that each leg must have the same set of vars.
+///
+/// An `or` pattern must, because the set of vars is defined as every var mentioned in any clause,
+/// so naturally they must all be the same.
+///
+/// "As with rules, src-vars are not currently supported within the clauses of or, but are supported
+/// on the or clause as a whole at top level."
+pub fn validate_or_join(or_join: &OrJoin) -> Result<()> {
+    // Grab our mentioned variables and ensure that the rules are followed.
+    match or_join.unify_vars {
+        UnifyVars::Implicit => {
+            // Each 'leg' must have the same variable set.
+            if or_join.clauses.len() < 2 {
+                Ok(())
+            } else {
+                let mut clauses = or_join.clauses.iter();
+                let template = clauses.next().unwrap().mentioned_variables();
+                for clause in clauses {
+                    if template != clause.mentioned_variables() {
+                        bail!(ErrorKind::NonMatchingVariablesInOrClause);
+                    }
+                }
+                Ok(())
+            }
+        },
+        UnifyVars::Explicit(ref vars) => {
+            // Each leg must use the joined vars.
+            let var_set: BTreeSet<Variable> = vars.iter().cloned().collect();
+            for clause in &or_join.clauses {
+                if !var_set.is_subset(&clause.mentioned_variables()) {
+                    bail!(ErrorKind::NonMatchingVariablesInOrClause);
+                }
+            }
+            Ok(())
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate mentat_core;
+    extern crate mentat_query;
+    extern crate mentat_query_parser;
+
+    use self::mentat_query::{
+        FindQuery,
+        NamespacedKeyword,
+        OrWhereClause,
+        Pattern,
+        PatternNonValuePlace,
+        PatternValuePlace,
+        PlainSymbol,
+        SrcVar,
+        UnifyVars,
+        Variable,
+        WhereClause,
+    };
+
+    use self::mentat_query_parser::parse_find_string;
+
+    use super::validate_or_join;
+
+    /// Tests that the top-level form is a valid `or`, returning the clauses.
+    fn valid_or_join(parsed: FindQuery, expected_unify: UnifyVars) -> Vec<OrWhereClause> {
+        let mut wheres = parsed.where_clauses.into_iter();
+
+        // There's only one.
+        let clause = wheres.next().unwrap();
+        assert_eq!(None, wheres.next());
+
+        match clause {
+            WhereClause::OrJoin(or_join) => {
+                // It's valid: the variables are the same in each branch.
+                assert_eq!((), validate_or_join(&or_join).unwrap());
+                assert_eq!(expected_unify, or_join.unify_vars);
+                or_join.clauses
+            },
+            _ => panic!(),
+        }
+    }
+
+    /// Test that an `or` is valid if all of its arms refer to the same variables.
+    #[test]
+    fn test_success_or() {
+        let query = r#"[:find [?artist ...]
+                        :where (or [?artist :artist/type :artist.type/group]
+                                   (and [?artist :artist/type :artist.type/person]
+                                        [?artist :artist/gender :artist.gender/female]))]"#;
+        let parsed = parse_find_string(query).unwrap();
+        let clauses = valid_or_join(parsed, UnifyVars::Implicit);
+
+        // Let's do some detailed parse checks.
+        let mut arms = clauses.into_iter();
+        match (arms.next(), arms.next(), arms.next()) {
+            (Some(left),
+            Some(right),
+            None) => {
+                assert_eq!(
+                    left,
+                    OrWhereClause::Clause(WhereClause::Pattern(Pattern {
+                        source: None,
+                        entity: PatternNonValuePlace::Variable(Variable(PlainSymbol::new("?artist"))),
+                        attribute: PatternNonValuePlace::Ident(NamespacedKeyword::new("artist", "type")),
+                        value: PatternValuePlace::IdentOrKeyword(NamespacedKeyword::new("artist.type", "group")),
+                        tx: PatternNonValuePlace::Placeholder,
+                    })));
+                assert_eq!(
+                    right,
+                    OrWhereClause::And(
+                        vec![
+                            WhereClause::Pattern(Pattern {
+                                source: None,
+                                entity: PatternNonValuePlace::Variable(Variable(PlainSymbol::new("?artist"))),
+                                attribute: PatternNonValuePlace::Ident(NamespacedKeyword::new("artist", "type")),
+                                value: PatternValuePlace::IdentOrKeyword(NamespacedKeyword::new("artist.type", "person")),
+                                tx: PatternNonValuePlace::Placeholder,
+                            }),
+                            WhereClause::Pattern(Pattern {
+                                source: None,
+                                entity: PatternNonValuePlace::Variable(Variable(PlainSymbol::new("?artist"))),
+                                attribute: PatternNonValuePlace::Ident(NamespacedKeyword::new("artist", "gender")),
+                                value: PatternValuePlace::IdentOrKeyword(NamespacedKeyword::new("artist.gender", "female")),
+                                tx: PatternNonValuePlace::Placeholder,
+                            }),
+                        ]));
+            },
+            _ => panic!(),
+        };
+    }
+
+    /// Test that an `or` with differing variable sets in each arm will fail to validate.
+    #[test]
+    fn test_invalid_implicit_or() {
+        let query = r#"[:find [?artist ...]
+                        :where (or [?artist :artist/type :artist.type/group]
+                                   [?artist :artist/type ?type])]"#;
+        let parsed = parse_find_string(query).unwrap();
+        match parsed.where_clauses.into_iter().next().unwrap() {
+            WhereClause::OrJoin(or_join) => assert!(validate_or_join(&or_join).is_err()),
+            _ => panic!(),
+        }
+    }
+
+    /// Test that two arms of an `or-join` can contain different variables if they both
+    /// contain the required `or-join` list.
+    #[test]
+    fn test_success_differing_or_join() {
+        let query = r#"[:find [?artist ...]
+                        :where (or-join [?artist]
+                                   [?artist :artist/type :artist.type/group]
+                                   (and [?artist :artist/type ?type]
+                                        [?type :artist/role :artist.role/parody]))]"#;
+        let parsed = parse_find_string(query).unwrap();
+        let clauses = valid_or_join(parsed, UnifyVars::Explicit(vec![Variable(PlainSymbol::new("?artist"))]));
+
+        // Let's do some detailed parse checks.
+        let mut arms = clauses.into_iter();
+        match (arms.next(), arms.next(), arms.next()) {
+            (Some(left),
+            Some(right),
+            None) => {
+                assert_eq!(
+                    left,
+                    OrWhereClause::Clause(WhereClause::Pattern(Pattern {
+                        source: None,
+                        entity: PatternNonValuePlace::Variable(Variable(PlainSymbol::new("?artist"))),
+                        attribute: PatternNonValuePlace::Ident(NamespacedKeyword::new("artist", "type")),
+                        value: PatternValuePlace::IdentOrKeyword(NamespacedKeyword::new("artist.type", "group")),
+                        tx: PatternNonValuePlace::Placeholder,
+                    })));
+                assert_eq!(
+                    right,
+                    OrWhereClause::And(
+                        vec![
+                            WhereClause::Pattern(Pattern {
+                                source: None,
+                                entity: PatternNonValuePlace::Variable(Variable(PlainSymbol::new("?artist"))),
+                                attribute: PatternNonValuePlace::Ident(NamespacedKeyword::new("artist", "type")),
+                                value: PatternValuePlace::Variable(Variable(PlainSymbol::new("?type"))),
+                                tx: PatternNonValuePlace::Placeholder,
+                            }),
+                            WhereClause::Pattern(Pattern {
+                                source: None,
+                                entity: PatternNonValuePlace::Variable(Variable(PlainSymbol::new("?type"))),
+                                attribute: PatternNonValuePlace::Ident(NamespacedKeyword::new("artist", "role")),
+                                value: PatternValuePlace::IdentOrKeyword(NamespacedKeyword::new("artist.role", "parody")),
+                                tx: PatternNonValuePlace::Placeholder,
+                            }),
+                        ]));
+            },
+            _ => panic!(),
+        };
+    }
+}

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -474,13 +474,30 @@ pub struct Predicate {
     pub args: Vec<FnArg>,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum UnifyVars {
+    Implicit,
+    Explicit(Vec<Variable>),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum OrWhereClause {
+    Clause(WhereClause),
+    And(Vec<WhereClause>),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct OrJoin {
+    pub unify_vars: UnifyVars,
+    pub clauses: Vec<OrWhereClause>,
+}
+
 #[allow(dead_code)]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum WhereClause {
     Not,
     NotJoin,
-    Or,
-    OrJoin,
+    OrJoin(OrJoin),
     Pred(Predicate),
     WhereFn,
     RuleExpr,

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -477,7 +477,30 @@ pub struct Predicate {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum UnifyVars {
+    /// `Implicit` means the variables in an `or` or `not` are derived from the enclosed pattern.
+    /// DataScript regards these vars as 'free': these variables don't need to be bound by the
+    /// enclosing environment.
+    ///
+    /// Datomic's documentation implies that all implicit variables are required:
+    ///
+    /// > Datomic will attempt to push the or clause down until all necessary variables are bound,
+    /// > and will throw an exception if that is not possible.
+    ///
+    /// but that would render top-level `or` expressions (as used in Datomic's own examples!)
+    /// impossible, so we assume that this is an error in the documentation.
+    ///
+    /// All contained 'arms' in an `or` with implicit variables must bind the same vars.
     Implicit,
+
+    /// `Explicit` means the variables in an `or-join` or `not-join` are explicitly listed,
+    /// specified with `required-vars` syntax.
+    ///
+    /// DataScript parses these as free, but allows (incorrectly) the use of more complicated
+    /// `rule-vars` syntax.
+    ///
+    /// Only the named variables will be unified with the enclosing query.
+    ///
+    /// Every 'arm' in an `or-join` must mention the entire set of explicit vars.
     Explicit(Vec<Variable>),
 }
 

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -541,21 +541,21 @@ pub struct FindQuery {
 }
 
 pub trait ContainsVariables {
-    fn acc_mentioned_variables(&self, acc: &mut BTreeSet<Variable>);
-    fn mentioned_variables(&self) -> BTreeSet<Variable> {
+    fn accumulate_mentioned_variables(&self, acc: &mut BTreeSet<Variable>);
+    fn collect_mentioned_variables(&self) -> BTreeSet<Variable> {
         let mut out = BTreeSet::new();
-        self.acc_mentioned_variables(&mut out);
+        self.accumulate_mentioned_variables(&mut out);
         out
     }
 }
 
 impl ContainsVariables for WhereClause {
-    fn acc_mentioned_variables(&self, acc: &mut BTreeSet<Variable>) {
+    fn accumulate_mentioned_variables(&self, acc: &mut BTreeSet<Variable>) {
         use WhereClause::*;
         match self {
-            &OrJoin(ref o)  => o.acc_mentioned_variables(acc),
-            &Pred(ref p)    => p.acc_mentioned_variables(acc),
-            &Pattern(ref p) => p.acc_mentioned_variables(acc),
+            &OrJoin(ref o)  => o.accumulate_mentioned_variables(acc),
+            &Pred(ref p)    => p.accumulate_mentioned_variables(acc),
+            &Pattern(ref p) => p.accumulate_mentioned_variables(acc),
             &Not            => (),
             &NotJoin        => (),
             &WhereFn        => (),
@@ -565,25 +565,25 @@ impl ContainsVariables for WhereClause {
 }
 
 impl ContainsVariables for OrWhereClause {
-    fn acc_mentioned_variables(&self, acc: &mut BTreeSet<Variable>) {
+    fn accumulate_mentioned_variables(&self, acc: &mut BTreeSet<Variable>) {
         use OrWhereClause::*;
         match self {
-            &And(ref clauses) => for clause in clauses { clause.acc_mentioned_variables(acc) },
-            &Clause(ref clause) => clause.acc_mentioned_variables(acc),
+            &And(ref clauses) => for clause in clauses { clause.accumulate_mentioned_variables(acc) },
+            &Clause(ref clause) => clause.accumulate_mentioned_variables(acc),
         }
     }
 }
 
 impl ContainsVariables for OrJoin {
-    fn acc_mentioned_variables(&self, acc: &mut BTreeSet<Variable>) {
+    fn accumulate_mentioned_variables(&self, acc: &mut BTreeSet<Variable>) {
         for clause in &self.clauses {
-            clause.acc_mentioned_variables(acc);
+            clause.accumulate_mentioned_variables(acc);
         }
     }
 }
 
 impl ContainsVariables for Predicate {
-    fn acc_mentioned_variables(&self, acc: &mut BTreeSet<Variable>) {
+    fn accumulate_mentioned_variables(&self, acc: &mut BTreeSet<Variable>) {
         for arg in &self.args {
             if let &FnArg::Variable(ref v) = arg {
                 acc_ref(acc, v)
@@ -600,7 +600,7 @@ fn acc_ref<T: Clone + Ord>(acc: &mut BTreeSet<T>, v: &T) {
 }
 
 impl ContainsVariables for Pattern {
-    fn acc_mentioned_variables(&self, acc: &mut BTreeSet<Variable>) {
+    fn accumulate_mentioned_variables(&self, acc: &mut BTreeSet<Variable>) {
         if let PatternNonValuePlace::Variable(ref v) = self.entity {
             acc_ref(acc, v)
         }


### PR DESCRIPTION
I'm really unhappy about the amount of boilerplate in this parser. But it works.

Note that unlike DataScript's parser, this one doesn't validate the contents of the variable lists.