### PR TITLE
Add an initial benchmark for the tx-parser crate. (#406) r=nalexander

### DIFF
--- a/tx-parser/benches/bench.rs
+++ b/tx-parser/benches/bench.rs
@@ -14,9 +14,7 @@ use mentat_tx_parser::Tx;
 fn bench_parse1(b: &mut Bencher) {
     let input = r#"[[:db/add 1 :test/val "a"]]"#;
     let parsed_edn = edn::parse::value(input).expect("to parse test input");
-    b.iter(|| {
-        return Tx::parse(parsed_edn.clone());
-    });
+    b.iter(|| Tx::parse(parsed_edn.clone()));
 }
 
 #[bench]
@@ -49,7 +47,5 @@ fn bench_parse2(b: &mut Bencher) {
          [:db/add 25 :test/val "y"]
          [:db/add 26 :test/val "z"]]"#;
     let parsed_edn = edn::parse::value(input).expect("to parse test input");
-    b.iter(|| {
-        return Tx::parse(parsed_edn.clone());
-    });
+    b.iter(|| Tx::parse(parsed_edn.clone()));
 }

--- a/tx-parser/benches/bench.rs
+++ b/tx-parser/benches/bench.rs
@@ -1,0 +1,55 @@
+#![feature(test)]
+
+// These benchmarks can be run from the project root with:
+// > cargo bench --package mentat_tx_parser
+
+extern crate test;
+extern crate edn;
+extern crate mentat_tx_parser;
+
+use test::Bencher;
+use mentat_tx_parser::Tx;
+
+#[bench]
+fn bench_parse1(b: &mut Bencher) {
+    let input = r#"[[:db/add 1 :test/val "a"]]"#;
+    let parsed_edn = edn::parse::value(input).expect("to parse test input");
+    b.iter(|| {
+        return Tx::parse(parsed_edn.clone());
+    });
+}
+
+#[bench]
+fn bench_parse2(b: &mut Bencher) {
+    let input = r#"
+        [[:db/add 1  :test/val "a"]
+         [:db/add 2  :test/val "b"]
+         [:db/add 3  :test/val "c"]
+         [:db/add 4  :test/val "d"]
+         [:db/add 5  :test/val "e"]
+         [:db/add 6  :test/val "f"]
+         [:db/add 7  :test/val "g"]
+         [:db/add 8  :test/val "h"]
+         [:db/add 9  :test/val "i"]
+         [:db/add 10 :test/val "j"]
+         [:db/add 11 :test/val "k"]
+         [:db/add 12 :test/val "l"]
+         [:db/add 13 :test/val "m"]
+         [:db/add 14 :test/val "n"]
+         [:db/add 15 :test/val "o"]
+         [:db/add 16 :test/val "p"]
+         [:db/add 17 :test/val "q"]
+         [:db/add 18 :test/val "r"]
+         [:db/add 19 :test/val "s"]
+         [:db/add 20 :test/val "t"]
+         [:db/add 21 :test/val "u"]
+         [:db/add 22 :test/val "v"]
+         [:db/add 23 :test/val "w"]
+         [:db/add 24 :test/val "x"]
+         [:db/add 25 :test/val "y"]
+         [:db/add 26 :test/val "z"]]"#;
+    let parsed_edn = edn::parse::value(input).expect("to parse test input");
+    b.iter(|| {
+        return Tx::parse(parsed_edn.clone());
+    });
+}


### PR DESCRIPTION
This is an example first benchmark for the tx-parser.  It can be run with:

```cargo bench --package mentat_tx_parser```

To take measurements and print it in a nicer format I used this command:

```for i in `seq 1 5`; do echo '---'; cargo bench --package mentat_tx_parser 2> /dev/null | sed -n -e 's/test \(.*\)\( ... bench: \)/\1/p'; done;```

Here are my results for that locally:

    bench_parse1      7,462 ns/iter (+/- 7,514)
    bench_parse2    384,068 ns/iter (+/- 48,037)
    ---
    bench_parse1      7,171 ns/iter (+/- 1,431)
    bench_parse2    381,971 ns/iter (+/- 59,735)
    ---
    bench_parse1      6,860 ns/iter (+/- 1,742)
    bench_parse2    352,454 ns/iter (+/- 177,286)
    ---
    bench_parse1      6,787 ns/iter (+/- 3,107)
    bench_parse2    348,041 ns/iter (+/- 146,625)
    ---
    bench_parse1      7,113 ns/iter (+/- 961)
    bench_parse2    376,373 ns/iter (+/- 52,412)