### PR TITLE
Use Rc for TypedValue and Variable. (#395) r=nalexander

### DIFF
--- a/core/src/intern_set.rs
+++ b/core/src/intern_set.rs
@@ -34,8 +34,27 @@ impl<T> InternSet<T> where T: Eq + Hash {
     }
 
     /// Intern a value, providing a ref-counted handle to the interned value.
-    pub fn intern(&mut self, value: T) -> Rc<T> {
-        let key = Rc::new(value);
+    ///
+    /// ```
+    /// use std::rc::Rc;
+    /// use mentat_core::intern_set::InternSet;
+    ///
+    /// let mut s = InternSet::new();
+    ///
+    /// let one = "foo".to_string();
+    /// let two = Rc::new("foo".to_string());
+    ///
+    /// let out_one = s.intern(one);
+    /// assert_eq!(out_one, two);
+    /// // assert!(!&out_one.ptr_eq(&two));      // Nightly-only.
+    ///
+    /// let out_two = s.intern(two);
+    /// assert_eq!(out_one, out_two);
+    /// assert_eq!(1, s.inner.len());
+    /// // assert!(&out_one.ptr_eq(&out_two));   // Nightly-only.
+    /// ```
+    pub fn intern<R: Into<Rc<T>>>(&mut self, value: R) -> Rc<T> {
+        let key: Rc<T> = value.into();
         if self.inner.insert(key.clone()) {
             key
         } else {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -17,6 +17,7 @@ extern crate edn;
 pub mod values;
 
 use std::collections::BTreeMap;
+use std::rc::Rc;
 use self::ordered_float::OrderedFloat;
 use self::edn::NamespacedKeyword;
 
@@ -66,8 +67,8 @@ pub enum TypedValue {
     Long(i64),
     Double(OrderedFloat<f64>),
     // TODO: &str throughout?
-    String(String),
-    Keyword(NamespacedKeyword),
+    String(Rc<String>),
+    Keyword(Rc<NamespacedKeyword>),
 }
 
 impl TypedValue {
@@ -95,17 +96,17 @@ impl TypedValue {
     }
 
     /// Construct a new `TypedValue::Keyword` instance by cloning the provided
-    /// values. This is expensive, so this might
+    /// values and wrapping them in a new `Rc`. This is expensive, so this might
     /// be best limited to tests.
     pub fn typed_ns_keyword(ns: &str, name: &str) -> TypedValue {
-        TypedValue::Keyword(NamespacedKeyword::new(ns, name))
+        TypedValue::Keyword(Rc::new(NamespacedKeyword::new(ns, name)))
     }
 
     /// Construct a new `TypedValue::String` instance by cloning the provided
-    /// value. This is expensive, so this might
+    /// value and wrapping it in a new `Rc`. This is expensive, so this might
     /// be best limited to tests.
     pub fn typed_string(s: &str) -> TypedValue {
-        TypedValue::String(s.to_string())
+        TypedValue::String(Rc::new(s.to_string()))
     }
 }
 

--- a/db/src/debug.rs
+++ b/db/src/debug.rs
@@ -14,6 +14,7 @@
 
 use std::borrow::Borrow;
 use std::io::{Write};
+use std::rc::Rc;
 
 use itertools::Itertools;
 use rusqlite;
@@ -110,7 +111,7 @@ trait ToIdent {
 impl ToIdent for TypedValue {
     fn map_ident(self, schema: &Schema) -> Self {
         if let TypedValue::Ref(e) = self {
-            schema.get_ident(e).cloned().map(TypedValue::Keyword).unwrap_or(TypedValue::Ref(e))
+            schema.get_ident(e).cloned().map(|i| TypedValue::Keyword(Rc::new(i))).unwrap_or(TypedValue::Ref(e))
         } else {
             self
         }

--- a/db/src/metadata.rs
+++ b/db/src/metadata.rs
@@ -222,7 +222,7 @@ pub fn update_schema_from_entid_quadruples<U>(schema: &mut Schema, assertions: U
         // Here we handle :db/ident assertions.
         if a == entids::DB_IDENT {
             if let TypedValue::Keyword(ref keyword) = typed_value {
-                ident_set.witness(e, keyword.clone(), added);
+                ident_set.witness(e, keyword.as_ref().clone(), added);
                 continue
             } else {
                 // Something is terribly wrong: the schema ensures we have a keyword.

--- a/db/tests/value_tests.rs
+++ b/db/tests/value_tests.rs
@@ -14,10 +14,12 @@ extern crate mentat_db;
 extern crate ordered_float;
 extern crate rusqlite;
 
+use ordered_float::OrderedFloat;
+
+use edn::symbols;
+
 use mentat_core::{TypedValue, ValueType};
 use mentat_db::db::TypedSQLValue;
-use ordered_float::OrderedFloat;
-use edn::symbols;
 
 // It's not possible to test to_sql_value_pair since rusqlite::ToSqlOutput doesn't implement
 // PartialEq.
@@ -34,8 +36,8 @@ fn test_from_sql_value_pair() {
     assert_eq!(TypedValue::from_sql_value_pair(rusqlite::types::Value::Real(0.0), 5).unwrap(), TypedValue::Double(OrderedFloat(0.0)));
     assert_eq!(TypedValue::from_sql_value_pair(rusqlite::types::Value::Real(0.5), 5).unwrap(), TypedValue::Double(OrderedFloat(0.5)));
 
-    assert_eq!(TypedValue::from_sql_value_pair(rusqlite::types::Value::Text(":db/keyword".into()), 10).unwrap(), TypedValue::String(":db/keyword".into()));
-    assert_eq!(TypedValue::from_sql_value_pair(rusqlite::types::Value::Text(":db/keyword".into()), 13).unwrap(), TypedValue::Keyword(symbols::NamespacedKeyword::new("db", "keyword")));
+    assert_eq!(TypedValue::from_sql_value_pair(rusqlite::types::Value::Text(":db/keyword".into()), 10).unwrap(), TypedValue::typed_string(":db/keyword"));
+    assert_eq!(TypedValue::from_sql_value_pair(rusqlite::types::Value::Text(":db/keyword".into()), 13).unwrap(), TypedValue::typed_ns_keyword("db", "keyword"));
 }
 
 #[test]
@@ -51,6 +53,6 @@ fn test_to_edn_value_pair() {
     assert_eq!(TypedValue::Double(OrderedFloat(0.0)).to_edn_value_pair(), (edn::Value::Float(OrderedFloat(0.0)), ValueType::Double));
     assert_eq!(TypedValue::Double(OrderedFloat(0.5)).to_edn_value_pair(), (edn::Value::Float(OrderedFloat(0.5)), ValueType::Double));
 
-    assert_eq!(TypedValue::String(":db/keyword".into()).to_edn_value_pair(), (edn::Value::Text(":db/keyword".into()), ValueType::String));
-    assert_eq!(TypedValue::Keyword(symbols::NamespacedKeyword::new("db", "keyword")).to_edn_value_pair(), (edn::Value::NamespacedKeyword(symbols::NamespacedKeyword::new("db", "keyword")), ValueType::Keyword));
+    assert_eq!(TypedValue::typed_string(":db/keyword").to_edn_value_pair(), (edn::Value::Text(":db/keyword".into()), ValueType::String));
+    assert_eq!(TypedValue::typed_ns_keyword("db", "keyword").to_edn_value_pair(), (edn::Value::NamespacedKeyword(symbols::NamespacedKeyword::new("db", "keyword")), ValueType::Keyword));
 }

--- a/query-algebrizer/src/clauses/mod.rs
+++ b/query-algebrizer/src/clauses/mod.rs
@@ -231,7 +231,7 @@ impl ConjoiningClauses {
                             // For attributes this shouldn't occur, because we check the binding in
                             // `table_for_places`/`alias_table`, and if it didn't resolve to a valid
                             // attribute then we should have already marked the pattern as empty.
-                            self.mark_known_empty(EmptyBecause::UnresolvedIdent(kw.clone()));
+                            self.mark_known_empty(EmptyBecause::UnresolvedIdent(kw.as_ref().clone()));
                         }
                     },
                     TypedValue::Ref(entid) => {
@@ -461,7 +461,7 @@ impl ConjoiningClauses {
                     Some(TypedValue::Keyword(ref kw)) =>
                         // Don't recurse: avoid needing to clone the keyword.
                         schema.attribute_for_ident(kw)
-                              .ok_or_else(|| EmptyBecause::InvalidAttributeIdent(kw.clone()))
+                              .ok_or_else(|| EmptyBecause::InvalidAttributeIdent(kw.as_ref().clone()))
                               .and_then(|attribute| self.table_for_attribute_and_value(attribute, value)),
                     Some(v) => {
                         // This pattern cannot match: the caller has bound a non-entity value to an

--- a/query-algebrizer/src/clauses/predicate.rs
+++ b/query-algebrizer/src/clauses/predicate.rs
@@ -88,7 +88,6 @@ mod testing {
     use super::*;
 
     use std::collections::HashSet;
-
     use mentat_core::attribute::Unique;
     use mentat_core::{
         Attribute,
@@ -117,7 +116,6 @@ mod testing {
         QueryValue,
     };
 
-
     #[test]
     /// Apply two patterns: a pattern and a numeric predicate.
     /// Verify that after application of the predicate we know that the value
@@ -132,8 +130,8 @@ mod testing {
             ..Default::default()
         });
 
-        let x = Variable(PlainSymbol::new("?x"));
-        let y = Variable(PlainSymbol::new("?y"));
+        let x = Variable::from_valid_name("?x");
+        let y = Variable::from_valid_name("?y");
         cc.apply_pattern(&schema, Pattern {
             source: None,
             entity: PatternNonValuePlace::Variable(x.clone()),
@@ -148,7 +146,7 @@ mod testing {
         assert!(cc.apply_numeric_predicate(&schema, comp, Predicate {
              operator: op,
              args: vec![
-                FnArg::Variable(Variable(PlainSymbol::new("?y"))), FnArg::EntidOrInteger(10),
+                FnArg::Variable(Variable::from_valid_name("?y")), FnArg::EntidOrInteger(10),
             ]}).is_ok());
 
         assert!(!cc.is_known_empty);
@@ -192,8 +190,8 @@ mod testing {
             ..Default::default()
         });
 
-        let x = Variable(PlainSymbol::new("?x"));
-        let y = Variable(PlainSymbol::new("?y"));
+        let x = Variable::from_valid_name("?x");
+        let y = Variable::from_valid_name("?y");
         cc.apply_pattern(&schema, Pattern {
             source: None,
             entity: PatternNonValuePlace::Variable(x.clone()),
@@ -208,7 +206,7 @@ mod testing {
         assert!(cc.apply_numeric_predicate(&schema, comp, Predicate {
              operator: op,
              args: vec![
-                FnArg::Variable(Variable(PlainSymbol::new("?y"))), FnArg::EntidOrInteger(10),
+                FnArg::Variable(Variable::from_valid_name("?y")), FnArg::EntidOrInteger(10),
             ]}).is_ok());
 
         assert!(!cc.is_known_empty);

--- a/query-algebrizer/src/clauses/resolve.rs
+++ b/query-algebrizer/src/clauses/resolve.rs
@@ -46,7 +46,7 @@ impl ConjoiningClauses {
                 self.column_bindings
                     .get(&var)
                     .and_then(|cols| cols.first().map(|col| QueryValue::Column(col.clone())))
-                    .ok_or_else(|| Error::from_kind(ErrorKind::UnboundVariable(var)))
+                    .ok_or_else(|| Error::from_kind(ErrorKind::UnboundVariable(var.name())))
             },
             // Can't be an entid.
             EntidOrInteger(i) => Ok(QueryValue::TypedValue(TypedValue::Long(i))),
@@ -73,13 +73,13 @@ impl ConjoiningClauses {
                 self.column_bindings
                     .get(&var)
                     .and_then(|cols| cols.first().map(|col| QueryValue::Column(col.clone())))
-                    .ok_or_else(|| Error::from_kind(ErrorKind::UnboundVariable(var)))
+                    .ok_or_else(|| Error::from_kind(ErrorKind::UnboundVariable(var.name())))
             },
             EntidOrInteger(i) => Ok(QueryValue::PrimitiveLong(i)),
             Ident(_) => unimplemented!(),     // TODO
             Constant(NonIntegerConstant::Boolean(val)) => Ok(QueryValue::TypedValue(TypedValue::Boolean(val))),
             Constant(NonIntegerConstant::Float(f)) => Ok(QueryValue::TypedValue(TypedValue::Double(f))),
-            Constant(NonIntegerConstant::Text(s)) => Ok(QueryValue::TypedValue(TypedValue::String(s.clone()))),
+            Constant(NonIntegerConstant::Text(s)) => Ok(QueryValue::TypedValue(TypedValue::typed_string(s.as_str()))),
             Constant(NonIntegerConstant::BigInteger(_)) => unimplemented!(),
             SrcVar(_) => unimplemented!(),
         }

--- a/query-algebrizer/src/errors.rs
+++ b/query-algebrizer/src/errors.rs
@@ -12,7 +12,6 @@ extern crate mentat_query;
 
 use self::mentat_query::{
     PlainSymbol,
-    Variable,
 };
 
 error_chain! {
@@ -31,9 +30,9 @@ error_chain! {
             display("invalid number of arguments to {}: expected {}, got {}.", name, expected, number)
         }
 
-        UnboundVariable(var: Variable) {
+        UnboundVariable(name: PlainSymbol) {
             description("unbound variable in function call")
-            display("unbound variable: {}", var.0)
+            display("unbound variable: {}", name)
         }
 
         NonNumericArgument(function: PlainSymbol, position: usize) {

--- a/query-algebrizer/src/validate.rs
+++ b/query-algebrizer/src/validate.rs
@@ -87,7 +87,6 @@ mod tests {
         Pattern,
         PatternNonValuePlace,
         PatternValuePlace,
-        PlainSymbol,
         UnifyVars,
         Variable,
         WhereClause,
@@ -134,7 +133,7 @@ mod tests {
                     left,
                     OrWhereClause::Clause(WhereClause::Pattern(Pattern {
                         source: None,
-                        entity: PatternNonValuePlace::Variable(Variable(PlainSymbol::new("?artist"))),
+                        entity: PatternNonValuePlace::Variable(Variable::from_valid_name("?artist")),
                         attribute: PatternNonValuePlace::Ident(NamespacedKeyword::new("artist", "type")),
                         value: PatternValuePlace::IdentOrKeyword(NamespacedKeyword::new("artist.type", "group")),
                         tx: PatternNonValuePlace::Placeholder,
@@ -145,14 +144,14 @@ mod tests {
                         vec![
                             WhereClause::Pattern(Pattern {
                                 source: None,
-                                entity: PatternNonValuePlace::Variable(Variable(PlainSymbol::new("?artist"))),
+                                entity: PatternNonValuePlace::Variable(Variable::from_valid_name("?artist")),
                                 attribute: PatternNonValuePlace::Ident(NamespacedKeyword::new("artist", "type")),
                                 value: PatternValuePlace::IdentOrKeyword(NamespacedKeyword::new("artist.type", "person")),
                                 tx: PatternNonValuePlace::Placeholder,
                             }),
                             WhereClause::Pattern(Pattern {
                                 source: None,
-                                entity: PatternNonValuePlace::Variable(Variable(PlainSymbol::new("?artist"))),
+                                entity: PatternNonValuePlace::Variable(Variable::from_valid_name("?artist")),
                                 attribute: PatternNonValuePlace::Ident(NamespacedKeyword::new("artist", "gender")),
                                 value: PatternValuePlace::IdentOrKeyword(NamespacedKeyword::new("artist.gender", "female")),
                                 tx: PatternNonValuePlace::Placeholder,
@@ -186,7 +185,7 @@ mod tests {
                                    (and [?artist :artist/type ?type]
                                         [?type :artist/role :artist.role/parody]))]"#;
         let parsed = parse_find_string(query).expect("expected successful parse");
-        let clauses = valid_or_join(parsed, UnifyVars::Explicit(vec![Variable(PlainSymbol::new("?artist"))]));
+        let clauses = valid_or_join(parsed, UnifyVars::Explicit(vec![Variable::from_valid_name("?artist")]));
 
         // Let's do some detailed parse checks.
         let mut arms = clauses.into_iter();
@@ -196,7 +195,7 @@ mod tests {
                     left,
                     OrWhereClause::Clause(WhereClause::Pattern(Pattern {
                         source: None,
-                        entity: PatternNonValuePlace::Variable(Variable(PlainSymbol::new("?artist"))),
+                        entity: PatternNonValuePlace::Variable(Variable::from_valid_name("?artist")),
                         attribute: PatternNonValuePlace::Ident(NamespacedKeyword::new("artist", "type")),
                         value: PatternValuePlace::IdentOrKeyword(NamespacedKeyword::new("artist.type", "group")),
                         tx: PatternNonValuePlace::Placeholder,
@@ -207,14 +206,14 @@ mod tests {
                         vec![
                             WhereClause::Pattern(Pattern {
                                 source: None,
-                                entity: PatternNonValuePlace::Variable(Variable(PlainSymbol::new("?artist"))),
+                                entity: PatternNonValuePlace::Variable(Variable::from_valid_name("?artist")),
                                 attribute: PatternNonValuePlace::Ident(NamespacedKeyword::new("artist", "type")),
-                                value: PatternValuePlace::Variable(Variable(PlainSymbol::new("?type"))),
+                                value: PatternValuePlace::Variable(Variable::from_valid_name("?type")),
                                 tx: PatternNonValuePlace::Placeholder,
                             }),
                             WhereClause::Pattern(Pattern {
                                 source: None,
-                                entity: PatternNonValuePlace::Variable(Variable(PlainSymbol::new("?type"))),
+                                entity: PatternNonValuePlace::Variable(Variable::from_valid_name("?type")),
                                 attribute: PatternNonValuePlace::Ident(NamespacedKeyword::new("artist", "role")),
                                 value: PatternValuePlace::IdentOrKeyword(NamespacedKeyword::new("artist.role", "parody")),
                                 tx: PatternNonValuePlace::Placeholder,

--- a/query-parser/src/find.rs
+++ b/query-parser/src/find.rs
@@ -185,6 +185,8 @@ pub fn parse_find(expr: edn::Value) -> QueryParseResult {
 mod test_parse {
     extern crate edn;
 
+    use std::rc::Rc;
+
     use self::edn::{NamespacedKeyword, PlainSymbol};
     use self::edn::types::Value;
     use super::mentat_query::{
@@ -217,8 +219,8 @@ mod test_parse {
         let parsed = parse_find(input).unwrap();
         if let FindSpec::FindRel(elems) = parsed.find_spec {
             assert_eq!(2, elems.len());
-            assert_eq!(vec![Element::Variable(Variable(edn::PlainSymbol::new("?x"))),
-                            Element::Variable(Variable(edn::PlainSymbol::new("?y")))],
+            assert_eq!(vec![Element::Variable(Variable::from_valid_name("?x")),
+                            Element::Variable(Variable::from_valid_name("?y"))],
                        elems);
         } else {
             panic!("Expected FindRel.");
@@ -229,9 +231,9 @@ mod test_parse {
                    vec![
                    WhereClause::Pattern(Pattern {
                        source: None,
-                       entity: PatternNonValuePlace::Variable(Variable(PlainSymbol::new("?x"))),
+                       entity: PatternNonValuePlace::Variable(Variable::from_valid_name("?x")),
                        attribute: PatternNonValuePlace::Ident(NamespacedKeyword::new("foo", "bar")),
-                       value: PatternValuePlace::Variable(Variable(PlainSymbol::new("?y"))),
+                       value: PatternValuePlace::Variable(Variable::from_valid_name("?y")),
                        tx: PatternNonValuePlace::Placeholder,
                    })]);
     }
@@ -244,14 +246,14 @@ mod test_parse {
                    vec![
                       WhereClause::Pattern(Pattern {
                           source: None,
-                          entity: PatternNonValuePlace::Variable(Variable(PlainSymbol::new("?x"))),
+                          entity: PatternNonValuePlace::Variable(Variable::from_valid_name("?x")),
                           attribute: PatternNonValuePlace::Ident(NamespacedKeyword::new("foo", "bar")),
-                          value: PatternValuePlace::Variable(Variable(PlainSymbol::new("?y"))),
+                          value: PatternValuePlace::Variable(Variable::from_valid_name("?y")),
                           tx: PatternNonValuePlace::Placeholder,
                       }),
                       WhereClause::Pred(Predicate {
                           operator: PlainSymbol::new("<"),
-                          args: vec![FnArg::Variable(Variable(PlainSymbol::new("?y"))),
+                          args: vec![FnArg::Variable(Variable::from_valid_name("?y")),
                                      FnArg::EntidOrInteger(10)],
                       }),
                   ]);

--- a/query-parser/tests/find_tests.rs
+++ b/query-parser/tests/find_tests.rs
@@ -45,18 +45,18 @@ fn can_parse_predicates() {
     let p = parse_find_string(s).unwrap();
 
     assert_eq!(p.find_spec,
-               FindSpec::FindColl(Element::Variable(Variable(PlainSymbol::new("?x")))));
+               FindSpec::FindColl(Element::Variable(Variable::from_valid_name("?x"))));
     assert_eq!(p.where_clauses,
                vec![
                    WhereClause::Pattern(Pattern {
                        source: None,
-                       entity: PatternNonValuePlace::Variable(Variable(PlainSymbol::new("?x"))),
+                       entity: PatternNonValuePlace::Variable(Variable::from_valid_name("?x")),
                        attribute: PatternNonValuePlace::Placeholder,
-                       value: PatternValuePlace::Variable(Variable(PlainSymbol::new("?y"))),
+                       value: PatternValuePlace::Variable(Variable::from_valid_name("?y")),
                        tx: PatternNonValuePlace::Placeholder,
                    }),
                    WhereClause::Pred(Predicate { operator: PlainSymbol::new("<"), args: vec![
-                       FnArg::Variable(Variable(PlainSymbol::new("?y"))), FnArg::EntidOrInteger(10),
+                       FnArg::Variable(Variable::from_valid_name("?y")), FnArg::EntidOrInteger(10),
                    ]}),
                ]);
 }
@@ -67,7 +67,7 @@ fn can_parse_simple_or() {
     let p = parse_find_string(s).unwrap();
 
     assert_eq!(p.find_spec,
-               FindSpec::FindScalar(Element::Variable(Variable(PlainSymbol::new("?x")))));
+               FindSpec::FindScalar(Element::Variable(Variable::from_valid_name("?x"))));
     assert_eq!(p.where_clauses,
                vec![
                    WhereClause::OrJoin(OrJoin {
@@ -76,7 +76,7 @@ fn can_parse_simple_or() {
                            OrWhereClause::Clause(
                                WhereClause::Pattern(Pattern {
                                    source: None,
-                                   entity: PatternNonValuePlace::Variable(Variable(PlainSymbol::new("?x"))),
+                                   entity: PatternNonValuePlace::Variable(Variable::from_valid_name("?x")),
                                    attribute: PatternNonValuePlace::Placeholder,
                                    value: PatternValuePlace::EntidOrInteger(10),
                                    tx: PatternNonValuePlace::Placeholder,
@@ -84,7 +84,7 @@ fn can_parse_simple_or() {
                            OrWhereClause::Clause(
                                WhereClause::Pattern(Pattern {
                                    source: None,
-                                   entity: PatternNonValuePlace::Variable(Variable(PlainSymbol::new("?x"))),
+                                   entity: PatternNonValuePlace::Variable(Variable::from_valid_name("?x")),
                                    attribute: PatternNonValuePlace::Placeholder,
                                    value: PatternValuePlace::EntidOrInteger(15),
                                    tx: PatternNonValuePlace::Placeholder,
@@ -100,16 +100,16 @@ fn can_parse_unit_or_join() {
     let p = parse_find_string(s).unwrap();
 
     assert_eq!(p.find_spec,
-               FindSpec::FindScalar(Element::Variable(Variable(PlainSymbol::new("?x")))));
+               FindSpec::FindScalar(Element::Variable(Variable::from_valid_name("?x"))));
     assert_eq!(p.where_clauses,
                vec![
                    WhereClause::OrJoin(OrJoin {
-                       unify_vars: UnifyVars::Explicit(vec![Variable(PlainSymbol::new("?x"))]),
+                       unify_vars: UnifyVars::Explicit(vec![Variable::from_valid_name("?x")]),
                        clauses: vec![
                            OrWhereClause::Clause(
                                WhereClause::Pattern(Pattern {
                                    source: None,
-                                   entity: PatternNonValuePlace::Variable(Variable(PlainSymbol::new("?x"))),
+                                   entity: PatternNonValuePlace::Variable(Variable::from_valid_name("?x")),
                                    attribute: PatternNonValuePlace::Placeholder,
                                    value: PatternValuePlace::EntidOrInteger(15),
                                    tx: PatternNonValuePlace::Placeholder,
@@ -125,16 +125,16 @@ fn can_parse_simple_or_join() {
     let p = parse_find_string(s).unwrap();
 
     assert_eq!(p.find_spec,
-               FindSpec::FindScalar(Element::Variable(Variable(PlainSymbol::new("?x")))));
+               FindSpec::FindScalar(Element::Variable(Variable::from_valid_name("?x"))));
     assert_eq!(p.where_clauses,
                vec![
                    WhereClause::OrJoin(OrJoin {
-                       unify_vars: UnifyVars::Explicit(vec![Variable(PlainSymbol::new("?x"))]),
+                       unify_vars: UnifyVars::Explicit(vec![Variable::from_valid_name("?x")]),
                        clauses: vec![
                            OrWhereClause::Clause(
                                WhereClause::Pattern(Pattern {
                                    source: None,
-                                   entity: PatternNonValuePlace::Variable(Variable(PlainSymbol::new("?x"))),
+                                   entity: PatternNonValuePlace::Variable(Variable::from_valid_name("?x")),
                                    attribute: PatternNonValuePlace::Placeholder,
                                    value: PatternValuePlace::EntidOrInteger(10),
                                    tx: PatternNonValuePlace::Placeholder,
@@ -142,7 +142,7 @@ fn can_parse_simple_or_join() {
                            OrWhereClause::Clause(
                                WhereClause::Pattern(Pattern {
                                    source: None,
-                                   entity: PatternNonValuePlace::Variable(Variable(PlainSymbol::new("?x"))),
+                                   entity: PatternNonValuePlace::Variable(Variable::from_valid_name("?x")),
                                    attribute: PatternNonValuePlace::Placeholder,
                                    value: PatternValuePlace::EntidOrInteger(15),
                                    tx: PatternNonValuePlace::Placeholder,
@@ -158,7 +158,7 @@ fn can_parse_simple_or_and_join() {
     let p = parse_find_string(s).unwrap();
 
     assert_eq!(p.find_spec,
-               FindSpec::FindScalar(Element::Variable(Variable(PlainSymbol::new("?x")))));
+               FindSpec::FindScalar(Element::Variable(Variable::from_valid_name("?x"))));
     assert_eq!(p.where_clauses,
                vec![
                    WhereClause::OrJoin(OrJoin {
@@ -167,7 +167,7 @@ fn can_parse_simple_or_and_join() {
                            OrWhereClause::Clause(
                                WhereClause::Pattern(Pattern {
                                    source: None,
-                                   entity: PatternNonValuePlace::Variable(Variable(PlainSymbol::new("?x"))),
+                                   entity: PatternNonValuePlace::Variable(Variable::from_valid_name("?x")),
                                    attribute: PatternNonValuePlace::Placeholder,
                                    value: PatternValuePlace::EntidOrInteger(10),
                                    tx: PatternNonValuePlace::Placeholder,
@@ -179,23 +179,23 @@ fn can_parse_simple_or_and_join() {
                                        clauses: vec![
                                            OrWhereClause::Clause(WhereClause::Pattern(Pattern {
                                                source: None,
-                                               entity: PatternNonValuePlace::Variable(Variable(PlainSymbol::new("?x"))),
+                                               entity: PatternNonValuePlace::Variable(Variable::from_valid_name("?x")),
                                                attribute: PatternNonValuePlace::Ident(NamespacedKeyword::new("foo", "bar")),
-                                               value: PatternValuePlace::Variable(Variable(PlainSymbol::new("?y"))),
+                                               value: PatternValuePlace::Variable(Variable::from_valid_name("?y")),
                                                tx: PatternNonValuePlace::Placeholder,
                                            })),
                                            OrWhereClause::Clause(WhereClause::Pattern(Pattern {
                                                source: None,
-                                               entity: PatternNonValuePlace::Variable(Variable(PlainSymbol::new("?x"))),
+                                               entity: PatternNonValuePlace::Variable(Variable::from_valid_name("?x")),
                                                attribute: PatternNonValuePlace::Ident(NamespacedKeyword::new("foo", "baz")),
-                                               value: PatternValuePlace::Variable(Variable(PlainSymbol::new("?y"))),
+                                               value: PatternValuePlace::Variable(Variable::from_valid_name("?y")),
                                                tx: PatternNonValuePlace::Placeholder,
                                            })),
                                        ],
                                    }),
 
                                    WhereClause::Pred(Predicate { operator: PlainSymbol::new("<"), args: vec![
-                                       FnArg::Variable(Variable(PlainSymbol::new("?y"))), FnArg::EntidOrInteger(1),
+                                       FnArg::Variable(Variable::from_valid_name("?y")), FnArg::EntidOrInteger(1),
                                    ]}),
                                ],
                            )

--- a/query-projector/src/lib.rs
+++ b/query-projector/src/lib.rs
@@ -20,7 +20,6 @@ extern crate mentat_query_sql;
 extern crate mentat_sql;
 
 use std::iter;
-
 use rusqlite::{
     Row,
     Rows,
@@ -38,7 +37,6 @@ use mentat_db::{
 use mentat_query::{
     Element,
     FindSpec,
-    PlainSymbol,
     Variable,
 };
 
@@ -172,13 +170,11 @@ impl TypedIndex {
 }
 
 fn column_name(var: &Variable) -> Name {
-    let &Variable(PlainSymbol(ref s)) = var;
-    s.clone()
+    var.to_string()
 }
 
 fn value_type_tag_name(var: &Variable) -> Name {
-    let &Variable(PlainSymbol(ref s)) = var;
-    format!("{}_value_type_tag", s)
+    format!("{}_value_type_tag", var.as_str())
 }
 
 /// Walk an iterator of `Element`s, collecting projector templates and columns.

--- a/query-translator/tests/translate.rs
+++ b/query-translator/tests/translate.rs
@@ -15,6 +15,8 @@ extern crate mentat_query_parser;
 extern crate mentat_query_translator;
 extern crate mentat_sql;
 
+use std::rc::Rc;
+
 use mentat_query::NamespacedKeyword;
 
 use mentat_core::{
@@ -59,6 +61,10 @@ fn prepopulated_schema() -> Schema {
     schema
 }
 
+fn make_arg(name: &'static str, value: &'static str) -> (String, Rc<String>) {
+    (name.to_string(), Rc::new(value.to_string()))
+}
+
 #[test]
 fn test_scalar() {
     let schema = prepopulated_schema();
@@ -66,7 +72,7 @@ fn test_scalar() {
     let input = r#"[:find ?x . :where [?x :foo/bar "yyy"]]"#;
     let SQLQuery { sql, args } = translate(&schema, input, None);
     assert_eq!(sql, "SELECT `datoms00`.e AS `?x` FROM `datoms` AS `datoms00` WHERE `datoms00`.a = 99 AND `datoms00`.v = $v0 LIMIT 1");
-    assert_eq!(args, vec![("$v0".to_string(), "yyy".to_string())]);
+    assert_eq!(args, vec![make_arg("$v0", "yyy")]);
 }
 
 #[test]
@@ -76,7 +82,7 @@ fn test_tuple() {
     let input = r#"[:find [?x] :where [?x :foo/bar "yyy"]]"#;
     let SQLQuery { sql, args } = translate(&schema, input, None);
     assert_eq!(sql, "SELECT `datoms00`.e AS `?x` FROM `datoms` AS `datoms00` WHERE `datoms00`.a = 99 AND `datoms00`.v = $v0 LIMIT 1");
-    assert_eq!(args, vec![("$v0".to_string(), "yyy".to_string())]);
+    assert_eq!(args, vec![make_arg("$v0", "yyy")]);
 }
 
 #[test]
@@ -86,7 +92,7 @@ fn test_coll() {
     let input = r#"[:find [?x ...] :where [?x :foo/bar "yyy"]]"#;
     let SQLQuery { sql, args } = translate(&schema, input, None);
     assert_eq!(sql, "SELECT DISTINCT `datoms00`.e AS `?x` FROM `datoms` AS `datoms00` WHERE `datoms00`.a = 99 AND `datoms00`.v = $v0");
-    assert_eq!(args, vec![("$v0".to_string(), "yyy".to_string())]);
+    assert_eq!(args, vec![make_arg("$v0", "yyy")]);
 }
 
 #[test]
@@ -96,7 +102,7 @@ fn test_rel() {
     let input = r#"[:find ?x :where [?x :foo/bar "yyy"]]"#;
     let SQLQuery { sql, args } = translate(&schema, input, None);
     assert_eq!(sql, "SELECT DISTINCT `datoms00`.e AS `?x` FROM `datoms` AS `datoms00` WHERE `datoms00`.a = 99 AND `datoms00`.v = $v0");
-    assert_eq!(args, vec![("$v0".to_string(), "yyy".to_string())]);
+    assert_eq!(args, vec![make_arg("$v0", "yyy")]);
 }
 
 #[test]
@@ -106,7 +112,7 @@ fn test_limit() {
     let input = r#"[:find ?x :where [?x :foo/bar "yyy"]]"#;
     let SQLQuery { sql, args } = translate(&schema, input, 5);
     assert_eq!(sql, "SELECT DISTINCT `datoms00`.e AS `?x` FROM `datoms` AS `datoms00` WHERE `datoms00`.a = 99 AND `datoms00`.v = $v0 LIMIT 5");
-    assert_eq!(args, vec![("$v0".to_string(), "yyy".to_string())]);
+    assert_eq!(args, vec![make_arg("$v0", "yyy")]);
 }
 
 #[test]
@@ -118,7 +124,7 @@ fn test_unknown_attribute_keyword_value() {
 
     // Only match keywords, not strings: tag = 13.
     assert_eq!(sql, "SELECT DISTINCT `datoms00`.e AS `?x` FROM `datoms` AS `datoms00` WHERE `datoms00`.v = $v0 AND `datoms00`.value_type_tag = 13");
-    assert_eq!(args, vec![("$v0".to_string(), ":ab/yyy".to_string())]);
+    assert_eq!(args, vec![make_arg("$v0", ":ab/yyy")]);
 }
 
 #[test]
@@ -131,7 +137,7 @@ fn test_unknown_attribute_string_value() {
     // We expect all_datoms because we're querying for a string. Magic, that.
     // We don't want keywords etc., so tag = 10.
     assert_eq!(sql, "SELECT DISTINCT `all_datoms00`.e AS `?x` FROM `all_datoms` AS `all_datoms00` WHERE `all_datoms00`.v = $v0 AND `all_datoms00`.value_type_tag = 10");
-    assert_eq!(args, vec![("$v0".to_string(), "horses".to_string())]);
+    assert_eq!(args, vec![make_arg("$v0", "horses")]);
 }
 
 #[test]

--- a/src/query.rs
+++ b/src/query.rs
@@ -84,7 +84,7 @@ pub fn q_once<'sqlite, 'schema, 'query, T, U>
     } else {
         let refs: Vec<(&str, &ToSql)> =
             args.iter()
-                .map(|&(ref k, ref v)| (k.as_str(), v as &ToSql))
+                .map(|&(ref k, ref v)| (k.as_str(), v.as_ref() as &ToSql))
                 .collect();
         statement.query_named(refs.as_slice())?
     };

--- a/tests/query.rs
+++ b/tests/query.rs
@@ -92,11 +92,11 @@ fn test_scalar() {
 
     assert_eq!(1, results.len());
 
-    if let QueryResults::Scalar(Some(TypedValue::Keyword(ref kw))) = results {
+    if let QueryResults::Scalar(Some(TypedValue::Keyword(ref rc))) = results {
         // Should be '24'.
-        assert_eq!(&NamespacedKeyword::new("db.type", "keyword"), kw);
+        assert_eq!(&NamespacedKeyword::new("db.type", "keyword"), rc.as_ref());
         assert_eq!(24,
-                   db.schema.get_entid(kw).unwrap());
+                   db.schema.get_entid(rc).unwrap());
     } else {
         panic!("Expected scalar.");
     }


### PR DESCRIPTION
Part 1, core: use Rc for String and Keyword.
Part 2, query: use Rc for Variable.
Part 3, sql: use Rc for args in SQLiteQueryBuilder.
Part 4, query-algebrizer: use Rc.
Part 5, db: use Rc.
Part 6, query-parser: use Rc.
Part 7, query-projector: use Rc.
Part 8, query-translator: use Rc.
Part 9, top level: use Rc.