### PR TITLE
WIP: applying complex 'or'

### DIFF
--- a/core/src/counter.rs
+++ b/core/src/counter.rs
@@ -20,11 +20,24 @@ pub struct RcCounter {
     c: Rc<AtomicUsize>,
 }
 
+/// A simple shared counter.
 impl RcCounter {
     pub fn new() -> Self {
         RcCounter { c: Rc::new(AtomicUsize::new(0)) }
     }
 
+    /// Return the next value in the sequence.
+    ///
+    /// ```
+    /// use mentat_core::counter::RcCounter;
+    ///
+    /// let c = RcCounter::with_initial(3);
+    /// assert_eq!(c.next(), 3);
+    /// assert_eq!(c.next(), 4);
+    /// let d = c.clone();
+    /// assert_eq!(d.next(), 5);
+    /// assert_eq!(c.next(), 6);
+    /// ```
     pub fn next(&self) -> usize {
         self.c.fetch_add(1, Ordering::SeqCst)
     }

--- a/core/src/counter.rs
+++ b/core/src/counter.rs
@@ -22,6 +22,10 @@ pub struct RcCounter {
 
 /// A simple shared counter.
 impl RcCounter {
+    pub fn with_initial(value: usize) -> Self {
+        RcCounter { c: Rc::new(AtomicUsize::new(value)) }
+    }
+
     pub fn new() -> Self {
         RcCounter { c: Rc::new(AtomicUsize::new(0)) }
     }

--- a/query-algebrizer/src/clauses/mod.rs
+++ b/query-algebrizer/src/clauses/mod.rs
@@ -49,6 +49,7 @@ use types::{
     ColumnConstraint,
     ColumnIntersection,
     ComputedTable,
+    Column,
     DatomsColumn,
     DatomsTable,
     EmptyBecause,
@@ -286,35 +287,55 @@ impl ConjoiningClauses {
         }
     }
 
-    pub fn bind_column_to_var(&mut self, schema: &Schema, table: TableAlias, column: DatomsColumn, var: Variable) {
+    pub fn bind_column_to_var<C: Into<Column>>(&mut self, schema: &Schema, table: TableAlias, column: C, var: Variable) {
+        let column = column.into();
         // Do we have an external binding for this?
         if let Some(bound_val) = self.bound_value(&var) {
             // Great! Use that instead.
             // We expect callers to do things like bind keywords here; we need to translate these
             // before they hit our constraints.
-            // TODO: recognize when the valueType might be a ref and also translate entids there.
-            if column == DatomsColumn::Value {
-                self.constrain_column_to_constant(table, column, bound_val);
-            } else {
-                match bound_val {
-                    TypedValue::Keyword(ref kw) => {
-                        if let Some(entid) = self.entid_for_ident(schema, kw) {
+            match column {
+                Column::Variable(_) => {
+                    // We don't need to handle expansion of attributes here. The subquery that
+                    // produces the variable projection will do so.
+                    self.constrain_column_to_constant(table, column, bound_val);
+                },
+
+                Column::Fixed(DatomsColumn::ValueTypeTag) => {
+                    // I'm pretty sure this is meaningless.
+                    unimplemented!();
+                },
+
+                // TODO: recognize when the valueType might be a ref and also translate entids there.
+                Column::Fixed(DatomsColumn::Value) => {
+                    self.constrain_column_to_constant(table, column, bound_val);
+                },
+
+                // These columns can only be entities, so attempt to translate keywords. If we can't
+                // get an entity out of the bound value, the pattern cannot produce results.
+                Column::Fixed(DatomsColumn::Attribute) |
+                Column::Fixed(DatomsColumn::Entity) |
+                Column::Fixed(DatomsColumn::Tx) => {
+                    match bound_val {
+                        TypedValue::Keyword(ref kw) => {
+                            if let Some(entid) = self.entid_for_ident(schema, kw) {
+                                self.constrain_column_to_entity(table, column, entid);
+                            } else {
+                                // Impossible.
+                                // For attributes this shouldn't occur, because we check the binding in
+                                // `table_for_places`/`alias_table`, and if it didn't resolve to a valid
+                                // attribute then we should have already marked the pattern as empty.
+                                self.mark_known_empty(EmptyBecause::UnresolvedIdent(kw.cloned()));
+                            }
+                        },
+                        TypedValue::Ref(entid) => {
                             self.constrain_column_to_entity(table, column, entid);
-                        } else {
-                            // Impossible.
-                            // For attributes this shouldn't occur, because we check the binding in
-                            // `table_for_places`/`alias_table`, and if it didn't resolve to a valid
-                            // attribute then we should have already marked the pattern as empty.
-                            self.mark_known_empty(EmptyBecause::UnresolvedIdent(kw.cloned()));
-                        }
-                    },
-                    TypedValue::Ref(entid) => {
-                        self.constrain_column_to_entity(table, column, entid);
-                    },
-                    _ => {
-                        // One can't bind an e, a, or tx to something other than an entity.
-                        self.mark_known_empty(EmptyBecause::InvalidBinding(column, bound_val));
-                    },
+                        },
+                        _ => {
+                            // One can't bind an e, a, or tx to something other than an entity.
+                            self.mark_known_empty(EmptyBecause::InvalidBinding(column, bound_val));
+                        },
+                    }
                 }
             }
 
@@ -328,10 +349,13 @@ impl ConjoiningClauses {
         // If this is a value, and we don't already know its type or where
         // to get its type, record that we can get it from this table.
         let needs_type_extraction =
-            !late_binding &&                           // Never need to extract for bound vars.
-            column == DatomsColumn::Value &&           // Never need to extract types for refs.
-            self.known_type(&var).is_none() &&         // Don't need to extract if we know a single type.
-            !self.extracted_types.contains_key(&var);  // We're already extracting the type.
+            !late_binding &&                                // Never need to extract for bound vars.
+
+            // Never need to extract types for refs, and var columns are handled elsewhere:
+            // a subquery will be projecting a type tag.
+            column == Column::Fixed(DatomsColumn::Value) &&
+            self.known_type(&var).is_none() &&              // Don't need to extract if we know a single type.
+            !self.extracted_types.contains_key(&var);       // We're already extracting the type.
 
         let alias = QualifiedAlias(table, column);
 
@@ -343,11 +367,13 @@ impl ConjoiningClauses {
         self.column_bindings.entry(var).or_insert(vec![]).push(alias);
     }
 
-    pub fn constrain_column_to_constant(&mut self, table: TableAlias, column: DatomsColumn, constant: TypedValue) {
+    pub fn constrain_column_to_constant<C: Into<Column>>(&mut self, table: TableAlias, column: C, constant: TypedValue) {
+        let column = column.into();
         self.wheres.add_intersection(ColumnConstraint::Equals(QualifiedAlias(table, column), QueryValue::TypedValue(constant)))
     }
 
-    pub fn constrain_column_to_entity(&mut self, table: TableAlias, column: DatomsColumn, entity: Entid) {
+    pub fn constrain_column_to_entity<C: Into<Column>>(&mut self, table: TableAlias, column: C, entity: Entid) {
+        let column = column.into();
         self.wheres.add_intersection(ColumnConstraint::Equals(QualifiedAlias(table, column), QueryValue::Entid(entity)))
     }
 
@@ -357,7 +383,7 @@ impl ConjoiningClauses {
 
     pub fn constrain_value_to_numeric(&mut self, table: TableAlias, value: i64) {
         self.wheres.add_intersection(ColumnConstraint::Equals(
-            QualifiedAlias(table, DatomsColumn::Value),
+            QualifiedAlias(table, Column::Fixed(DatomsColumn::Value)),
             QueryValue::PrimitiveLong(value)))
     }
 
@@ -586,7 +612,7 @@ impl ConjoiningClauses {
                     Some(v) => {
                         // This pattern cannot match: the caller has bound a non-entity value to an
                         // attribute place.
-                        Err(EmptyBecause::InvalidBinding(DatomsColumn::Attribute, v.clone()))
+                        Err(EmptyBecause::InvalidBinding(Column::Fixed(DatomsColumn::Attribute), v.clone()))
                     },
                 }
             },

--- a/query-algebrizer/src/clauses/mod.rs
+++ b/query-algebrizer/src/clauses/mod.rs
@@ -171,7 +171,7 @@ pub struct ConjoiningClauses {
 
     /// A mapping, similar to `column_bindings`, but used to pull type tags out of the store at runtime.
     /// If a var isn't present in `known_types`, it should be present here.
-    extracted_types: BTreeMap<Variable, QualifiedAlias>,
+    pub extracted_types: BTreeMap<Variable, QualifiedAlias>,
 }
 
 impl Debug for ConjoiningClauses {

--- a/query-algebrizer/src/clauses/mod.rs
+++ b/query-algebrizer/src/clauses/mod.rs
@@ -206,6 +206,18 @@ impl Default for ConjoiningClauses {
     }
 }
 
+impl ConjoiningClauses {
+    /// Construct a new `ConjoiningClauses` with the provided alias counter. This allows a caller
+    /// to share a counter with an enclosing scope, and to start counting at a particular offset
+    /// for testing.
+    pub fn with_alias_counter(counter: RcCounter) -> ConjoiningClauses {
+        ConjoiningClauses {
+            alias_counter: counter,
+            ..Default::default()
+        }
+    }
+}
+
 /// Cloning.
 impl ConjoiningClauses {
     fn make_receptacle(&self) -> ConjoiningClauses {

--- a/query-algebrizer/src/clauses/mod.rs
+++ b/query-algebrizer/src/clauses/mod.rs
@@ -212,6 +212,7 @@ impl ConjoiningClauses {
         let mut concrete = ConjoiningClauses::default();
         concrete.empty_because = self.empty_because.clone();
 
+        concrete.alias_counter = self.alias_counter.clone();
         concrete.input_variables = self.input_variables.clone();
         concrete.value_bindings = self.value_bindings.clone();
         concrete.known_types = self.known_types.clone();

--- a/query-algebrizer/src/clauses/mod.rs
+++ b/query-algebrizer/src/clauses/mod.rs
@@ -221,31 +221,29 @@ impl ConjoiningClauses {
 /// Cloning.
 impl ConjoiningClauses {
     fn make_receptacle(&self) -> ConjoiningClauses {
-        let mut concrete = ConjoiningClauses::default();
-        concrete.empty_because = self.empty_because.clone();
-
-        concrete.alias_counter = self.alias_counter.clone();
-        concrete.input_variables = self.input_variables.clone();
-        concrete.value_bindings = self.value_bindings.clone();
-        concrete.known_types = self.known_types.clone();
-        concrete.extracted_types = self.extracted_types.clone();
-
-        concrete
+        ConjoiningClauses {
+            alias_counter: self.alias_counter.clone(),
+            empty_because: self.empty_because.clone(),
+            input_variables: self.input_variables.clone(),
+            value_bindings: self.value_bindings.clone(),
+            known_types: self.known_types.clone(),
+            extracted_types: self.extracted_types.clone(),
+            ..Default::default()
+        }
     }
 
     /// Make a new CC populated with the relevant variable associations in this CC.
     /// The CC shares an alias count with all of its copies.
     fn use_as_template(&self, vars: &BTreeSet<Variable>) -> ConjoiningClauses {
-        let mut template = ConjoiningClauses::default();
-        template.alias_counter = self.alias_counter.clone();     // Rc ftw.
-        template.empty_because = self.empty_because.clone();
-
-        template.input_variables = self.input_variables.intersection(vars).cloned().collect();
-        template.value_bindings = self.value_bindings.with_intersected_keys(&vars);
-        template.known_types = self.known_types.with_intersected_keys(&vars);
-        template.extracted_types = self.extracted_types.with_intersected_keys(&vars);
-
-        template
+        ConjoiningClauses {
+            alias_counter: self.alias_counter.clone(),
+            empty_because: self.empty_because.clone(),
+            input_variables: self.input_variables.intersection(vars).cloned().collect(),
+            value_bindings: self.value_bindings.with_intersected_keys(&vars),
+            known_types: self.known_types.with_intersected_keys(&vars),
+            extracted_types: self.extracted_types.with_intersected_keys(&vars),
+            ..Default::default()
+        }
     }
 }
 

--- a/query-algebrizer/src/clauses/or.rs
+++ b/query-algebrizer/src/clauses/or.rs
@@ -772,9 +772,9 @@ mod testing {
         let cc = alg(&schema, query);
         let vx = Variable::from_valid_name("?x");
         let d0 = "datoms00".to_string();
-        let d0e = QualifiedAlias(d0.clone(), DatomsColumn::Entity);
-        let d0a = QualifiedAlias(d0.clone(), DatomsColumn::Attribute);
-        let d0v = QualifiedAlias(d0.clone(), DatomsColumn::Value);
+        let d0e = QualifiedAlias::new(d0.clone(), DatomsColumn::Entity);
+        let d0a = QualifiedAlias::new(d0.clone(), DatomsColumn::Attribute);
+        let d0v = QualifiedAlias::new(d0.clone(), DatomsColumn::Value);
         let knows = QueryValue::Entid(66);
         let parent = QueryValue::Entid(67);
         let john = QueryValue::TypedValue(TypedValue::typed_string("John"));
@@ -814,11 +814,11 @@ mod testing {
         let vx = Variable::from_valid_name("?x");
         let d0 = "datoms00".to_string();
         let d1 = "datoms01".to_string();
-        let d0e = QualifiedAlias(d0.clone(), DatomsColumn::Entity);
-        let d0a = QualifiedAlias(d0.clone(), DatomsColumn::Attribute);
-        let d1e = QualifiedAlias(d1.clone(), DatomsColumn::Entity);
-        let d1a = QualifiedAlias(d1.clone(), DatomsColumn::Attribute);
-        let d1v = QualifiedAlias(d1.clone(), DatomsColumn::Value);
+        let d0e = QualifiedAlias::new(d0.clone(), DatomsColumn::Entity);
+        let d0a = QualifiedAlias::new(d0.clone(), DatomsColumn::Attribute);
+        let d1e = QualifiedAlias::new(d1.clone(), DatomsColumn::Entity);
+        let d1a = QualifiedAlias::new(d1.clone(), DatomsColumn::Attribute);
+        let d1v = QualifiedAlias::new(d1.clone(), DatomsColumn::Value);
         let name = QueryValue::Entid(65);
         let knows = QueryValue::Entid(66);
         let parent = QueryValue::Entid(67);
@@ -864,12 +864,12 @@ mod testing {
         let vx = Variable::from_valid_name("?x");
         let d0 = "datoms00".to_string();
         let d1 = "datoms01".to_string();
-        let d0e = QualifiedAlias(d0.clone(), DatomsColumn::Entity);
-        let d0a = QualifiedAlias(d0.clone(), DatomsColumn::Attribute);
-        let d0v = QualifiedAlias(d0.clone(), DatomsColumn::Value);
-        let d1e = QualifiedAlias(d1.clone(), DatomsColumn::Entity);
-        let d1a = QualifiedAlias(d1.clone(), DatomsColumn::Attribute);
-        let d1v = QualifiedAlias(d1.clone(), DatomsColumn::Value);
+        let d0e = QualifiedAlias::new(d0.clone(), DatomsColumn::Entity);
+        let d0a = QualifiedAlias::new(d0.clone(), DatomsColumn::Attribute);
+        let d0v = QualifiedAlias::new(d0.clone(), DatomsColumn::Value);
+        let d1e = QualifiedAlias::new(d1.clone(), DatomsColumn::Entity);
+        let d1a = QualifiedAlias::new(d1.clone(), DatomsColumn::Attribute);
+        let d1v = QualifiedAlias::new(d1.clone(), DatomsColumn::Value);
         let knows = QueryValue::Entid(66);
         let age = QueryValue::Entid(68);
         let john = QueryValue::TypedValue(TypedValue::typed_string("John"));
@@ -903,8 +903,9 @@ mod testing {
     // These two are not equivalent:
     // [:find ?x :where [?x :foo/bar ?y] (or-join [?x] [?x :foo/baz ?y])]
     // [:find ?x :where [?x :foo/bar ?y] [?x :foo/baz ?y]]
+    // TODO: fixme
+    /*
     #[test]
-    #[should_panic(expected = "not yet implemented")]
     fn test_unit_or_join_doesnt_flatten() {
         let schema = prepopulated_schema();
         let query = r#"[:find ?x
@@ -915,21 +916,20 @@ mod testing {
         let vy = Variable::from_valid_name("?y");
         let d0 = "datoms00".to_string();
         let d1 = "datoms01".to_string();
-        let d0e = QualifiedAlias(d0.clone(), DatomsColumn::Entity);
-        let d0a = QualifiedAlias(d0.clone(), DatomsColumn::Attribute);
-        let d0v = QualifiedAlias(d0.clone(), DatomsColumn::Value);
-        let d1e = QualifiedAlias(d1.clone(), DatomsColumn::Entity);
-        let d1a = QualifiedAlias(d1.clone(), DatomsColumn::Attribute);
+        let d0e = QualifiedAlias::new(d0.clone(), DatomsColumn::Entity);
+        let d0a = QualifiedAlias::new(d0.clone(), DatomsColumn::Attribute);
+        let d0v = QualifiedAlias::new(d0.clone(), DatomsColumn::Value);
+        let d1e = QualifiedAlias::new(d1.clone(), DatomsColumn::Entity);
+        let d1a = QualifiedAlias::new(d1.clone(), DatomsColumn::Attribute);
         let knows = QueryValue::Entid(66);
         let parent = QueryValue::Entid(67);
 
         assert!(!cc.is_known_empty());
         assert_eq!(cc.wheres, ColumnIntersection(vec![
             ColumnConstraintOrAlternation::Constraint(ColumnConstraint::Equals(d0a.clone(), knows.clone())),
-            ColumnConstraintOrAlternation::Constraint(ColumnConstraint::Equals(d1a.clone(), parent.clone())),
             // The outer pattern joins against the `or` on the entity, but not value -- ?y means
             // different things in each place.
-            ColumnConstraintOrAlternation::Constraint(ColumnConstraint::Equals(d0e.clone(), QueryValue::Column(d1e.clone()))),
+            ColumnConstraintOrAlternation::Constraint(ColumnConstraint::Equals(d0e.clone(), QueryValue::Column(QualifiedAlias::new("c00".to_string(), VariableColumn::Variable(vx.clone()))))),
         ]));
         assert_eq!(cc.column_bindings.get(&vx), Some(&vec![d0e, d1e]));
 
@@ -938,6 +938,7 @@ mod testing {
         assert_eq!(cc.from, vec![SourceAlias(DatomsTable::Datoms, d0),
                                  SourceAlias(DatomsTable::Datoms, d1)]);
     }
+    */
 
     // These two are equivalent:
     // [:find ?x :where [?x :foo/bar ?y] (or [?x :foo/baz ?y])]
@@ -977,8 +978,8 @@ mod testing {
     /// Strictly speaking this can be implemented with a `NOT EXISTS` clause for the second pattern,
     /// but that would be a fair amount of analysis work, I think.
     #[test]
-    #[should_panic(expected = "not yet implemented")]
     #[allow(dead_code, unused_variables)]
+    // TODO: flesh this out.
     fn test_alternation_with_and() {
         let schema = prepopulated_schema();
         let query = r#"

--- a/query-algebrizer/src/clauses/or.rs
+++ b/query-algebrizer/src/clauses/or.rs
@@ -686,11 +686,21 @@ mod testing {
         SourceAlias,
     };
 
-    use algebrize;
+    use {
+        algebrize,
+        algebrize_with_counter,
+    };
 
     fn alg(schema: &Schema, input: &str) -> ConjoiningClauses {
         let parsed = parse_find_string(input).expect("parse failed");
         algebrize(schema.into(), parsed).expect("algebrize failed").cc
+    }
+
+    /// Algebrize with a starting counter, so we can compare inner queries by algebrizing a
+    /// simpler version.
+    fn alg_c(schema: &Schema, counter: usize, input: &str) -> ConjoiningClauses {
+        let parsed = parse_find_string(input).expect("parse failed");
+        algebrize_with_counter(schema.into(), parsed, counter).expect("algebrize failed").cc
     }
 
     fn compare_ccs(left: ConjoiningClauses, right: ConjoiningClauses) {
@@ -903,8 +913,6 @@ mod testing {
     // These two are not equivalent:
     // [:find ?x :where [?x :foo/bar ?y] (or-join [?x] [?x :foo/baz ?y])]
     // [:find ?x :where [?x :foo/bar ?y] [?x :foo/baz ?y]]
-    // TODO: fixme
-    /*
     #[test]
     fn test_unit_or_join_doesnt_flatten() {
         let schema = prepopulated_schema();
@@ -915,30 +923,27 @@ mod testing {
         let vx = Variable::from_valid_name("?x");
         let vy = Variable::from_valid_name("?y");
         let d0 = "datoms00".to_string();
-        let d1 = "datoms01".to_string();
+        let c0 = "c00".to_string();
+        let c0x = QualifiedAlias::new(c0.clone(), VariableColumn::Variable(vx.clone()));
         let d0e = QualifiedAlias::new(d0.clone(), DatomsColumn::Entity);
         let d0a = QualifiedAlias::new(d0.clone(), DatomsColumn::Attribute);
         let d0v = QualifiedAlias::new(d0.clone(), DatomsColumn::Value);
-        let d1e = QualifiedAlias::new(d1.clone(), DatomsColumn::Entity);
-        let d1a = QualifiedAlias::new(d1.clone(), DatomsColumn::Attribute);
         let knows = QueryValue::Entid(66);
-        let parent = QueryValue::Entid(67);
 
         assert!(!cc.is_known_empty());
         assert_eq!(cc.wheres, ColumnIntersection(vec![
             ColumnConstraintOrAlternation::Constraint(ColumnConstraint::Equals(d0a.clone(), knows.clone())),
             // The outer pattern joins against the `or` on the entity, but not value -- ?y means
             // different things in each place.
-            ColumnConstraintOrAlternation::Constraint(ColumnConstraint::Equals(d0e.clone(), QueryValue::Column(QualifiedAlias::new("c00".to_string(), VariableColumn::Variable(vx.clone()))))),
+            ColumnConstraintOrAlternation::Constraint(ColumnConstraint::Equals(d0e.clone(), QueryValue::Column(c0x.clone()))),
         ]));
-        assert_eq!(cc.column_bindings.get(&vx), Some(&vec![d0e, d1e]));
+        assert_eq!(cc.column_bindings.get(&vx), Some(&vec![d0e, c0x]));
 
         // ?y does not have a binding in the `or-join` pattern.
         assert_eq!(cc.column_bindings.get(&vy), Some(&vec![d0v]));
         assert_eq!(cc.from, vec![SourceAlias(DatomsTable::Datoms, d0),
-                                 SourceAlias(DatomsTable::Datoms, d1)]);
+                                 SourceAlias(DatomsTable::Computed(0), c0)]);
     }
-    */
 
     // These two are equivalent:
     // [:find ?x :where [?x :foo/bar ?y] (or [?x :foo/baz ?y])]
@@ -978,8 +983,6 @@ mod testing {
     /// Strictly speaking this can be implemented with a `NOT EXISTS` clause for the second pattern,
     /// but that would be a fair amount of analysis work, I think.
     #[test]
-    #[allow(dead_code, unused_variables)]
-    // TODO: flesh this out.
     fn test_alternation_with_and() {
         let schema = prepopulated_schema();
         let query = r#"
@@ -988,6 +991,34 @@ mod testing {
                              [?x :foo/parent "Ámbar"])
                         [?x :foo/knows "Daphne"])]"#;
         let cc = alg(&schema, query);
+        let mut tables = cc.computed_tables.into_iter();
+        match (tables.next(), tables.next()) {
+            (Some(ComputedTable::Union { projection, type_extraction, arms }), None) => {
+                assert_eq!(projection, vec![Variable::from_valid_name("?x")].into_iter().collect());
+                assert!(type_extraction.is_empty());
+
+                let mut arms = arms.into_iter();
+                match (arms.next(), arms.next(), arms.next()) {
+                    (Some(and), Some(pattern), None) => {
+                        let expected_and = alg_c(&schema,
+                                                 0,  // The first pattern to be processed.
+                                                 r#"[:find ?x :where [?x :foo/knows "John"] [?x :foo/parent "Ámbar"]]"#);
+                        compare_ccs(and, expected_and);
+
+                        let expected_pattern = alg_c(&schema,
+                                                     2,      // Two aliases taken by the other arm.
+                                                     r#"[:find ?x :where [?x :foo/knows "Daphne"]]"#);
+                        compare_ccs(pattern, expected_pattern);
+                    },
+                    _ => {
+                        panic!("Expected two arms");
+                    }
+                }
+            },
+            _ => {
+                panic!("Didn't get two inner tables.");
+            },
+        }
     }
 
     #[test]

--- a/query-algebrizer/src/clauses/pattern.rs
+++ b/query-algebrizer/src/clauses/pattern.rs
@@ -295,6 +295,7 @@ mod testing {
     };
 
     use types::{
+        Column,
         ColumnConstraint,
         DatomsTable,
         QualifiedAlias,
@@ -365,9 +366,9 @@ mod testing {
 
         // println!("{:#?}", cc);
 
-        let d0_e = QualifiedAlias("datoms00".to_string(), DatomsColumn::Entity);
-        let d0_a = QualifiedAlias("datoms00".to_string(), DatomsColumn::Attribute);
-        let d0_v = QualifiedAlias("datoms00".to_string(), DatomsColumn::Value);
+        let d0_e = QualifiedAlias::new("datoms00".to_string(), DatomsColumn::Entity);
+        let d0_a = QualifiedAlias::new("datoms00".to_string(), DatomsColumn::Attribute);
+        let d0_v = QualifiedAlias::new("datoms00".to_string(), DatomsColumn::Value);
 
         // After this, we know a lot of things:
         assert!(!cc.is_known_empty());
@@ -405,8 +406,8 @@ mod testing {
 
         // println!("{:#?}", cc);
 
-        let d0_e = QualifiedAlias("datoms00".to_string(), DatomsColumn::Entity);
-        let d0_v = QualifiedAlias("datoms00".to_string(), DatomsColumn::Value);
+        let d0_e = QualifiedAlias::new("datoms00".to_string(), DatomsColumn::Entity);
+        let d0_v = QualifiedAlias::new("datoms00".to_string(), DatomsColumn::Value);
 
         assert!(!cc.is_known_empty());
         assert_eq!(cc.from, vec![SourceAlias(DatomsTable::Datoms, "datoms00".to_string())]);
@@ -454,8 +455,8 @@ mod testing {
 
         // println!("{:#?}", cc);
 
-        let d0_e = QualifiedAlias("datoms00".to_string(), DatomsColumn::Entity);
-        let d0_a = QualifiedAlias("datoms00".to_string(), DatomsColumn::Attribute);
+        let d0_e = QualifiedAlias::new("datoms00".to_string(), DatomsColumn::Entity);
+        let d0_a = QualifiedAlias::new("datoms00".to_string(), DatomsColumn::Attribute);
 
         assert!(!cc.is_known_empty());
         assert_eq!(cc.from, vec![SourceAlias(DatomsTable::Datoms, "datoms00".to_string())]);
@@ -496,7 +497,7 @@ mod testing {
         });
 
         assert!(cc.is_known_empty());
-        assert_eq!(cc.empty_because.unwrap(), EmptyBecause::InvalidBinding(DatomsColumn::Attribute, hello));
+        assert_eq!(cc.empty_because.unwrap(), EmptyBecause::InvalidBinding(Column::Fixed(DatomsColumn::Attribute), hello));
     }
 
 
@@ -519,7 +520,7 @@ mod testing {
 
         // println!("{:#?}", cc);
 
-        let d0_e = QualifiedAlias("all_datoms00".to_string(), DatomsColumn::Entity);
+        let d0_e = QualifiedAlias::new("all_datoms00".to_string(), DatomsColumn::Entity);
 
         assert!(!cc.is_known_empty());
         assert_eq!(cc.from, vec![SourceAlias(DatomsTable::AllDatoms, "all_datoms00".to_string())]);
@@ -549,8 +550,8 @@ mod testing {
 
         // println!("{:#?}", cc);
 
-        let d0_e = QualifiedAlias("all_datoms00".to_string(), DatomsColumn::Entity);
-        let d0_v = QualifiedAlias("all_datoms00".to_string(), DatomsColumn::Value);
+        let d0_e = QualifiedAlias::new("all_datoms00".to_string(), DatomsColumn::Entity);
+        let d0_v = QualifiedAlias::new("all_datoms00".to_string(), DatomsColumn::Value);
 
         assert!(!cc.is_known_empty());
         assert_eq!(cc.from, vec![SourceAlias(DatomsTable::AllDatoms, "all_datoms00".to_string())]);
@@ -609,11 +610,11 @@ mod testing {
 
         println!("{:#?}", cc);
 
-        let d0_e = QualifiedAlias("datoms00".to_string(), DatomsColumn::Entity);
-        let d0_a = QualifiedAlias("datoms00".to_string(), DatomsColumn::Attribute);
-        let d0_v = QualifiedAlias("datoms00".to_string(), DatomsColumn::Value);
-        let d1_e = QualifiedAlias("datoms01".to_string(), DatomsColumn::Entity);
-        let d1_a = QualifiedAlias("datoms01".to_string(), DatomsColumn::Attribute);
+        let d0_e = QualifiedAlias::new("datoms00".to_string(), DatomsColumn::Entity);
+        let d0_a = QualifiedAlias::new("datoms00".to_string(), DatomsColumn::Attribute);
+        let d0_v = QualifiedAlias::new("datoms00".to_string(), DatomsColumn::Value);
+        let d1_e = QualifiedAlias::new("datoms01".to_string(), DatomsColumn::Entity);
+        let d1_a = QualifiedAlias::new("datoms01".to_string(), DatomsColumn::Attribute);
 
         assert!(!cc.is_known_empty());
         assert_eq!(cc.from, vec![
@@ -669,9 +670,9 @@ mod testing {
             tx: PatternNonValuePlace::Placeholder,
         });
 
-        let d0_e = QualifiedAlias("datoms00".to_string(), DatomsColumn::Entity);
-        let d0_a = QualifiedAlias("datoms00".to_string(), DatomsColumn::Attribute);
-        let d0_v = QualifiedAlias("datoms00".to_string(), DatomsColumn::Value);
+        let d0_e = QualifiedAlias::new("datoms00".to_string(), DatomsColumn::Entity);
+        let d0_a = QualifiedAlias::new("datoms00".to_string(), DatomsColumn::Attribute);
+        let d0_v = QualifiedAlias::new("datoms00".to_string(), DatomsColumn::Value);
 
         // ?y has been expanded into `true`.
         assert_eq!(cc.wheres, vec![

--- a/query-algebrizer/src/lib.rs
+++ b/query-algebrizer/src/lib.rs
@@ -106,10 +106,12 @@ pub use clauses::{
 };
 
 pub use types::{
+    Column,
     ColumnAlternation,
     ColumnConstraint,
     ColumnConstraintOrAlternation,
     ColumnIntersection,
+    ColumnName,
     ComputedTable,
     DatomsColumn,
     DatomsTable,
@@ -117,5 +119,6 @@ pub use types::{
     QueryValue,
     SourceAlias,
     TableAlias,
+    VariableColumn,
 };
 

--- a/query-algebrizer/src/lib.rs
+++ b/query-algebrizer/src/lib.rs
@@ -110,6 +110,7 @@ pub use types::{
     ColumnConstraint,
     ColumnConstraintOrAlternation,
     ColumnIntersection,
+    ComputedTable,
     DatomsColumn,
     DatomsTable,
     QualifiedAlias,

--- a/query-algebrizer/src/lib.rs
+++ b/query-algebrizer/src/lib.rs
@@ -19,10 +19,11 @@ mod types;
 mod validate;
 mod clauses;
 
-
 use mentat_core::{
     Schema,
 };
+
+use mentat_core::counter::RcCounter;
 
 use mentat_query::{
     FindQuery,
@@ -69,11 +70,20 @@ impl AlgebraicQuery {
     }
 }
 
-#[allow(dead_code)]
+pub fn algebrize_with_counter(schema: &Schema, parsed: FindQuery, counter: usize) -> Result<AlgebraicQuery> {
+    let alias_counter = RcCounter::with_initial(counter);
+    let cc = clauses::ConjoiningClauses::with_alias_counter(alias_counter);
+    algebrize_with_cc(schema, parsed, cc)
+}
+
 pub fn algebrize(schema: &Schema, parsed: FindQuery) -> Result<AlgebraicQuery> {
+    algebrize_with_cc(schema, parsed, clauses::ConjoiningClauses::default())
+}
+
+#[allow(dead_code)]
+pub fn algebrize_with_cc(schema: &Schema, parsed: FindQuery, mut cc: ConjoiningClauses) -> Result<AlgebraicQuery> {
     // TODO: integrate default source into pattern processing.
     // TODO: flesh out the rest of find-into-context.
-    let mut cc = clauses::ConjoiningClauses::default();
     let where_clauses = parsed.where_clauses;
     for where_clause in where_clauses {
         cc.apply_clause(schema, where_clause)?;

--- a/query-algebrizer/src/types.rs
+++ b/query-algebrizer/src/types.rs
@@ -8,6 +8,7 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
+use std::collections::BTreeSet;
 use std::collections::HashSet;
 
 use std::fmt::{
@@ -28,13 +29,24 @@ use mentat_query::{
 };
 
 /// This enum models the fixed set of default tables we have -- two
-/// tables and two views.
+/// tables and two views -- and computed tables defined in the enclosing CC.
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
 pub enum DatomsTable {
     Datoms,             // The non-fulltext datoms table.
     FulltextValues,     // The virtual table mapping IDs to strings.
     FulltextDatoms,     // The fulltext-datoms view.
     AllDatoms,          // Fulltext and non-fulltext datoms.
+    Computed(usize),    // A computed table, tracked elsewhere in the query.
+}
+
+/// A source of rows that isn't a named table -- typically a subquery or union.
+pub enum ComputedTable {
+    // Subquery(BTreeSet<Variable>, ::clauses::ConjoiningClauses),
+    Union {
+        projection: BTreeSet<Variable>,
+        type_extraction: BTreeSet<Variable>,
+        arms: Vec<::clauses::ConjoiningClauses>,
+    },
 }
 
 impl DatomsTable {
@@ -44,6 +56,7 @@ impl DatomsTable {
             DatomsTable::FulltextValues => "fulltext_values",
             DatomsTable::FulltextDatoms => "fulltext_datoms",
             DatomsTable::AllDatoms => "all_datoms",
+            DatomsTable::Computed(_) => "c",
         }
     }
 }

--- a/query-projector/src/lib.rs
+++ b/query-projector/src/lib.rs
@@ -228,7 +228,7 @@ fn project_elements<'a, I: IntoIterator<Item = &'a Element>>(
 
                     // Also project the type from the SQL query.
                     let type_name = value_type_tag_name(var);
-                    let type_qa = QualifiedAlias(table, DatomsColumn::ValueTypeTag);
+                    let type_qa = QualifiedAlias::new(table, DatomsColumn::ValueTypeTag);
                     cols.push(ProjectedColumn(ColumnOrExpression::Column(type_qa), type_name));
                 }
             }

--- a/query-sql/src/lib.rs
+++ b/query-sql/src/lib.rs
@@ -430,7 +430,10 @@ impl SelectQuery {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mentat_query_algebrizer::DatomsTable;
+    use mentat_query_algebrizer::{
+        DatomsColumn,
+        DatomsTable,
+    };
 
     fn build_constraint(c: Constraint) -> String {
         let mut builder = SQLiteQueryBuilder::new();
@@ -442,19 +445,19 @@ mod tests {
     #[test]
     fn test_in_constraint() {
         let none = Constraint::In {
-            left: ColumnOrExpression::Column(QualifiedAlias("datoms01".to_string(), DatomsColumn::Value)),
+            left: ColumnOrExpression::Column(QualifiedAlias::new("datoms01".to_string(), DatomsColumn::Value)),
             list: vec![],
         };
 
         let one = Constraint::In {
-            left: ColumnOrExpression::Column(QualifiedAlias("datoms01".to_string(), DatomsColumn::Value)),
+            left: ColumnOrExpression::Column(QualifiedAlias::new("datoms01".to_string(), DatomsColumn::Value)),
             list: vec![
                 ColumnOrExpression::Entid(123),
             ],
         };
 
         let three = Constraint::In {
-            left: ColumnOrExpression::Column(QualifiedAlias("datoms01".to_string(), DatomsColumn::Value)),
+            left: ColumnOrExpression::Column(QualifiedAlias::new("datoms01".to_string(), DatomsColumn::Value)),
             list: vec![
                 ColumnOrExpression::Entid(123),
                 ColumnOrExpression::Entid(456),
@@ -509,24 +512,24 @@ mod tests {
             projection: Projection::Columns(
                             vec![
                                 ProjectedColumn(
-                                    ColumnOrExpression::Column(QualifiedAlias(datoms00.clone(), DatomsColumn::Entity)),
+                                    ColumnOrExpression::Column(QualifiedAlias::new(datoms00.clone(), DatomsColumn::Entity)),
                                     "x".to_string()),
                             ]),
             from: FromClause::TableList(TableList(source_aliases)),
             constraints: vec![
                 Constraint::Infix {
                     op: eq.clone(),
-                    left: ColumnOrExpression::Column(QualifiedAlias(datoms01.clone(), DatomsColumn::Value)),
-                    right: ColumnOrExpression::Column(QualifiedAlias(datoms00.clone(), DatomsColumn::Value)),
+                    left: ColumnOrExpression::Column(QualifiedAlias::new(datoms01.clone(), DatomsColumn::Value)),
+                    right: ColumnOrExpression::Column(QualifiedAlias::new(datoms00.clone(), DatomsColumn::Value)),
                 },
                 Constraint::Infix {
                     op: eq.clone(),
-                    left: ColumnOrExpression::Column(QualifiedAlias(datoms00.clone(), DatomsColumn::Attribute)),
+                    left: ColumnOrExpression::Column(QualifiedAlias::new(datoms00.clone(), DatomsColumn::Attribute)),
                     right: ColumnOrExpression::Entid(65537),
                 },
                 Constraint::Infix {
                     op: eq.clone(),
-                    left: ColumnOrExpression::Column(QualifiedAlias(datoms01.clone(), DatomsColumn::Attribute)),
+                    left: ColumnOrExpression::Column(QualifiedAlias::new(datoms01.clone(), DatomsColumn::Attribute)),
                     right: ColumnOrExpression::Entid(65536),
                 },
             ],

--- a/query-sql/src/lib.rs
+++ b/query-sql/src/lib.rs
@@ -19,10 +19,12 @@ use mentat_core::{
 };
 
 use mentat_query_algebrizer::{
-    DatomsColumn,
+    Column,
     QualifiedAlias,
     QueryValue,
     SourceAlias,
+    TableAlias,
+    VariableColumn,
 };
 
 use mentat_sql::{
@@ -117,7 +119,7 @@ enum JoinOp {
 }
 
 // Short-hand for a list of tables all inner-joined.
-pub struct TableList(pub Vec<SourceAlias>);
+pub struct TableList(pub Vec<TableOrSubquery>);
 
 impl TableList {
     fn is_empty(&self) -> bool {
@@ -133,8 +135,9 @@ pub struct Join {
 }
 
 #[allow(dead_code)]
-enum TableOrSubquery {
+pub enum TableOrSubquery {
     Table(SourceAlias),
+    Union(Vec<SelectQuery>, TableAlias),
     // TODO: Subquery.
 }
 
@@ -152,9 +155,23 @@ pub struct SelectQuery {
     pub limit: Option<u64>,
 }
 
-// We know that DatomsColumns are safe to serialize.
-fn push_column(qb: &mut QueryBuilder, col: &DatomsColumn) {
-    qb.push_sql(col.as_str());
+fn push_column(qb: &mut QueryBuilder, col: &Column) -> BuildQueryResult {
+    match col {
+        &Column::Fixed(ref d) => {
+            qb.push_sql(d.as_str());
+            Ok(())
+        },
+        &Column::Variable(ref vc) => {
+            match vc {
+                &VariableColumn::Variable(ref v) => {
+                    qb.push_identifier(v.as_str())
+                },
+                &VariableColumn::VariableTypeTag(ref v) => {
+                    qb.push_identifier(format!("{}_value_type_tag", v.name()).as_str())
+                },
+            }
+        },
+    }
 }
 
 //---------------------------------------------------------
@@ -196,8 +213,7 @@ impl QueryFragment for ColumnOrExpression {
             &Column(QualifiedAlias(ref table, ref column)) => {
                 out.push_identifier(table.as_str())?;
                 out.push_sql(".");
-                push_column(out, column);
-                Ok(())
+                push_column(out, column)
             },
             &Entid(entid) => {
                 out.push_sql(entid.to_string().as_str());
@@ -324,8 +340,8 @@ impl QueryFragment for TableList {
             return Ok(());
         }
 
-        interpose!(sa, self.0,
-                   { source_alias_push_sql(out, sa)? },
+        interpose!(t, self.0,
+                   { t.push_sql(out)? },
                    { out.push_sql(", ") });
         Ok(())
     }
@@ -343,7 +359,15 @@ impl QueryFragment for TableOrSubquery {
     fn push_sql(&self, out: &mut QueryBuilder) -> BuildQueryResult {
         use self::TableOrSubquery::*;
         match self {
-            &Table(ref sa) => source_alias_push_sql(out, sa)
+            &Table(ref sa) => source_alias_push_sql(out, sa),
+            &Union(ref subqueries, ref table_alias) => {
+                out.push_sql("(");
+                interpose!(subquery, subqueries,
+                           { subquery.push_sql(out)? },
+                           { out.push_sql(" UNION ") });
+                out.push_sql(") AS ");
+                out.push_identifier(table_alias.as_str())
+            },
         }
     }
 }
@@ -476,8 +500,8 @@ mod tests {
         let datoms01 = "datoms01".to_string();
         let eq = Op("=");
         let source_aliases = vec![
-            SourceAlias(DatomsTable::Datoms, datoms00.clone()),
-            SourceAlias(DatomsTable::Datoms, datoms01.clone()),
+            TableOrSubquery::Table(SourceAlias(DatomsTable::Datoms, datoms00.clone())),
+            TableOrSubquery::Table(SourceAlias(DatomsTable::Datoms, datoms01.clone())),
         ];
 
         let mut query = SelectQuery {

--- a/query-translator/src/translate.rs
+++ b/query-translator/src/translate.rs
@@ -20,10 +20,14 @@ use mentat_query_algebrizer::{
     ColumnConstraint,
     ColumnConstraintOrAlternation,
     ColumnIntersection,
+    ComputedTable,
     ConjoiningClauses,
     DatomsColumn,
+    DatomsTable,
     QualifiedAlias,
     QueryValue,
+    SourceAlias,
+    TableAlias,
 };
 
 use mentat_query_projector::{
@@ -37,9 +41,11 @@ use mentat_query_sql::{
     Constraint,
     FromClause,
     Op,
+    ProjectedColumn,
     Projection,
     SelectQuery,
     TableList,
+    TableOrSubquery,
 };
 
 trait ToConstraint {
@@ -136,7 +142,7 @@ impl ToConstraint for ColumnConstraint {
             },
 
             HasType(table, value_type) => {
-                let column = QualifiedAlias(table, DatomsColumn::ValueTypeTag).to_column();
+                let column = QualifiedAlias::new(table, DatomsColumn::ValueTypeTag).to_column();
                 Constraint::equal(column, ColumnOrExpression::Integer(value_type.value_type_tag()))
             },
         }
@@ -148,6 +154,44 @@ pub struct ProjectedSelect{
     pub projector: Box<Projector>,
 }
 
+// Nasty little hack to let us move out of indexed context.
+struct ConsumableVec<T> {
+    inner: Vec<Option<T>>,
+}
+
+impl<T> ConsumableVec<T> {
+    fn with_vec(vec: Vec<T>) -> ConsumableVec<T> {
+        ConsumableVec { inner: vec.into_iter().map(|x| Some(x)).collect() }
+    }
+
+    fn take_dangerously(&mut self, i: usize) -> T {
+        ::std::mem::replace(&mut self.inner[i], None).expect("each value to only be fetched once")
+    }
+}
+
+fn table_for_computed(computed: ComputedTable, alias: TableAlias) -> TableOrSubquery {
+    match computed {
+        ComputedTable::Union {
+            projection, type_extraction, arms,
+        } => {
+            // The projection list for each CC must have the same shape and the same names.
+            // The values we project might be fixed or they might be columns, and of course
+            // each arm will have different columns.
+            // TODO: type extraction.
+            let queries = arms.into_iter()
+                              .map(|cc| {
+                                    let var_columns = projection.iter().map(|var| {
+                                        let col = cc.column_bindings.get(&var).unwrap()[0].clone();
+                                        ProjectedColumn(ColumnOrExpression::Column(col), var.to_string())
+                                    }).collect();
+                                    let projection = Projection::Columns(var_columns);
+                                    cc_to_select_query(projection, cc, false, None)
+                            }).collect();
+            TableOrSubquery::Union(queries, alias)
+        },
+    }
+}
+
 /// Returns a `SelectQuery` that queries for the provided `cc`. Note that this _always_ returns a
 /// query that runs SQL. The next level up the call stack can check for known-empty queries if
 /// needed.
@@ -155,7 +199,24 @@ fn cc_to_select_query<T: Into<Option<u64>>>(projection: Projection, cc: Conjoini
     let from = if cc.from.is_empty() {
         FromClause::Nothing
     } else {
-        FromClause::TableList(TableList(cc.from))
+        // Move these out of the CC.
+        let from = cc.from;
+        let mut computed = ConsumableVec::with_vec(cc.computed_tables);
+
+        let tables =
+            from.into_iter().map(|source_alias| {
+                match source_alias {
+                    SourceAlias(DatomsTable::Computed(i), alias) => {
+                        let comp = computed.take_dangerously(i);
+                        table_for_computed(comp, alias)
+                    },
+                    _ => {
+                        TableOrSubquery::Table(source_alias)
+                    }
+                }
+            });
+
+        FromClause::TableList(TableList(tables.collect()))
     };
 
     let limit = if cc.empty_because.is_some() { Some(0) } else { limit.into() };

--- a/query-translator/src/translate.rs
+++ b/query-translator/src/translate.rs
@@ -20,6 +20,7 @@ use mentat_query_algebrizer::{
     ColumnConstraint,
     ColumnConstraintOrAlternation,
     ColumnIntersection,
+    ColumnName,
     ComputedTable,
     ConjoiningClauses,
     DatomsColumn,
@@ -28,6 +29,7 @@ use mentat_query_algebrizer::{
     QueryValue,
     SourceAlias,
     TableAlias,
+    VariableColumn,
 };
 
 use mentat_query_projector::{
@@ -175,19 +177,53 @@ fn table_for_computed(computed: ComputedTable, alias: TableAlias) -> TableOrSubq
             projection, type_extraction, arms,
         } => {
             // The projection list for each CC must have the same shape and the same names.
-            // The values we project might be fixed or they might be columns, and of course
-            // each arm will have different columns.
-            // TODO: type extraction.
-            let queries = arms.into_iter()
-                              .map(|cc| {
-                                    let var_columns = projection.iter().map(|var| {
-                                        let col = cc.column_bindings.get(&var).unwrap()[0].clone();
-                                        ProjectedColumn(ColumnOrExpression::Column(col), var.to_string())
-                                    }).collect();
-                                    let projection = Projection::Columns(var_columns);
-                                    cc_to_select_query(projection, cc, false, None)
-                            }).collect();
-            TableOrSubquery::Union(queries, alias)
+            // The values we project might be fixed or they might be columns.
+            TableOrSubquery::Union(
+                arms.into_iter()
+                    .map(|cc| {
+                        // We're going to end up with the variables being projected and also some
+                        // type tag columns.
+                        let mut columns: Vec<ProjectedColumn> = Vec::with_capacity(projection.len() + type_extraction.len());
+
+                        // For each variable, find out which column it maps to within this arm, and
+                        // project it as the variable name.
+                        // E.g., SELECT datoms03.v AS `?x`.
+                        for var in projection.iter() {
+                            let col = cc.column_bindings.get(&var).unwrap()[0].clone();
+                            let proj = ProjectedColumn(ColumnOrExpression::Column(col), var.to_string());
+                            columns.push(proj);
+                        }
+
+                        // Similarly, project type tags if they're not known conclusively in the
+                        // outer query.
+                        for var in type_extraction.iter() {
+                            let expression =
+                                if let Some(known) = cc.known_type(var) {
+                                    // If we know the type for sure, just project the constant.
+                                    // SELECT datoms03.v AS `?x`, 10 AS `?x_value_type_tag`
+                                    ColumnOrExpression::Integer(known.value_type_tag())
+                                } else {
+                                    // Otherwise, we'll have an established type binding! This'll be
+                                    // either a datoms table or, recursively, a subquery. Project
+                                    // this:
+                                    // SELECT datoms03.v AS `?x`,
+                                    //        datoms03.value_type_tag AS `?x_value_type_tag`
+                                    let extract = cc.extracted_types
+                                                    .get(var)
+                                                    .expect("Expected variable to have a known type or an extracted type");
+                                    ColumnOrExpression::Column(extract.clone())
+                                };
+                            let type_column = VariableColumn::VariableTypeTag(var.clone());
+                            let proj = ProjectedColumn(expression, type_column.column_name());
+                            columns.push(proj);
+                        }
+
+                        // Each arm simply turns into a subquery.
+                        // The SQL translation will stuff "UNION" between each arm.
+                        let projection = Projection::Columns(columns);
+                        cc_to_select_query(projection, cc, false, None)
+                  }).collect(),
+                alias)
         },
     }
 }
@@ -203,6 +239,10 @@ fn cc_to_select_query<T: Into<Option<u64>>>(projection: Projection, cc: Conjoini
         let from = cc.from;
         let mut computed = ConsumableVec::with_vec(cc.computed_tables);
 
+        // Why do we put computed tables directly into the `FROM` clause? The alternative is to use
+        // a CTE (`WITH`). They're typically equivalent, but some SQL systems (notably Postgres)
+        // treat CTEs as optimization barriers, so a `WITH` can be significantly slower. Given that
+        // this is easy enough to change later, we'll opt for using direct inclusion in `FROM`.
         let tables =
             from.into_iter().map(|source_alias| {
                 match source_alias {

--- a/query-translator/tests/translate.rs
+++ b/query-translator/tests/translate.rs
@@ -259,3 +259,97 @@ fn test_simple_or_join() {
     assert_eq!(sql, "SELECT `datoms01`.v AS `?url`, `datoms02`.v AS `?description` FROM `datoms` AS `datoms00`, `datoms` AS `datoms01`, `datoms` AS `datoms02` WHERE ((`datoms00`.a = 97 AND `datoms00`.v = $v0) OR (`datoms00`.a = 98 AND `datoms00`.v = $v1)) AND `datoms01`.a = 97 AND `datoms02`.a = 99 AND `datoms00`.e = `datoms01`.e AND `datoms00`.e = `datoms02`.e LIMIT 1");
     assert_eq!(args, vec![make_arg("$v0", "http://foo.com/"), make_arg("$v1", "Foo")]);
 }
+
+#[test]
+fn test_complex_or_join() {
+    let mut schema = Schema::default();
+    associate_ident(&mut schema, NamespacedKeyword::new("page", "save"), 95);
+    add_attribute(&mut schema, 95, Attribute {
+        value_type: ValueType::Ref,
+        ..Default::default()
+    });
+
+    associate_ident(&mut schema, NamespacedKeyword::new("save", "title"), 96);
+    associate_ident(&mut schema, NamespacedKeyword::new("page", "url"), 97);
+    associate_ident(&mut schema, NamespacedKeyword::new("page", "title"), 98);
+    associate_ident(&mut schema, NamespacedKeyword::new("page", "description"), 99);
+    for x in 96..100 {
+        add_attribute(&mut schema, x, Attribute {
+            value_type: ValueType::String,
+            ..Default::default()
+        });
+    }
+
+    let input = r#"[:find [?url ?description]
+                    :where
+                    (or-join [?page]
+                      [?page :page/url "http://foo.com/"]
+                      [?page :page/title "Foo"]
+                      (and
+                        [?page :page/save ?save]
+                        [?save :save/title "Foo"]))
+                    [?page :page/url ?url]
+                    [?page :page/description ?description]]"#;
+    let SQLQuery { sql, args } = translate(&schema, input, None);
+    assert_eq!(sql, "SELECT `datoms04`.v AS `?url`, \
+                            `datoms05`.v AS `?description` \
+                     FROM (SELECT `datoms00`.e AS `?page` \
+                           FROM `datoms` AS `datoms00` \
+                           WHERE `datoms00`.a = 97 \
+                           AND `datoms00`.v = $v0 \
+                           UNION \
+                           SELECT `datoms01`.e AS `?page` \
+                               FROM `datoms` AS `datoms01` \
+                               WHERE `datoms01`.a = 98 \
+                               AND `datoms01`.v = $v1 \
+                           UNION \
+                           SELECT `datoms02`.e AS `?page` \
+                               FROM `datoms` AS `datoms02`, \
+                                   `datoms` AS `datoms03` \
+                               WHERE `datoms02`.a = 95 \
+                               AND `datoms03`.a = 96 \
+                               AND `datoms03`.v = $v2 \
+                               AND `datoms02`.v = `datoms03`.e) AS `c00`, \
+                           `datoms` AS `datoms04`, \
+                           `datoms` AS `datoms05` \
+                    WHERE `datoms04`.a = 97 \
+                    AND `datoms05`.a = 99 \
+                    AND `c00`.`?page` = `datoms04`.e \
+                    AND `c00`.`?page` = `datoms05`.e \
+                    LIMIT 1");
+    assert_eq!(args, vec![make_arg("$v0", "http://foo.com/"),
+                          make_arg("$v1", "Foo"),
+                          make_arg("$v2", "Foo")]);
+}
+
+
+#[test]
+fn test_complex_or_join_type_projection() {
+    let mut schema = Schema::default();
+    associate_ident(&mut schema, NamespacedKeyword::new("page", "title"), 98);
+    add_attribute(&mut schema, 98, Attribute {
+        value_type: ValueType::String,
+        ..Default::default()
+    });
+
+    let input = r#"[:find [?y]
+                    :where
+                    (or
+                      [6 :page/title ?y]
+                      [5 _ ?y])]"#;
+    let SQLQuery { sql, args } = translate(&schema, input, None);
+    assert_eq!(sql, "SELECT `c00`.`?y` AS `?y`, \
+                            `c00`.`?y_value_type_tag` AS `?y_value_type_tag` \
+                       FROM (SELECT `datoms00`.v AS `?y`, \
+                                    10 AS `?y_value_type_tag` \
+                            FROM `datoms` AS `datoms00` \
+                            WHERE `datoms00`.e = 6 \
+                            AND `datoms00`.a = 98 \
+                            UNION \
+                            SELECT `all_datoms01`.v AS `?y`, \
+                                `all_datoms01`.value_type_tag AS `?y_value_type_tag` \
+                            FROM `all_datoms` AS `all_datoms01` \
+                            WHERE `all_datoms01`.e = 5) AS `c00` \
+                    LIMIT 1");
+    assert_eq!(args, vec![]);
+}

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -670,12 +670,12 @@ impl ContainsVariables for OrJoin {
 }
 
 impl OrJoin {
-    pub fn dismember(self) -> (Vec<OrWhereClause>, BTreeSet<Variable>) {
+    pub fn dismember(self) -> (Vec<OrWhereClause>, UnifyVars, BTreeSet<Variable>) {
         let vars = match self.mentioned_vars {
                        Some(m) => m,
                        None => self.collect_mentioned_variables(),
                    };
-        (self.clauses, vars)
+        (self.clauses, self.unify_vars, vars)
     }
 
     pub fn mentioned_variables<'a>(&'a mut self) -> &'a BTreeSet<Variable> {


### PR DESCRIPTION
This is proceeding in stages.

1. Because complex `or`, and other kinds of binding-introducing patterns, are expressed as subqueries — a `UNION` of subqueries in this case — we need to extend several components:
  - CC, which now needs to understand that some of its data isn't just coming from a named table, but a computed table. In order to avoid churning too much, I opted to do this by adding a simple indexed `Computed` table to `DatomsTable`.
  - query-sql, which now needs to represent nested queries.
  - The translator, which needs to turn those nested queries into a string.

2. We need to build an internal Datalog/SQL projection representation for these subqueries. They contribute column bindings, just like a simple table — `"c00"` — but the columns are named for variables. Furthermore, we need to unify the static types of these variables with the surrounding query, and (for each arm individually) project type columns, preserving a single SQL projection. The end result might have a query like

```edn
[:find ?v
 :where
 (or-join [?x]
   [?x 99 ?v]
   (and
     [?x ?a ?v]
     [(> ?v 10)]
     [?x 96 16]))
  [?x 101 17]]
```

turning into the SQL

```sql
SELECT c0.`?v` AS `?v`,
       c0.`?v_value_type_tag` AS `?v_value_type_tag`
FROM
  (
  SELECT datoms01.e AS `?x`,
         datoms01.v AS `?v`,
         4 AS `?v_value_type_tag`     -- This clause's attribute determines this.
  FROM datoms AS datoms01
  WHERE datoms01.a = 99

  UNION

  SELECT datoms02.e AS `?x`,
         datoms02.v AS `?v`,
         datoms02.value_type_tag AS `?v_value_type_tag`  -- This one's doesn't.
  FROM datoms AS datoms02,
       datoms AS datoms03
  WHERE datoms02.v > 10
    AND datoms03.e = datoms02.e
    AND datoms03.a = 96
    AND datoms03.v = 16
  ) AS c0,

  datoms AS datoms00
WHERE datoms00.a = 101
  AND datoms00.v = 17
  AND datoms00.e = c0.`?x`
```

3. Finally, we need to propagate shared type deductions out of the arms of the `or`, just as we did for simple `or`s.

Some of this work will generalize nicely to @fluffyemily's `NOT EXISTS` work in handling `not-join`, and perhaps to binding-generation work that @ncalexan will get to.