### PR TITLE
Implement ordering

### DIFF
--- a/query-algebrizer/src/clauses/mod.rs
+++ b/query-algebrizer/src/clauses/mod.rs
@@ -272,7 +272,7 @@ impl ConjoiningClauses {
 }
 
 impl ConjoiningClauses {
-    fn bound_value(&self, var: &Variable) -> Option<TypedValue> {
+    pub fn bound_value(&self, var: &Variable) -> Option<TypedValue> {
         self.value_bindings.get(var).cloned()
     }
 

--- a/query-algebrizer/src/errors.rs
+++ b/query-algebrizer/src/errors.rs
@@ -31,7 +31,7 @@ error_chain! {
         }
 
         UnboundVariable(name: PlainSymbol) {
-            description("unbound variable in function call")
+            description("unbound variable in order clause or function call")
             display("unbound variable: {}", name)
         }
 

--- a/query-algebrizer/src/lib.rs
+++ b/query-algebrizer/src/lib.rs
@@ -14,6 +14,8 @@ extern crate error_chain;
 extern crate mentat_core;
 extern crate mentat_query;
 
+use std::collections::BTreeSet;
+
 mod errors;
 mod types;
 mod validate;
@@ -29,6 +31,7 @@ use mentat_query::{
     FindQuery,
     FindSpec,
     SrcVar,
+    Variable,
 };
 
 pub use errors::{
@@ -41,6 +44,7 @@ pub use errors::{
 pub struct AlgebraicQuery {
     default_source: SrcVar,
     pub find_spec: FindSpec,
+    pub with: BTreeSet<Variable>,
     has_aggregates: bool,
     pub limit: Option<u64>,
     pub cc: clauses::ConjoiningClauses,
@@ -96,6 +100,7 @@ pub fn algebrize_with_cc(schema: &Schema, parsed: FindQuery, mut cc: ConjoiningC
         default_source: parsed.default_source,
         find_spec: parsed.find_spec,
         has_aggregates: false,           // TODO: we don't parse them yet.
+        with: parsed.with.into_iter().collect(),
         limit: limit,
         cc: cc,
     })

--- a/query-algebrizer/src/types.rs
+++ b/query-algebrizer/src/types.rs
@@ -24,7 +24,9 @@ use mentat_core::{
 };
 
 use mentat_query::{
+    Direction,
     NamespacedKeyword,
+    Order,
     Variable,
 };
 
@@ -217,6 +219,17 @@ impl Debug for QueryValue {
             },
 
         }
+    }
+}
+
+/// Represents an entry in the ORDER BY list: a variable or a variable's type tag.
+/// (We require order vars to be projected, so we can simply use a variable here.)
+pub struct OrderBy(pub Direction, pub VariableColumn);
+
+impl From<Order> for OrderBy {
+    fn from(item: Order) -> OrderBy {
+        let Order(direction, variable) = item;
+        OrderBy(direction, VariableColumn::Variable(variable))
     }
 }
 

--- a/query-projector/src/lib.rs
+++ b/query-projector/src/lib.rs
@@ -37,6 +37,7 @@ use mentat_db::{
 use mentat_query::{
     Element,
     FindSpec,
+    Variable,
 };
 
 use mentat_query_algebrizer::{
@@ -47,6 +48,7 @@ use mentat_query_algebrizer::{
 
 use mentat_query_sql::{
     ColumnOrExpression,
+    Name,
     Projection,
     ProjectedColumn,
 };
@@ -154,6 +156,29 @@ impl TypedIndex {
     }
 }
 
+fn candidate_column(query: &AlgebraicQuery, var: &Variable) -> (ColumnOrExpression, Name) {
+    // Every variable should be bound by the top-level CC to at least
+    // one column in the query. If that constraint is violated it's a
+    // bug in our code, so it's appropriate to panic here.
+    let columns = query.cc
+                       .column_bindings
+                       .get(var)
+                       .expect("Every variable has a binding");
+
+    let qa = columns[0].clone();
+    let name = VariableColumn::Variable(var.clone()).column_name();
+    (ColumnOrExpression::Column(qa), name)
+}
+
+fn candidate_type_column(query: &AlgebraicQuery, var: &Variable) -> (ColumnOrExpression, Name) {
+    let extracted_alias = query.cc
+                               .extracted_types
+                               .get(var)
+                               .expect("Every variable has a known type or an extracted type");
+    let type_name = VariableColumn::VariableTypeTag(var.clone()).column_name();
+    (ColumnOrExpression::Column(extracted_alias.clone()), type_name)
+}
+
 /// Walk an iterator of `Element`s, collecting projector templates and columns.
 ///
 /// Returns a pair: the SQL projection (which should always be a `Projection::Columns`)
@@ -181,34 +206,20 @@ fn project_elements<'a, I: IntoIterator<Item = &'a Element>>(
             // into the SQL projection, aliased to the name of the variable,
             // and we push an annotated index into the projector.
             &Element::Variable(ref var) => {
-                // Every variable should be bound by the top-level CC to at least
-                // one column in the query. If that constraint is violated it's a
-                // bug in our code, so it's appropriate to panic here.
-                let columns = query.cc
-                                   .column_bindings
-                                   .get(var)
-                                   .expect("Every variable has a binding");
 
-                let qa = columns[0].clone();
-                let name = VariableColumn::Variable(var.clone()).column_name();
-
+                let (column, name) = candidate_column(query, var);
+                cols.push(ProjectedColumn(column, name));
                 if let Some(t) = query.cc.known_type(var) {
-                    cols.push(ProjectedColumn(ColumnOrExpression::Column(qa), name));
                     let tag = t.value_type_tag();
                     templates.push(TypedIndex::Known(i, tag));
                     i += 1;     // We used one SQL column.
                 } else {
-                    cols.push(ProjectedColumn(ColumnOrExpression::Column(qa), name));
                     templates.push(TypedIndex::Unknown(i, i + 1));
                     i += 2;     // We used two SQL columns.
 
                     // Also project the type from the SQL query.
-                    let extracted_alias = query.cc
-                                               .extracted_types
-                                               .get(var)
-                                               .expect("Every variable has a known type or an extracted type");
-                    let type_name = VariableColumn::VariableTypeTag(var.clone()).column_name();
-                    cols.push(ProjectedColumn(ColumnOrExpression::Column(extracted_alias.clone()), type_name));
+                    let (type_column, type_name) = candidate_type_column(query, &var);
+                    cols.push(ProjectedColumn(type_column, type_name));
                 }
             }
         }

--- a/query-translator/tests/translate.rs
+++ b/query-translator/tests/translate.rs
@@ -370,3 +370,24 @@ fn test_with_without_aggregate() {
     assert_eq!(sql, "SELECT DISTINCT `all_datoms00`.e AS `?x`, `all_datoms00`.v AS `?y`, `all_datoms00`.value_type_tag AS `?y_value_type_tag` FROM `all_datoms` AS `all_datoms00`");
     assert_eq!(args, vec![]);
 }
+
+#[test]
+fn test_order_by() {
+    let schema = prepopulated_schema();
+
+    // Known type.
+    let input = r#"[:find ?x :where [?x :foo/bar ?y] :order (desc ?y)]"#;
+    let SQLQuery { sql, args } = translate(&schema, input, None);
+    assert_eq!(sql, "SELECT DISTINCT `datoms00`.e AS `?x`, `datoms00`.v AS `?y` \
+                     FROM `datoms` AS `datoms00` \
+                     WHERE `datoms00`.a = 99 \
+                     ORDER BY `?y` DESC");
+
+    // Unknown type.
+    let input = r#"[:find ?x :with ?y :where [?x _ ?y] :order ?y ?x]"#;
+    let SQLQuery { sql, args } = translate(&schema, input, None);
+    assert_eq!(sql, "SELECT DISTINCT `all_datoms00`.e AS `?x`, `all_datoms00`.v AS `?y`, \
+                                     `all_datoms00`.value_type_tag AS `?y_value_type_tag` \
+                     FROM `all_datoms` AS `all_datoms00` \
+                     ORDER BY `?y_value_type_tag` ASC, `?y` ASC, `?x` ASC");
+}

--- a/query-translator/tests/translate.rs
+++ b/query-translator/tests/translate.rs
@@ -353,3 +353,20 @@ fn test_complex_or_join_type_projection() {
                     LIMIT 1");
     assert_eq!(args, vec![]);
 }
+
+#[test]
+fn test_with_without_aggregate() {
+    let schema = prepopulated_schema();
+
+    // Known type.
+    let input = r#"[:find ?x :with ?y :where [?x :foo/bar ?y]]"#;
+    let SQLQuery { sql, args } = translate(&schema, input, None);
+    assert_eq!(sql, "SELECT DISTINCT `datoms00`.e AS `?x`, `datoms00`.v AS `?y` FROM `datoms` AS `datoms00` WHERE `datoms00`.a = 99");
+    assert_eq!(args, vec![]);
+
+    // Unknown type.
+    let input = r#"[:find ?x :with ?y :where [?x _ ?y]]"#;
+    let SQLQuery { sql, args } = translate(&schema, input, None);
+    assert_eq!(sql, "SELECT DISTINCT `all_datoms00`.e AS `?x`, `all_datoms00`.v AS `?y`, `all_datoms00`.value_type_tag AS `?y_value_type_tag` FROM `all_datoms` AS `all_datoms00`");
+    assert_eq!(args, vec![]);
+}

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -129,6 +129,15 @@ impl PredicateFn {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Direction {
+    Ascending,
+    Descending,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Order(pub Direction, pub Variable);   // Future: Element instead of Variable?
+
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum SrcVar {
     DefaultSrc,
     NamedSrc(SrcVarName),

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -134,6 +134,7 @@ pub enum Direction {
     Descending,
 }
 
+/// An abstract declaration of ordering: direction and variable.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Order(pub Direction, pub Variable);   // Future: Element instead of Variable?
 
@@ -603,6 +604,7 @@ pub struct FindQuery {
     pub in_vars: Vec<Variable>,
     pub in_sources: Vec<SrcVar>,
     pub where_clauses: Vec<WhereClause>,
+    pub order: Option<Vec<Order>>,
     // TODO: in_rules;
 }
 


### PR DESCRIPTION
Built on top of #414.

Note that this _should_ order numbers correctly, because both `Long` and `Double` have the same type tag (5). But there's no test for that yet.