### PR TITLE
Add :limit to queries

### DIFF
--- a/query-algebrizer/src/clauses/mod.rs
+++ b/query-algebrizer/src/clauses/mod.rs
@@ -441,6 +441,11 @@ impl ConjoiningClauses {
             QueryValue::PrimitiveLong(value)))
     }
 
+    /// Mark the given value as a long.
+    pub fn constrain_var_to_long(&mut self, variable: Variable) {
+        self.narrow_types_for_var(variable, unit_type_set(ValueType::Long));
+    }
+
     /// Mark the given value as one of the set of numeric types.
     fn constrain_var_to_numeric(&mut self, variable: Variable) {
         let mut numeric_types = HashSet::with_capacity(2);

--- a/query-algebrizer/src/errors.rs
+++ b/query-algebrizer/src/errors.rs
@@ -47,6 +47,11 @@ error_chain! {
             display("invalid argument to {}: expected numeric in position {}.", function, position)
         }
 
+        InvalidLimit(val: String, kind: ValueType) {
+            description("invalid limit")
+            display("invalid limit {} of type {}: expected natural number.", val, kind)
+        }
+
         NonMatchingVariablesInOrClause {
             // TODO: flesh out.
             description("non-matching variables in 'or' clause")

--- a/query-parser/src/parse.rs
+++ b/query-parser/src/parse.rs
@@ -18,7 +18,7 @@ use std; // To refer to std::result::Result.
 use std::collections::BTreeSet;
 
 use self::combine::{eof, many, many1, optional, parser, satisfy, satisfy_map, Parser, ParseResult, Stream};
-use self::combine::combinator::{choice, or, try};
+use self::combine::combinator::{any, choice, or, try};
 
 use self::mentat_parser_utils::{
     ResultParser,
@@ -43,6 +43,7 @@ use self::mentat_query::{
     FindSpec,
     FnArg,
     FromValue,
+    Limit,
     Order,
     OrJoin,
     OrWhereClause,
@@ -102,6 +103,16 @@ error_chain! {
             description("missing field")
             display("missing field: '{}'", value)
         }
+
+        UnknownLimitVar(var: edn::PlainSymbol) {
+            description("limit var not present in :in")
+            display("limit var {} not present in :in", var)
+        }
+
+        InvalidLimit(val: edn::Value) {
+            description("limit value not valid")
+            display("expected natural number, got {}", val)
+        }
     }
 }
 
@@ -154,6 +165,20 @@ pub struct Where;
 
 def_parser!(Where, pattern_value_place, PatternValuePlace,  {
     satisfy_map(PatternValuePlace::from_value)
+});
+
+def_parser!(Query, natural_number, u64, {
+    any().and_then(|v: edn::ValueAndSpan| {
+        match v.inner {
+            edn::SpannedValue::Integer(x) if (x > 0) => {
+                Ok(x as u64)
+            },
+            spanned => {
+                let e = Box::new(Error::from_kind(ErrorKind::InvalidLimit(spanned.into())));
+                Err(combine::primitives::Error::Other(e))
+            },
+        }
+    })
 });
 
 def_parser!(Where, pattern_non_value_place, PatternNonValuePlace, {
@@ -335,6 +360,7 @@ def_parser!(Find, spec, FindSpec, {
 
 def_matches_keyword!(Find, literal_find, "find");
 def_matches_keyword!(Find, literal_in, "in");
+def_matches_keyword!(Find, literal_limit, "limit");
 def_matches_keyword!(Find, literal_order, "order");
 def_matches_keyword!(Find, literal_where, "where");
 def_matches_keyword!(Find, literal_with, "with");
@@ -343,6 +369,7 @@ def_matches_keyword!(Find, literal_with, "with");
 enum FindQueryPart {
     FindSpec(FindSpec),
     In(BTreeSet<Variable>),
+    Limit(Limit),
     Order(Vec<Order>),
     WhereClauses(Vec<WhereClause>),
     With(BTreeSet<Variable>),
@@ -372,6 +399,12 @@ def_parser!(Find, query, FindQuery, {
     let p_in_vars = Find::literal_in()
         .with(Find::vars().map(FindQueryPart::In));
 
+    let p_limit = Find::literal_limit()
+        .with(vector().of_exactly(
+            Query::variable().map(|v| Limit::Variable(v))
+                             .or(Query::natural_number().map(|n| Limit::Fixed(n)))))
+        .map(FindQueryPart::Limit);
+
     let p_order_clauses = Find::literal_order()
         .with(vector().of_exactly(many1(Query::order()).map(FindQueryPart::Order)));
 
@@ -383,17 +416,19 @@ def_parser!(Find, query, FindQuery, {
         .with(Find::vars().map(FindQueryPart::With));
 
     (or(map(), keyword_map()))
-        .of_exactly(many(choice::<[&mut Parser<Input = ValueStream, Output = FindQueryPart>; 5], _>([
+        .of_exactly(many(choice::<[&mut Parser<Input = ValueStream, Output = FindQueryPart>; 6], _>([
             // Ordered by likelihood.
             &mut try(p_find_spec),
             &mut try(p_where_clauses),
             &mut try(p_in_vars),
+            &mut try(p_limit),
             &mut try(p_order_clauses),
             &mut try(p_with_vars),
         ])))
         .and_then(|parts: Vec<FindQueryPart>| -> std::result::Result<FindQuery, combine::primitives::Error<edn::ValueAndSpan, edn::ValueAndSpan>>  {
             let mut find_spec = None;
             let mut in_vars = None;
+            let mut limit = Limit::None;
             let mut order_clauses = None;
             let mut where_clauses = None;
             let mut with_vars = None;
@@ -402,9 +437,19 @@ def_parser!(Find, query, FindQuery, {
                 match part {
                     FindQueryPart::FindSpec(x) => find_spec = Some(x),
                     FindQueryPart::In(x) => in_vars = Some(x),
+                    FindQueryPart::Limit(x) => limit = x,
                     FindQueryPart::Order(x) => order_clauses = Some(x),
                     FindQueryPart::WhereClauses(x) => where_clauses = Some(x),
                     FindQueryPart::With(x) => with_vars = Some(x),
+                }
+            }
+
+            // Make sure that if we have `:limit ?x`, `?x` appears in `:in`.
+            let in_vars = in_vars.unwrap_or(BTreeSet::default());
+            if let Limit::Variable(ref v) = limit {
+                if !in_vars.contains(v) {
+                    let e = Box::new(Error::from_kind(ErrorKind::UnknownLimitVar(v.name())));
+                    return Err(combine::primitives::Error::Other(e));
                 }
             }
 
@@ -412,7 +457,8 @@ def_parser!(Find, query, FindQuery, {
                 default_source: SrcVar::DefaultSrc,
                 find_spec: find_spec.clone().ok_or(combine::primitives::Error::Unexpected("expected :find".into()))?,
                 in_sources: BTreeSet::default(),    // TODO
-                in_vars: in_vars.unwrap_or(BTreeSet::default()),
+                in_vars: in_vars,
+                limit: limit,
                 order: order_clauses,
                 where_clauses: where_clauses.ok_or(combine::primitives::Error::Unexpected("expected :where".into()))?,
                 with: with_vars.unwrap_or(BTreeSet::default()),
@@ -674,5 +720,32 @@ mod test {
                           input,
                           FindSpec::FindTuple(vec![Element::Variable(variable(vx)),
                                                    Element::Variable(variable(vy))]));
+    }
+
+    #[test]
+    fn test_natural_numbers() {
+        let text = edn::Value::Text("foo".to_string());
+        let neg = edn::Value::Integer(-10);
+        let zero = edn::Value::Integer(0);
+        let pos = edn::Value::Integer(5);
+
+        // This is terrible, but destructuring errors is a shitshow.
+        let mut par = Query::natural_number();
+        let x = par.parse(text.with_spans().into_atom_stream()).err().expect("an error").errors;
+        let result = format!("{:?}", x);
+        assert_eq!(result, "[Other(Error(InvalidLimit(Text(\"foo\")), State { next_error: None, backtrace: None })), Expected(Borrowed(\"natural_number\"))]");
+
+        let mut par = Query::natural_number();
+        let x = par.parse(neg.with_spans().into_atom_stream()).err().expect("an error").errors;
+        let result = format!("{:?}", x);
+        assert_eq!(result, "[Other(Error(InvalidLimit(Integer(-10)), State { next_error: None, backtrace: None })), Expected(Borrowed(\"natural_number\"))]");
+
+        let mut par = Query::natural_number();
+        let x = par.parse(zero.with_spans().into_atom_stream()).err().expect("an error").errors;
+        let result = format!("{:?}", x);
+        assert_eq!(result, "[Other(Error(InvalidLimit(Integer(0)), State { next_error: None, backtrace: None })), Expected(Borrowed(\"natural_number\"))]");
+
+        let mut par = Query::natural_number();
+        assert_eq!(None, par.parse(pos.with_spans().into_atom_stream()).err());
     }
 }

--- a/query-parser/src/parse.rs
+++ b/query-parser/src/parse.rs
@@ -334,22 +334,18 @@ def_parser!(Find, spec, FindSpec, {
 });
 
 def_matches_keyword!(Find, literal_find, "find");
-
 def_matches_keyword!(Find, literal_in, "in");
-
-def_matches_keyword!(Find, literal_with, "with");
-
-def_matches_keyword!(Find, literal_where, "where");
-
 def_matches_keyword!(Find, literal_order, "order");
+def_matches_keyword!(Find, literal_where, "where");
+def_matches_keyword!(Find, literal_with, "with");
 
 /// Express something close to a builder pattern for a `FindQuery`.
 enum FindQueryPart {
     FindSpec(FindSpec),
-    With(BTreeSet<Variable>),
     In(BTreeSet<Variable>),
-    WhereClauses(Vec<WhereClause>),
     Order(Vec<Order>),
+    WhereClauses(Vec<WhereClause>),
+    With(BTreeSet<Variable>),
 }
 
 def_parser!(Find, vars, BTreeSet<Variable>, {
@@ -373,49 +369,53 @@ def_parser!(Find, query, FindQuery, {
     let p_find_spec = Find::literal_find()
         .with(vector().of_exactly(Find::spec().map(FindQueryPart::FindSpec)));
 
-    let p_in_vars = Find::literal_in().with(Find::vars().map(FindQueryPart::In));
-
-    let p_with_vars = Find::literal_with().with(Find::vars().map(FindQueryPart::With));
-
-    let p_where_clauses = Find::literal_where()
-        .with(vector().of_exactly(Where::clauses().map(FindQueryPart::WhereClauses))).expected(":where clauses");
+    let p_in_vars = Find::literal_in()
+        .with(Find::vars().map(FindQueryPart::In));
 
     let p_order_clauses = Find::literal_order()
         .with(vector().of_exactly(many1(Query::order()).map(FindQueryPart::Order)));
 
+    let p_where_clauses = Find::literal_where()
+        .with(vector().of_exactly(Where::clauses().map(FindQueryPart::WhereClauses)))
+        .expected(":where clauses");
+
+    let p_with_vars = Find::literal_with()
+        .with(Find::vars().map(FindQueryPart::With));
+
     (or(map(), keyword_map()))
         .of_exactly(many(choice::<[&mut Parser<Input = ValueStream, Output = FindQueryPart>; 5], _>([
+            // Ordered by likelihood.
             &mut try(p_find_spec),
-            &mut try(p_in_vars),
-            &mut try(p_with_vars),
             &mut try(p_where_clauses),
+            &mut try(p_in_vars),
             &mut try(p_order_clauses),
+            &mut try(p_with_vars),
         ])))
         .and_then(|parts: Vec<FindQueryPart>| -> std::result::Result<FindQuery, combine::primitives::Error<edn::ValueAndSpan, edn::ValueAndSpan>>  {
             let mut find_spec = None;
             let mut in_vars = None;
-            let mut with_vars = None;
-            let mut where_clauses = None;
             let mut order_clauses = None;
+            let mut where_clauses = None;
+            let mut with_vars = None;
 
             for part in parts {
                 match part {
                     FindQueryPart::FindSpec(x) => find_spec = Some(x),
-                    FindQueryPart::With(x) => with_vars = Some(x),
                     FindQueryPart::In(x) => in_vars = Some(x),
-                    FindQueryPart::WhereClauses(x) => where_clauses = Some(x),
                     FindQueryPart::Order(x) => order_clauses = Some(x),
+                    FindQueryPart::WhereClauses(x) => where_clauses = Some(x),
+                    FindQueryPart::With(x) => with_vars = Some(x),
                 }
             }
 
             Ok(FindQuery {
-                find_spec: find_spec.clone().ok_or(combine::primitives::Error::Unexpected("expected :find".into()))?,
                 default_source: SrcVar::DefaultSrc,
-                with: with_vars.unwrap_or(BTreeSet::default()),
-                in_vars: in_vars.unwrap_or(BTreeSet::default()),
+                find_spec: find_spec.clone().ok_or(combine::primitives::Error::Unexpected("expected :find".into()))?,
                 in_sources: BTreeSet::default(),    // TODO
+                in_vars: in_vars.unwrap_or(BTreeSet::default()),
                 order: order_clauses,
                 where_clauses: where_clauses.ok_or(combine::primitives::Error::Unexpected("expected :where".into()))?,
+                with: with_vars.unwrap_or(BTreeSet::default()),
             })
         })
 });

--- a/query-projector/src/lib.rs
+++ b/query-projector/src/lib.rs
@@ -37,6 +37,7 @@ use mentat_db::{
 use mentat_query::{
     Element,
     FindSpec,
+    Limit,
     Variable,
 };
 
@@ -442,8 +443,8 @@ pub struct CombinedProjection {
 }
 
 impl CombinedProjection {
-    fn flip_distinct_for_limit(mut self, limit: Option<u64>) -> Self {
-        if limit == Some(1) {
+    fn flip_distinct_for_limit(mut self, limit: &Limit) -> Self {
+        if *limit == Limit::Fixed(1) {
             self.distinct = false;
         }
         self
@@ -474,7 +475,7 @@ pub fn query_projection(query: &AlgebraicQuery) -> CombinedProjection {
         match query.find_spec {
             FindColl(ref element) => {
                 let (cols, templates) = project_elements(1, iter::once(element), query);
-                CollProjector::combine(cols, templates).flip_distinct_for_limit(query.limit)
+                CollProjector::combine(cols, templates).flip_distinct_for_limit(&query.limit)
             },
 
             FindScalar(ref element) => {
@@ -485,7 +486,7 @@ pub fn query_projection(query: &AlgebraicQuery) -> CombinedProjection {
             FindRel(ref elements) => {
                 let column_count = query.find_spec.expected_column_count();
                 let (cols, templates) = project_elements(column_count, elements, query);
-                RelProjector::combine(column_count, cols, templates).flip_distinct_for_limit(query.limit)
+                RelProjector::combine(column_count, cols, templates).flip_distinct_for_limit(&query.limit)
             },
 
             FindTuple(ref elements) => {

--- a/query-sql/Cargo.toml
+++ b/query-sql/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.0.1"
 workspace = ".."
 
 [dependencies]
+regex = "0.2"
+
 [dependencies.mentat_core]
 path = "../core"
 

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -370,11 +370,18 @@ pub struct Aggregate {
 }
 */
 
-#[derive(Clone,Debug,Eq,PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Element {
     Variable(Variable),
     // Aggregate(Aggregate),   // TODO
     // Pull(Pull),             // TODO
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Limit {
+    None,
+    Fixed(u64),
+    Variable(Variable),
 }
 
 /// A definition of the first part of a find query: the
@@ -408,7 +415,7 @@ pub enum Element {
 /// # }
 /// ```
 ///
-#[derive(Clone,Debug,Eq,PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum FindSpec {
     /// Returns an array of arrays.
     FindRel(Vec<Element>),
@@ -610,6 +617,7 @@ pub struct FindQuery {
     pub with: BTreeSet<Variable>,
     pub in_vars: BTreeSet<Variable>,
     pub in_sources: BTreeSet<SrcVar>,
+    pub limit: Limit,
     pub where_clauses: Vec<WhereClause>,
     pub order: Option<Vec<Order>>,
     // TODO: in_rules;

--- a/sql/src/lib.rs
+++ b/sql/src/lib.rs
@@ -154,7 +154,7 @@ impl QueryBuilder for SQLiteQueryBuilder {
     fn push_bind_param(&mut self, name: &str) -> BuildQueryResult {
         // Do some validation first.
         // This is not free, but it's probably worth it for now.
-        if !name.chars().all(char::is_alphanumeric) {
+        if !name.chars().all(|c| char::is_alphanumeric(c) || c == '_') {
             bail!(ErrorKind::InvalidParameterName(name.to_string()));
         }
 

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -110,20 +110,17 @@ impl Conn {
     }
 
     /// Query the Mentat store, using the given connection and the current metadata.
-    pub fn q_once<T, U>(&self,
+    pub fn q_once<T>(&self,
                      sqlite: &rusqlite::Connection,
                      query: &str,
-                     inputs: T,
-                     limit: U) -> Result<QueryResults>
-        where T: Into<Option<QueryInputs>>,
-              U: Into<Option<u64>>
+                     inputs: T) -> Result<QueryResults>
+        where T: Into<Option<QueryInputs>>
         {
 
         q_once(sqlite,
                &*self.current_schema(),
                query,
-               inputs,
-               limit)
+               inputs)
     }
 
     /// Transact entities against the Mentat store, using the given connection and the current

--- a/src/query.rs
+++ b/src/query.rs
@@ -59,24 +59,20 @@ pub type QueryExecutionResult = Result<QueryResults>;
 /// instances.
 /// The caller is responsible for ensuring that the SQLite connection has an open transaction if
 /// isolation is required.
-pub fn q_once<'sqlite, 'schema, 'query, T, U>
+pub fn q_once<'sqlite, 'schema, 'query, T>
 (sqlite: &'sqlite rusqlite::Connection,
  schema: &'schema Schema,
  query: &'query str,
- inputs: T,
- limit: U) -> QueryExecutionResult
-        where T: Into<Option<QueryInputs>>,
-              U: Into<Option<u64>>
+ inputs: T) -> QueryExecutionResult
+        where T: Into<Option<QueryInputs>>
 {
     let parsed = parse_find_string(query)?;
-    let mut algebrized = algebrize_with_inputs(schema, parsed, 0, inputs.into().unwrap_or(QueryInputs::default()))?;
+    let algebrized = algebrize_with_inputs(schema, parsed, 0, inputs.into().unwrap_or(QueryInputs::default()))?;
 
     if algebrized.is_known_empty() {
         // We don't need to do any SQL work at all.
         return Ok(QueryResults::empty(&algebrized.find_spec));
     }
-
-    algebrized.apply_limit(limit.into());
 
     // Because this is q_once, we can check that all of our `:in` variables are bound at this point.
     // If they aren't, the user has made an error -- perhaps writing the wrong variable in `:in`, or

--- a/tests/query.rs
+++ b/tests/query.rs
@@ -41,7 +41,7 @@ fn test_rel() {
     // Rel.
     let start = time::PreciseTime::now();
     let results = q_once(&c, &db.schema,
-                         "[:find ?x ?ident :where [?x :db/ident ?ident]]", None, None)
+                         "[:find ?x ?ident :where [?x :db/ident ?ident]]", None)
         .expect("Query failed");
     let end = time::PreciseTime::now();
 
@@ -71,7 +71,7 @@ fn test_failing_scalar() {
     // Scalar that fails.
     let start = time::PreciseTime::now();
     let results = q_once(&c, &db.schema,
-                         "[:find ?x . :where [?x :db/fulltext true]]", None, None)
+                         "[:find ?x . :where [?x :db/fulltext true]]", None)
         .expect("Query failed");
     let end = time::PreciseTime::now();
 
@@ -93,7 +93,7 @@ fn test_scalar() {
     // Scalar that succeeds.
     let start = time::PreciseTime::now();
     let results = q_once(&c, &db.schema,
-                         "[:find ?ident . :where [24 :db/ident ?ident]]", None, None)
+                         "[:find ?ident . :where [24 :db/ident ?ident]]", None)
         .expect("Query failed");
     let end = time::PreciseTime::now();
 
@@ -123,7 +123,7 @@ fn test_tuple() {
                          "[:find [?index ?cardinality]
                            :where [:db/txInstant :db/index ?index]
                                   [:db/txInstant :db/cardinality ?cardinality]]",
-                         None, None)
+                         None)
         .expect("Query failed");
     let end = time::PreciseTime::now();
 
@@ -150,7 +150,7 @@ fn test_coll() {
     // Coll.
     let start = time::PreciseTime::now();
     let results = q_once(&c, &db.schema,
-                         "[:find [?e ...] :where [?e :db/ident _]]", None, None)
+                         "[:find [?e ...] :where [?e :db/ident _]]", None)
         .expect("Query failed");
     let end = time::PreciseTime::now();
 
@@ -175,7 +175,7 @@ fn test_inputs() {
     let ee = (Variable::from_valid_name("?e"), TypedValue::Ref(5));
     let inputs = QueryInputs::with_value_sequence(vec![ee]);
     let results = q_once(&c, &db.schema,
-                         "[:find ?i . :in ?e :where [?e :db/ident ?i]]", inputs, None)
+                         "[:find ?i . :in ?e :where [?e :db/ident ?i]]", inputs)
                         .expect("query to succeed");
 
     if let QueryResults::Scalar(Some(TypedValue::Keyword(value))) = results {
@@ -195,7 +195,7 @@ fn test_unbound_inputs() {
     let xx = (Variable::from_valid_name("?x"), TypedValue::Ref(5));
     let inputs = QueryInputs::with_value_sequence(vec![xx]);
     let results = q_once(&c, &db.schema,
-                         "[:find ?i . :in ?e :where [?e :db/ident ?i]]", inputs, None);
+                         "[:find ?i . :in ?e :where [?e :db/ident ?i]]", inputs);
 
     match results {
         Result::Err(Error(ErrorKind::UnboundVariables(vars), _)) => {


### PR DESCRIPTION
At present we take limits as an argument alongside the query.

That's flawed: the limit is used when algebrizing (no need to use `DISTINCT` when only fetching one result); in some cases it can be included in the generated SQL; and it breaks our ability to associate cached prepared statements back to input Datalog. Quite apart from all that, it's nice to be able to stuff everything — including ordering and limiting — into the same blob, and supporting limit arguments makes our code more complex.

I plan to:

- Parse `:limit` alongside `:order`.
- Allow the use of variable bindings for `:limit`.
- Remove the existing limit argument mechanism.