### PR TITLE
UUIDs and instants. Fixes #44, #45, #426, #427.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = []
 rustc_version = "0.1.7"
 
 [dependencies]
+chrono = "0.3"
 clap = "2.19.3"
 error-chain = "0.8.1"
 nickel = "0.9.0"

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -33,6 +33,13 @@ pub use edn::{
     Uuid,
 };
 
+pub use edn::{
+    DateTime,
+    FromMicros,
+    ToMicros,
+    UTC,
+};
+
 /// Core types defining a Mentat knowledge base.
 
 /// Represents one entid in the entid space.
@@ -123,6 +130,7 @@ pub enum TypedValue {
     Boolean(bool),
     Long(i64),
     Double(OrderedFloat<f64>),
+    Instant(DateTime<UTC>),
     // TODO: &str throughout?
     String(Rc<String>),
     Keyword(Rc<NamespacedKeyword>),
@@ -147,6 +155,7 @@ impl TypedValue {
             &TypedValue::Ref(_) => ValueType::Ref,
             &TypedValue::Boolean(_) => ValueType::Boolean,
             &TypedValue::Long(_) => ValueType::Long,
+            &TypedValue::Instant(_) => ValueType::Instant,
             &TypedValue::Double(_) => ValueType::Double,
             &TypedValue::String(_) => ValueType::String,
             &TypedValue::Keyword(_) => ValueType::Keyword,
@@ -166,6 +175,10 @@ impl TypedValue {
     /// be best limited to tests.
     pub fn typed_string(s: &str) -> TypedValue {
         TypedValue::String(Rc::new(s.to_string()))
+    }
+
+    pub fn current_instant() -> TypedValue {
+        TypedValue::Instant(UTC::now())
     }
 }
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -25,7 +25,13 @@ use std::rc::Rc;
 use enum_set::EnumSet;
 
 use self::ordered_float::OrderedFloat;
-use self::edn::NamespacedKeyword;
+use self::edn::{
+    NamespacedKeyword,
+};
+
+pub use edn::{
+    Uuid,
+};
 
 /// Core types defining a Mentat knowledge base.
 
@@ -48,6 +54,7 @@ pub enum ValueType {
     Double,
     String,
     Keyword,
+    Uuid,
 }
 
 impl ValueType {
@@ -61,6 +68,7 @@ impl ValueType {
         s.insert(ValueType::Double);
         s.insert(ValueType::String);
         s.insert(ValueType::Keyword);
+        s.insert(ValueType::Uuid);
         s
     }
 }
@@ -86,6 +94,7 @@ impl ValueType {
             ValueType::Double => values::DB_TYPE_DOUBLE.clone(),
             ValueType::String => values::DB_TYPE_STRING.clone(),
             ValueType::Keyword => values::DB_TYPE_KEYWORD.clone(),
+            ValueType::Uuid => values::DB_TYPE_UUID.clone(),
         }
     }
 }
@@ -100,6 +109,7 @@ impl fmt::Display for ValueType {
             ValueType::Double =>  ":db.type/double",
             ValueType::String =>  ":db.type/string",
             ValueType::Keyword => ":db.type/keyword",
+            ValueType::Uuid =>    ":db.type/uuid",
         })
     }
 }
@@ -116,6 +126,7 @@ pub enum TypedValue {
     // TODO: &str throughout?
     String(Rc<String>),
     Keyword(Rc<NamespacedKeyword>),
+    Uuid(Uuid),                        // It's only 128 bits, so this should be acceptable to clone.
 }
 
 impl TypedValue {
@@ -139,6 +150,7 @@ impl TypedValue {
             &TypedValue::Double(_) => ValueType::Double,
             &TypedValue::String(_) => ValueType::String,
             &TypedValue::Keyword(_) => ValueType::Keyword,
+            &TypedValue::Uuid(_) => ValueType::Uuid,
         }
     }
 
@@ -173,6 +185,7 @@ impl SQLValueType for ValueType {
             ValueType::Long =>     5,
             ValueType::Double =>   5,
             ValueType::String =>  10,
+            ValueType::Uuid =>    11,
             ValueType::Keyword => 13,
         }
     }
@@ -195,6 +208,7 @@ impl SQLValueType for ValueType {
             Boolean                 => (int == 0) || (int == 1),
             ValueType::String       => false,
             Keyword                 => false,
+            Uuid                    => false,
         }
     }
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -208,6 +208,8 @@ impl SQLValueType for ValueType {
     ///
     /// ```
     /// use mentat_core::{ValueType, SQLValueType};
+    /// assert!(!ValueType::Instant.accommodates_integer(1493399581314));
+    /// assert!(!ValueType::Instant.accommodates_integer(1493399581314000));
     /// assert!(ValueType::Boolean.accommodates_integer(1));
     /// assert!(!ValueType::Boolean.accommodates_integer(-1));
     /// assert!(!ValueType::Boolean.accommodates_integer(10));
@@ -216,7 +218,8 @@ impl SQLValueType for ValueType {
     fn accommodates_integer(&self, int: i64) -> bool {
         use ValueType::*;
         match *self {
-            Instant | Long | Double => true,
+            Instant                 => false,          // Always use #inst.
+            Long | Double           => true,
             Ref                     => int >= 0,
             Boolean                 => (int == 0) || (int == 1),
             ValueType::String       => false,

--- a/db/src/bootstrap.rs
+++ b/db/src/bootstrap.rs
@@ -98,7 +98,7 @@ lazy_static! {
  ;; TODO: support user-specified functions in the future.
  ;; :db.install/function {:db/valueType :db.type/ref
  ;;                       :db/cardinality :db.cardinality/many}
- :db/txInstant         {:db/valueType   :db.type/long
+ :db/txInstant         {:db/valueType   :db.type/instant
                         :db/cardinality :db.cardinality/one
                         :db/index       true}
  :db/valueType         {:db/valueType   :db.type/ref

--- a/db/src/bootstrap.rs
+++ b/db/src/bootstrap.rs
@@ -61,6 +61,8 @@ lazy_static! {
              (ns_keyword!("db.type", "long"),         entids::DB_TYPE_LONG),
              (ns_keyword!("db.type", "double"),       entids::DB_TYPE_DOUBLE),
              (ns_keyword!("db.type", "string"),       entids::DB_TYPE_STRING),
+             (ns_keyword!("db.type", "uuid"),         entids::DB_TYPE_UUID),
+             (ns_keyword!("db.type", "uri"),          entids::DB_TYPE_URI),
              (ns_keyword!("db.type", "boolean"),      entids::DB_TYPE_BOOLEAN),
              (ns_keyword!("db.type", "instant"),      entids::DB_TYPE_INSTANT),
              (ns_keyword!("db.type", "bytes"),        entids::DB_TYPE_BYTES),
@@ -69,25 +71,13 @@ lazy_static! {
              (ns_keyword!("db.unique", "value"),      entids::DB_UNIQUE_VALUE),
              (ns_keyword!("db.unique", "identity"),   entids::DB_UNIQUE_IDENTITY),
              (ns_keyword!("db", "doc"),               entids::DB_DOC),
+             (ns_keyword!("db.schema", "version"),    entids::DB_SCHEMA_VERSION),
+             (ns_keyword!("db.schema", "attribute"),  entids::DB_SCHEMA_ATTRIBUTE),
         ]
-    };
-
-    static ref V2_IDENTS: Vec<(symbols::NamespacedKeyword, i64)> = {
-        [(*V1_IDENTS).clone(),
-         vec![(ns_keyword!("db.schema", "version"),   entids::DB_SCHEMA_VERSION),
-              (ns_keyword!("db.schema", "attribute"), entids::DB_SCHEMA_ATTRIBUTE),
-         ]].concat()
     };
 
     static ref V1_PARTS: Vec<(symbols::NamespacedKeyword, i64, i64)> = {
         vec![(ns_keyword!("db.part", "db"), 0, (1 + V1_IDENTS.len()) as i64),
-             (ns_keyword!("db.part", "user"), 0x10000, 0x10000),
-             (ns_keyword!("db.part", "tx"), TX0, TX0),
-        ]
-    };
-
-    static ref V2_PARTS: Vec<(symbols::NamespacedKeyword, i64, i64)> = {
-        vec![(ns_keyword!("db.part", "db"), 0, (1 + V2_IDENTS.len()) as i64),
              (ns_keyword!("db.part", "user"), 0x10000, 0x10000),
              (ns_keyword!("db.part", "tx"), TX0, TX0),
         ]
@@ -126,16 +116,8 @@ lazy_static! {
  :db/fulltext          {:db/valueType   :db.type/boolean
                         :db/cardinality :db.cardinality/one}
  :db/noHistory         {:db/valueType   :db.type/boolean
-                        :db/cardinality :db.cardinality/one}}"#;
-        edn::parse::value(s)
-            .map(|v| v.without_spans())
-            .map_err(|_| ErrorKind::BadBootstrapDefinition("Unable to parse V1_SYMBOLIC_SCHEMA".into()))
-            .unwrap()
-    };
-
-    static ref V2_SYMBOLIC_SCHEMA: Value = {
-        let s = r#"
-{:db.alter/attribute   {:db/valueType   :db.type/ref
+                        :db/cardinality :db.cardinality/one}
+ :db.alter/attribute   {:db/valueType   :db.type/ref
                         :db/cardinality :db.cardinality/many}
  :db.schema/version    {:db/valueType   :db.type/long
                         :db/cardinality :db.cardinality/one}
@@ -146,13 +128,9 @@ lazy_static! {
                         :db/index       true
                         :db/unique      :db.unique/value
                         :db/cardinality :db.cardinality/many}}"#;
-        let right = edn::parse::value(s)
+        edn::parse::value(s)
             .map(|v| v.without_spans())
-            .map_err(|_| ErrorKind::BadBootstrapDefinition("Unable to parse V2_SYMBOLIC_SCHEMA".into()))
-            .unwrap();
-
-        edn::utils::merge(&V1_SYMBOLIC_SCHEMA, &right)
-            .ok_or(ErrorKind::BadBootstrapDefinition("Unable to parse V2_SYMBOLIC_SCHEMA".into()))
+            .map_err(|_| ErrorKind::BadBootstrapDefinition("Unable to parse V1_SYMBOLIC_SCHEMA".into()))
             .unwrap()
     };
 }
@@ -248,27 +226,27 @@ fn symbolic_schema_to_assertions(symbolic_schema: &Value) -> Result<Vec<Value>> 
 }
 
 pub fn bootstrap_partition_map() -> PartitionMap {
-    V2_PARTS[..].iter()
+    V1_PARTS[..].iter()
         .map(|&(ref part, start, index)| (part.to_string(), Partition::new(start, index)))
         .collect()
 }
 
 pub fn bootstrap_ident_map() -> IdentMap {
-    V2_IDENTS[..].iter()
+    V1_IDENTS[..].iter()
         .map(|&(ref ident, entid)| (ident.clone(), entid))
         .collect()
 }
 
 pub fn bootstrap_schema() -> Schema {
     let ident_map = bootstrap_ident_map();
-    let bootstrap_triples = symbolic_schema_to_triples(&ident_map, &V2_SYMBOLIC_SCHEMA).unwrap();
+    let bootstrap_triples = symbolic_schema_to_triples(&ident_map, &V1_SYMBOLIC_SCHEMA).unwrap();
     Schema::from_ident_map_and_triples(ident_map, bootstrap_triples).unwrap()
 }
 
 pub fn bootstrap_entities() -> Vec<Entity> {
     let bootstrap_assertions: Value = Value::Vector([
-        symbolic_schema_to_assertions(&V2_SYMBOLIC_SCHEMA).unwrap(),
-        idents_to_assertions(&V2_IDENTS[..]),
+        symbolic_schema_to_assertions(&V1_SYMBOLIC_SCHEMA).unwrap(),
+        idents_to_assertions(&V1_IDENTS[..]),
     ].concat());
 
     // Failure here is a coding error (since the inputs are fixed), not a runtime error.

--- a/db/src/db.rs
+++ b/db/src/db.rs
@@ -81,7 +81,7 @@ pub fn new_connection<T>(uri: T) -> rusqlite::Result<rusqlite::Connection> where
 
 /// Version history:
 ///
-/// 1: initial Mentat schema.
+/// 1: initial Rust Mentat schema.
 pub const CURRENT_VERSION: i32 = 1;
 
 /// MIN_SQLITE_VERSION should be changed when there's a new minimum version of sqlite required
@@ -354,7 +354,10 @@ impl TypedSQLValue for TypedValue {
         match (value_type_tag, value) {
             (0, rusqlite::types::Value::Integer(x)) => Ok(TypedValue::Ref(x)),
             (1, rusqlite::types::Value::Integer(x)) => Ok(TypedValue::Boolean(0 != x)),
+
+            // Negative integers are simply times before 1970.
             (4, rusqlite::types::Value::Integer(x)) => Ok(TypedValue::Instant(DateTime::<UTC>::from_micros(x))),
+
             // SQLite distinguishes integral from decimal types, allowing long and double to
             // share a tag.
             (5, rusqlite::types::Value::Integer(x)) => Ok(TypedValue::Long(x)),

--- a/db/src/db.rs
+++ b/db/src/db.rs
@@ -72,10 +72,8 @@ pub fn new_connection<T>(uri: T) -> rusqlite::Result<rusqlite::Connection> where
 
 /// Version history:
 ///
-/// 1: initial schema.
-/// 2: added :db.schema/version and /attribute in bootstrap; assigned idents 36 and 37, so we bump
-///    the part range here; tie bootstrapping to the SQLite user_version.
-pub const CURRENT_VERSION: i32 = 2;
+/// 1: initial Mentat schema.
+pub const CURRENT_VERSION: i32 = 1;
 
 /// MIN_SQLITE_VERSION should be changed when there's a new minimum version of sqlite required
 /// for the project to work.
@@ -93,9 +91,9 @@ fn to_bool_ref(x: bool) -> &'static bool {
 }
 
 lazy_static! {
-    /// SQL statements to be executed, in order, to create the Mentat SQL schema (version 2).
+    /// SQL statements to be executed, in order, to create the Mentat SQL schema (version 1).
     #[cfg_attr(rustfmt, rustfmt_skip)]
-    static ref V2_STATEMENTS: Vec<&'static str> = { vec![
+    static ref V1_STATEMENTS: Vec<&'static str> = { vec![
         r#"CREATE TABLE datoms (e INTEGER NOT NULL, a SMALLINT NOT NULL, v BLOB NOT NULL, tx INTEGER NOT NULL,
                                 value_type_tag SMALLINT NOT NULL,
                                 index_avet TINYINT NOT NULL DEFAULT 0, index_vaet TINYINT NOT NULL DEFAULT 0,
@@ -203,7 +201,7 @@ fn get_user_version(conn: &rusqlite::Connection) -> Result<i32> {
 pub fn create_current_version(conn: &mut rusqlite::Connection) -> Result<DB> {
     let tx = conn.transaction()?;
 
-    for statement in (&V2_STATEMENTS).iter() {
+    for statement in (&V1_STATEMENTS).iter() {
         tx.execute(statement, &[])?;
     }
 
@@ -1173,12 +1171,12 @@ mod tests {
 
             // Does not include :db/txInstant.
             let datoms = debug::datoms_after(&conn, &db.schema, 0).unwrap();
-            assert_eq!(datoms.0.len(), 74);
+            assert_eq!(datoms.0.len(), 76);
 
             // Includes :db/txInstant.
             let transactions = debug::transactions_after(&conn, &db.schema, 0).unwrap();
             assert_eq!(transactions.0.len(), 1);
-            assert_eq!(transactions.0[0].0.len(), 75);
+            assert_eq!(transactions.0[0].0.len(), 77);
 
             let test_conn = TestConn {
                 sqlite: conn,

--- a/db/src/entids.rs
+++ b/db/src/entids.rs
@@ -44,18 +44,18 @@ pub const DB_TYPE_KEYWORD: Entid = 24;
 pub const DB_TYPE_LONG: Entid = 25;
 pub const DB_TYPE_DOUBLE: Entid = 26;
 pub const DB_TYPE_STRING: Entid = 27;
-pub const DB_TYPE_BOOLEAN: Entid = 28;
-pub const DB_TYPE_INSTANT: Entid = 29;
-pub const DB_TYPE_BYTES: Entid = 30;
-pub const DB_CARDINALITY_ONE: Entid = 31;
-pub const DB_CARDINALITY_MANY: Entid = 32;
-pub const DB_UNIQUE_VALUE: Entid = 33;
-pub const DB_UNIQUE_IDENTITY: Entid = 34;
-pub const DB_DOC: Entid = 35;
-
-// Added in SQL schema v2.
-pub const DB_SCHEMA_VERSION: Entid = 36;
-pub const DB_SCHEMA_ATTRIBUTE: Entid = 37;
+pub const DB_TYPE_UUID: Entid = 28;
+pub const DB_TYPE_URI: Entid = 29;
+pub const DB_TYPE_BOOLEAN: Entid = 30;
+pub const DB_TYPE_INSTANT: Entid = 31;
+pub const DB_TYPE_BYTES: Entid = 32;
+pub const DB_CARDINALITY_ONE: Entid = 33;
+pub const DB_CARDINALITY_MANY: Entid = 34;
+pub const DB_UNIQUE_VALUE: Entid = 35;
+pub const DB_UNIQUE_IDENTITY: Entid = 36;
+pub const DB_DOC: Entid = 37;
+pub const DB_SCHEMA_VERSION: Entid = 38;
+pub const DB_SCHEMA_ATTRIBUTE: Entid = 39;
 
 /// Return `false` if the given attribute will not change the metadata: recognized idents, schema,
 /// partitions in the partition map.

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -11,12 +11,12 @@
 #[macro_use]
 extern crate error_chain;
 extern crate itertools;
+
 #[macro_use]
 extern crate lazy_static;
 extern crate rusqlite;
-extern crate time;
-
 extern crate tabwriter;
+extern crate time;
 
 #[macro_use]
 extern crate edn;
@@ -24,8 +24,15 @@ extern crate mentat_core;
 extern crate mentat_tx;
 extern crate mentat_tx_parser;
 
-use itertools::Itertools;
 use std::iter::repeat;
+
+use itertools::Itertools;
+
+use mentat_core::{
+    DateTime,
+    UTC,
+};
+
 pub use errors::{Error, ErrorKind, ResultExt, Result};
 
 pub mod db;
@@ -89,10 +96,7 @@ pub fn repeat_values(values_per_tuple: usize, tuples: usize) -> String {
     values
 }
 
-/// Return the current time in milliseconds after the Unix epoch according to the local clock.
-///
-/// Compare `Date.now()` in JavaScript, `System.currentTimeMillis` in Java.
-pub fn now() -> i64 {
-    let now = time::get_time();
-    (now.sec as i64 * 1_000) + (now.nsec as i64 / (1_000_000))
+/// Return the current time as a UTC `DateTime` instance.
+pub fn now() -> DateTime<UTC> {
+    UTC::now()
 }

--- a/db/src/metadata.rs
+++ b/db/src/metadata.rs
@@ -119,6 +119,7 @@ pub fn update_schema_map_from_entid_triples<U>(schema_map: &mut SchemaMap, asser
                     TypedValue::Ref(entids::DB_TYPE_BOOLEAN) => { builder.value_type(ValueType::Boolean); },
                     TypedValue::Ref(entids::DB_TYPE_DOUBLE) => { builder.value_type(ValueType::Double); },
                     TypedValue::Ref(entids::DB_TYPE_LONG) => { builder.value_type(ValueType::Long); },
+                    TypedValue::Ref(entids::DB_TYPE_INSTANT) => { builder.value_type(ValueType::Instant); },
                     TypedValue::Ref(entids::DB_TYPE_STRING) => { builder.value_type(ValueType::String); },
                     TypedValue::Ref(entids::DB_TYPE_UUID) => { builder.value_type(ValueType::Uuid); },
                     TypedValue::Ref(entids::DB_TYPE_KEYWORD) => { builder.value_type(ValueType::Keyword); },

--- a/db/src/metadata.rs
+++ b/db/src/metadata.rs
@@ -115,14 +115,14 @@ pub fn update_schema_map_from_entid_triples<U>(schema_map: &mut SchemaMap, asser
 
             entids::DB_VALUE_TYPE => {
                 match *value {
-                    TypedValue::Ref(entids::DB_TYPE_REF) => { builder.value_type(ValueType::Ref); },
                     TypedValue::Ref(entids::DB_TYPE_BOOLEAN) => { builder.value_type(ValueType::Boolean); },
-                    TypedValue::Ref(entids::DB_TYPE_DOUBLE) => { builder.value_type(ValueType::Double); },
-                    TypedValue::Ref(entids::DB_TYPE_LONG) => { builder.value_type(ValueType::Long); },
+                    TypedValue::Ref(entids::DB_TYPE_DOUBLE)  => { builder.value_type(ValueType::Double); },
                     TypedValue::Ref(entids::DB_TYPE_INSTANT) => { builder.value_type(ValueType::Instant); },
-                    TypedValue::Ref(entids::DB_TYPE_STRING) => { builder.value_type(ValueType::String); },
-                    TypedValue::Ref(entids::DB_TYPE_UUID) => { builder.value_type(ValueType::Uuid); },
                     TypedValue::Ref(entids::DB_TYPE_KEYWORD) => { builder.value_type(ValueType::Keyword); },
+                    TypedValue::Ref(entids::DB_TYPE_LONG)    => { builder.value_type(ValueType::Long); },
+                    TypedValue::Ref(entids::DB_TYPE_REF)     => { builder.value_type(ValueType::Ref); },
+                    TypedValue::Ref(entids::DB_TYPE_STRING)  => { builder.value_type(ValueType::String); },
+                    TypedValue::Ref(entids::DB_TYPE_UUID)    => { builder.value_type(ValueType::Uuid); },
                     _ => bail!(ErrorKind::BadSchemaAssertion(format!("Expected [... :db/valueType :db.type/*] but got [... :db/valueType {:?}] for entid {} and attribute {}", value, entid, attr)))
                 }
             },

--- a/db/src/metadata.rs
+++ b/db/src/metadata.rs
@@ -120,6 +120,7 @@ pub fn update_schema_map_from_entid_triples<U>(schema_map: &mut SchemaMap, asser
                     TypedValue::Ref(entids::DB_TYPE_DOUBLE) => { builder.value_type(ValueType::Double); },
                     TypedValue::Ref(entids::DB_TYPE_LONG) => { builder.value_type(ValueType::Long); },
                     TypedValue::Ref(entids::DB_TYPE_STRING) => { builder.value_type(ValueType::String); },
+                    TypedValue::Ref(entids::DB_TYPE_UUID) => { builder.value_type(ValueType::Uuid); },
                     TypedValue::Ref(entids::DB_TYPE_KEYWORD) => { builder.value_type(ValueType::Keyword); },
                     _ => bail!(ErrorKind::BadSchemaAssertion(format!("Expected [... :db/valueType :db.type/*] but got [... :db/valueType {:?}] for entid {} and attribute {}", value, entid, attr)))
                 }

--- a/db/src/schema.rs
+++ b/db/src/schema.rs
@@ -240,6 +240,7 @@ impl SchemaTypeChecking for Schema {
                 (&ValueType::Long, tv @ TypedValue::Long(_)) => Ok(tv),
                 (&ValueType::Double, tv @ TypedValue::Double(_)) => Ok(tv),
                 (&ValueType::String, tv @ TypedValue::String(_)) => Ok(tv),
+                (&ValueType::Uuid, tv @ TypedValue::Uuid(_)) => Ok(tv),
                 (&ValueType::Keyword, tv @ TypedValue::Keyword(_)) => Ok(tv),
                 // Ref coerces a little: we interpret some things depending on the schema as a Ref.
                 (&ValueType::Ref, TypedValue::Long(x)) => Ok(TypedValue::Ref(x)),

--- a/db/src/tx.rs
+++ b/db/src/tx.rs
@@ -70,10 +70,13 @@ use internal_types::{
     TermWithTempIds,
     TermWithoutTempIds,
     replace_lookup_ref};
+
 use mentat_core::{
+    DateTime,
+    Schema,
+    UTC,
     attribute,
     intern_set,
-    Schema,
 };
 use mentat_tx::entities as entmod;
 use mentat_tx::entities::{
@@ -127,10 +130,7 @@ pub struct Tx<'conn, 'a> {
     tx_id: Entid,
 
     /// The timestamp when the transaction began to be committed.
-    ///
-    /// This is milliseconds after the Unix epoch according to the transactor's local clock.
-    // TODO: :db.type/instant.
-    tx_instant: i64,
+    tx_instant: DateTime<UTC>,
 }
 
 impl<'conn, 'a> Tx<'conn, 'a> {
@@ -140,7 +140,7 @@ impl<'conn, 'a> Tx<'conn, 'a> {
         schema_for_mutation: &'a Schema,
         schema: &'a Schema,
         tx_id: Entid,
-        tx_instant: i64) -> Tx<'conn, 'a> {
+        tx_instant: DateTime<UTC>) -> Tx<'conn, 'a> {
         Tx {
             store: store,
             partition_map: partition_map,
@@ -532,7 +532,7 @@ impl<'conn, 'a> Tx<'conn, 'a> {
         non_fts_one.push((self.tx_id,
                           entids::DB_TX_INSTANT,
                           self.schema.require_attribute_for_entid(entids::DB_TX_INSTANT).unwrap(),
-                          TypedValue::Long(self.tx_instant),
+                          TypedValue::Instant(self.tx_instant),
                           true));
 
         if !non_fts_one.is_empty() {

--- a/db/src/types.rs
+++ b/db/src/types.rs
@@ -95,13 +95,3 @@ pub struct TxReport {
     /// literal tempids to all unify to a single freshly allocated entid.)
     pub tempids: BTreeMap<String, Entid>,
 }
-
-impl Default for TxReport {
-    fn default() -> Self {
-        TxReport {
-            tx_id: Entid::default(),
-            tx_instant: UTC::now(),
-            tempids: BTreeMap::default(),
-        }
-    }
-}

--- a/db/src/types.rs
+++ b/db/src/types.rs
@@ -16,12 +16,14 @@ use std::collections::BTreeMap;
 extern crate mentat_core;
 
 pub use self::mentat_core::{
+    DateTime,
     Entid,
     ValueType,
     TypedValue,
     Attribute,
     AttributeBitFlags,
     Schema,
+    UTC,
 };
 
 /// Represents one partition of the entid space.
@@ -78,16 +80,13 @@ pub type AVMap<'a> = HashMap<&'a AVPair, Entid>;
 
 /// A transaction report summarizes an applied transaction.
 // TODO: include map of resolved tempids.
-#[derive(Clone, Debug, Default, Eq, Hash, Ord, PartialOrd, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialOrd, PartialEq)]
 pub struct TxReport {
     /// The transaction ID of the transaction.
     pub tx_id: Entid,
 
     /// The timestamp when the transaction began to be committed.
-    ///
-    /// This is milliseconds after the Unix epoch according to the transactor's local clock.
-    // TODO: :db.type/instant.
-    pub tx_instant: i64,
+    pub tx_instant: DateTime<UTC>,
 
     /// A map from string literal tempid to resolved or allocated entid.
     ///
@@ -95,4 +94,14 @@ pub struct TxReport {
     /// existing entid, or is allocated a new entid.  (It is possible for multiple distinct string
     /// literal tempids to all unify to a single freshly allocated entid.)
     pub tempids: BTreeMap<String, Entid>,
+}
+
+impl Default for TxReport {
+    fn default() -> Self {
+        TxReport {
+            tx_id: Entid::default(),
+            tx_instant: UTC::now(),
+            tempids: BTreeMap::default(),
+        }
+    }
 }

--- a/edn/Cargo.toml
+++ b/edn/Cargo.toml
@@ -11,6 +11,7 @@ build = "build.rs"
 readme = "./README.md"
 
 [dependencies]
+chrono = "0.3"
 itertools = "0.5.9"
 num = "0.1.35"
 ordered-float = "0.4.0"

--- a/edn/Cargo.toml
+++ b/edn/Cargo.toml
@@ -15,6 +15,7 @@ itertools = "0.5.9"
 num = "0.1.35"
 ordered-float = "0.4.0"
 pretty = "0.2.0"
+uuid = "0.5.0"
 
 [build-dependencies]
 peg = "0.5.1"

--- a/edn/src/edn.rustpeg
+++ b/edn/src/edn.rustpeg
@@ -153,7 +153,7 @@ pub text -> ValueAndSpan =
 // We accept an arbitrary depth of decimals.
 // Note that we discard the timezone information -- all times are translated to UTC.
 pub inst_string -> DateTime<UTC> =
-    "\"" d:$( [0-9]*<4> "-" [0-2][0-9] "-" [0-3][0-9]
+    "#inst" whitespace+ "\"" d:$( [0-9]*<4> "-" [0-2][0-9] "-" [0-3][0-9]
               "T"
               [0-2][0-9] ":" [0-5][0-9] ":" [0-6][0-9]
               ("." [0-9]+)?
@@ -165,8 +165,16 @@ pub inst_string -> DateTime<UTC> =
             .map_err(|_| "invalid datetime")        // Oh, rustpeg.
     }
 
+pub inst_micros -> DateTime<UTC> =
+    "#instmicros" whitespace+ d:$( digit+ ) {
+        let micros = d.parse::<i64>().unwrap();
+        let seconds: i64 = micros / 1000000;
+        let nanos: u32 = ((micros % 1000000).abs() as u32) * 1000;
+        UTC.timestamp(seconds, nanos)
+    }
+
 pub inst_millis -> DateTime<UTC> =
-    d:$( digit+ ) {
+    "#instmillis" whitespace+ d:$( digit+ ) {
         let millis = d.parse::<i64>().unwrap();
         let seconds: i64 = millis / 1000;
         let nanos: u32 = ((millis % 1000).abs() as u32) * 1000000;
@@ -174,7 +182,7 @@ pub inst_millis -> DateTime<UTC> =
     }
 
 pub inst -> ValueAndSpan =
-    start:#position "#inst" whitespace+ t:(inst_millis / inst_string) end:#position {
+    start:#position t:(inst_millis / inst_micros / inst_string) end:#position {
         ValueAndSpan {
             inner: SpannedValue::Instant(t),
             span: Span::new(start, end)

--- a/edn/src/edn.rustpeg
+++ b/edn/src/edn.rustpeg
@@ -14,6 +14,11 @@ use std::collections::{BTreeSet, BTreeMap, LinkedList};
 use std::iter::FromIterator;
 use std::f64::{NAN, INFINITY, NEG_INFINITY};
 
+use chrono::{
+    DateTime,
+    TimeZone,
+    UTC
+};
 use num::BigInt;
 use ordered_float::OrderedFloat;
 use uuid::Uuid;
@@ -143,6 +148,39 @@ pub text -> ValueAndSpan =
         }
     }
 
+
+// RFC 3339 timestamps. #inst "1985-04-12T23:20:50.52Z"
+// We accept an arbitrary depth of decimals.
+// Note that we discard the timezone information -- all times are translated to UTC.
+pub inst_string -> DateTime<UTC> =
+    "\"" d:$( [0-9]*<4> "-" [0-2][0-9] "-" [0-3][0-9]
+              "T"
+              [0-2][0-9] ":" [0-5][0-9] ":" [0-6][0-9]
+              ("." [0-9]+)?
+              "Z" / (("+" / "-") [0-2][0-9] ":" [0-5][0-9])
+            )
+    "\"" {?
+        DateTime::parse_from_rfc3339(d)
+            .map(|t| t.with_timezone(&UTC))
+            .map_err(|_| "invalid datetime")        // Oh, rustpeg.
+    }
+
+pub inst_millis -> DateTime<UTC> =
+    d:$( digit+ ) {
+        let millis = d.parse::<i64>().unwrap();
+        let seconds: i64 = millis / 1000;
+        let nanos: u32 = ((millis % 1000).abs() as u32) * 1000000;
+        UTC.timestamp(seconds, nanos)
+    }
+
+pub inst -> ValueAndSpan =
+    start:#position "#inst" whitespace+ t:(inst_millis / inst_string) end:#position {
+        ValueAndSpan {
+            inner: SpannedValue::Instant(t),
+            span: Span::new(start, end)
+        }
+    }
+
 pub uuid_string -> Uuid =
     "\"" u:$( [a-f0-9]*<8> "-" [a-f0-9]*<4> "-" [a-f0-9]*<4> "-" [a-f0-9]*<4> "-" [a-f0-9]*<12> ) "\"" {
         Uuid::parse_str(u).expect("this is a valid UUID string")
@@ -234,7 +272,7 @@ pub map -> ValueAndSpan =
 // It's important that float comes before integer or the parser assumes that
 // floats are integers and fails to parse
 pub value -> ValueAndSpan =
-    __ v:(nil / nan / infinity / boolean / float / octalinteger / hexinteger / basedinteger / uuid / bigint / integer / text / keyword / symbol / list / vector / map / set) __ {
+    __ v:(nil / nan / infinity / boolean / float / octalinteger / hexinteger / basedinteger / inst / uuid / bigint / integer / text / keyword / symbol / list / vector / map / set) __ {
         v
     }
 

--- a/edn/src/edn.rustpeg
+++ b/edn/src/edn.rustpeg
@@ -16,6 +16,7 @@ use std::f64::{NAN, INFINITY, NEG_INFINITY};
 
 use num::BigInt;
 use ordered_float::OrderedFloat;
+use uuid::Uuid;
 
 use types::{SpannedValue, Span, ValueAndSpan};
 
@@ -142,6 +143,19 @@ pub text -> ValueAndSpan =
         }
     }
 
+pub uuid_string -> Uuid =
+    "\"" u:$( [a-f0-9]*<8> "-" [a-f0-9]*<4> "-" [a-f0-9]*<4> "-" [a-f0-9]*<4> "-" [a-f0-9]*<12> ) "\"" {
+        Uuid::parse_str(u).expect("this is a valid UUID string")
+    }
+
+pub uuid -> ValueAndSpan =
+    start:#position "#uuid" whitespace+ u:(uuid_string) end:#position {
+        ValueAndSpan {
+            inner: SpannedValue::Uuid(u),
+            span: Span::new(start, end)
+        }
+    }
+
 namespace_divider = "."
 namespace_separator = "/"
 
@@ -220,7 +234,7 @@ pub map -> ValueAndSpan =
 // It's important that float comes before integer or the parser assumes that
 // floats are integers and fails to parse
 pub value -> ValueAndSpan =
-    __ v:(nil / nan / infinity / boolean / float / octalinteger / hexinteger / basedinteger / bigint / integer / text / keyword / symbol / list / vector / map / set) __ {
+    __ v:(nil / nan / infinity / boolean / float / octalinteger / hexinteger / basedinteger / uuid / bigint / integer / text / keyword / symbol / list / vector / map / set) __ {
         v
     }
 

--- a/edn/src/lib.rs
+++ b/edn/src/lib.rs
@@ -12,6 +12,7 @@ extern crate itertools;
 extern crate num;
 extern crate ordered_float;
 extern crate pretty;
+extern crate uuid;
 
 pub mod symbols;
 pub mod types;
@@ -23,8 +24,12 @@ pub mod parse {
     include!(concat!(env!("OUT_DIR"), "/edn.rs"));
 }
 
+// Re-export the types we use.
 pub use num::BigInt;
 pub use ordered_float::OrderedFloat;
+pub use uuid::Uuid;
+
+// Export from our modules.
 pub use parse::ParseError;
 pub use types::{Span, SpannedValue, Value, ValueAndSpan};
 pub use symbols::{Keyword, NamespacedKeyword, PlainSymbol, NamespacedSymbol};

--- a/edn/src/lib.rs
+++ b/edn/src/lib.rs
@@ -8,6 +8,7 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
+extern crate chrono;
 extern crate itertools;
 extern crate num;
 extern crate ordered_float;
@@ -25,11 +26,19 @@ pub mod parse {
 }
 
 // Re-export the types we use.
+pub use chrono::{DateTime, UTC};
 pub use num::BigInt;
 pub use ordered_float::OrderedFloat;
 pub use uuid::Uuid;
 
 // Export from our modules.
 pub use parse::ParseError;
-pub use types::{Span, SpannedValue, Value, ValueAndSpan};
+pub use types::{
+    FromMicros,
+    Span,
+    SpannedValue,
+    ToMicros,
+    Value,
+    ValueAndSpan,
+};
 pub use symbols::{Keyword, NamespacedKeyword, PlainSymbol, NamespacedSymbol};

--- a/edn/src/pretty_print.rs
+++ b/edn/src/pretty_print.rs
@@ -69,6 +69,7 @@ impl Value {
             Value::NamespacedKeyword(ref v) => pp.text(":").append(v.namespace.as_ref()).append("/").append(v.name.as_ref()),
             Value::Keyword(ref v) => pp.text(":").append(v.0.as_ref()),
             Value::Text(ref v) => pp.text("\"").append(v.as_ref()).append("\""),
+            Value::Uuid(ref u) => pp.text("#uuid \"").append(u.hyphenated().to_string()).append("\""),
             _ => pp.text(self.to_string())
         }
     }

--- a/edn/src/types.rs
+++ b/edn/src/types.rs
@@ -15,9 +15,11 @@ use std::cmp::{Ordering, Ord, PartialOrd};
 use std::fmt::{Display, Formatter};
 use std::f64;
 
-use symbols;
 use num::BigInt;
 use ordered_float::OrderedFloat;
+use uuid::Uuid;
+
+use symbols;
 
 /// Value represents one of the allowed values in an EDN string.
 #[derive(PartialEq, Eq, Hash, Clone, Debug)]
@@ -28,6 +30,7 @@ pub enum Value {
     BigInteger(BigInt),
     Float(OrderedFloat<f64>),
     Text(String),
+    Uuid(Uuid),
     PlainSymbol(symbols::PlainSymbol),
     NamespacedSymbol(symbols::NamespacedSymbol),
     Keyword(symbols::Keyword),
@@ -55,6 +58,7 @@ pub enum SpannedValue {
     BigInteger(BigInt),
     Float(OrderedFloat<f64>),
     Text(String),
+    Uuid(Uuid),
     PlainSymbol(symbols::PlainSymbol),
     NamespacedSymbol(symbols::NamespacedSymbol),
     Keyword(symbols::Keyword),
@@ -126,6 +130,7 @@ impl From<SpannedValue> for Value {
             SpannedValue::BigInteger(v) => Value::BigInteger(v),
             SpannedValue::Float(v) => Value::Float(v),
             SpannedValue::Text(v) => Value::Text(v),
+            SpannedValue::Uuid(v) => Value::Uuid(v),
             SpannedValue::PlainSymbol(v) => Value::PlainSymbol(v),
             SpannedValue::NamespacedSymbol(v) => Value::NamespacedSymbol(v),
             SpannedValue::Keyword(v) => Value::Keyword(v),
@@ -271,6 +276,7 @@ macro_rules! def_common_value_methods {
         def_is!(is_big_integer, $t::BigInteger(_));
         def_is!(is_float, $t::Float(_));
         def_is!(is_text, $t::Text(_));
+        def_is!(is_uuid, $t::Uuid(_));
         def_is!(is_symbol, $t::PlainSymbol(_));
         def_is!(is_namespaced_symbol, $t::NamespacedSymbol(_));
         def_is!(is_keyword, $t::Keyword(_));
@@ -293,6 +299,7 @@ macro_rules! def_common_value_methods {
         def_as_ref!(as_big_integer, $t::BigInteger, BigInt);
         def_as_ref!(as_ordered_float, $t::Float, OrderedFloat<f64>);
         def_as_ref!(as_text, $t::Text, String);
+        def_as_ref!(as_uuid, $t::Uuid, Uuid);
         def_as_ref!(as_symbol, $t::PlainSymbol, symbols::PlainSymbol);
         def_as_ref!(as_namespaced_symbol, $t::NamespacedSymbol, symbols::NamespacedSymbol);
         def_as_ref!(as_keyword, $t::Keyword, symbols::Keyword);
@@ -308,6 +315,7 @@ macro_rules! def_common_value_methods {
         def_into!(into_ordered_float, $t::Float, OrderedFloat<f64>,);
         def_into!(into_float, $t::Float, f64, |v: OrderedFloat<f64>| v.into_inner());
         def_into!(into_text, $t::Text, String,);
+        def_into!(into_uuid, $t::Uuid, Uuid,);
         def_into!(into_symbol, $t::PlainSymbol, symbols::PlainSymbol,);
         def_into!(into_namespaced_symbol, $t::NamespacedSymbol, symbols::NamespacedSymbol,);
         def_into!(into_keyword, $t::Keyword, symbols::Keyword,);
@@ -337,14 +345,15 @@ macro_rules! def_common_value_methods {
                 $t::BigInteger(_) => 3,
                 $t::Float(_) => 4,
                 $t::Text(_) => 5,
-                $t::PlainSymbol(_) => 6,
-                $t::NamespacedSymbol(_) => 7,
-                $t::Keyword(_) => 8,
-                $t::NamespacedKeyword(_) => 9,
-                $t::Vector(_) => 10,
-                $t::List(_) => 11,
-                $t::Set(_) => 12,
-                $t::Map(_) => 13,
+                $t::Uuid(_) => 6,
+                $t::PlainSymbol(_) => 7,
+                $t::NamespacedSymbol(_) => 8,
+                $t::Keyword(_) => 9,
+                $t::NamespacedKeyword(_) => 10,
+                $t::Vector(_) => 11,
+                $t::List(_) => 12,
+                $t::Set(_) => 13,
+                $t::Map(_) => 14,
             }
         }
 
@@ -356,6 +365,7 @@ macro_rules! def_common_value_methods {
                 $t::BigInteger(_) => false,
                 $t::Float(_) => false,
                 $t::Text(_) => false,
+                $t::Uuid(_) => false,
                 $t::PlainSymbol(_) => false,
                 $t::NamespacedSymbol(_) => false,
                 $t::Keyword(_) => false,
@@ -392,6 +402,7 @@ macro_rules! def_common_value_ord {
             (&$t::BigInteger(ref a), &$t::BigInteger(ref b)) => b.cmp(a),
             (&$t::Float(ref a), &$t::Float(ref b)) => b.cmp(a),
             (&$t::Text(ref a), &$t::Text(ref b)) => b.cmp(a),
+            (&$t::Uuid(ref a), &$t::Uuid(ref b)) => b.cmp(a),
             (&$t::PlainSymbol(ref a), &$t::PlainSymbol(ref b)) => b.cmp(a),
             (&$t::NamespacedSymbol(ref a), &$t::NamespacedSymbol(ref b)) => b.cmp(a),
             (&$t::Keyword(ref a), &$t::Keyword(ref b)) => b.cmp(a),
@@ -429,6 +440,7 @@ macro_rules! def_common_value_display {
             }
             // TODO: EDN escaping.
             $t::Text(ref v) => write!($f, "\"{}\"", v),
+            $t::Uuid(ref u) => write!($f, "#uuid \"{}\"", u.hyphenated().to_string()),
             $t::PlainSymbol(ref v) => v.fmt($f),
             $t::NamespacedSymbol(ref v) => v.fmt($f),
             $t::Keyword(ref v) => v.fmt($f),

--- a/edn/tests/tests.rs
+++ b/edn/tests/tests.rs
@@ -8,6 +8,7 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
+extern crate chrono;
 extern crate edn;
 extern crate num;
 extern crate ordered_float;
@@ -22,7 +23,17 @@ use num::traits::{Zero, One};
 use ordered_float::OrderedFloat;
 
 use edn::parse::{self, ParseError};
-use edn::types::{Value, SpannedValue, Span, ValueAndSpan};
+use edn::types::{
+    Value,
+    ValueAndSpan,
+    Span,
+    SpannedValue,
+};
+use uuid::Uuid;
+use chrono::{
+    TimeZone,
+    UTC,
+};
 use edn::symbols;
 use edn::utils;
 
@@ -412,6 +423,11 @@ fn test_value() {
     assert_eq!(value("(1)").unwrap(), List(LinkedList::from_iter(vec![Integer(1)])));
     assert_eq!(value("#{1}").unwrap(), Set(BTreeSet::from_iter(vec![Integer(1)])));
     assert_eq!(value("{1 2}").unwrap(), Map(BTreeMap::from_iter(vec![(Integer(1), Integer(2))])));
+    assert_eq!(value("#uuid \"e43c6f3e-3123-49b7-8098-9b47a7bc0fa4\"").unwrap(),
+               Uuid(uuid::Uuid::parse_str("e43c6f3e-3123-49b7-8098-9b47a7bc0fa4").unwrap()));
+    assert_eq!(value("#inst 1493410985187").unwrap(), Instant(UTC.timestamp(1493410985, 187000000)));
+    assert_eq!(value("#inst \"2017-04-28T20:23:05.187Z\"").unwrap(),
+               Instant(UTC.timestamp(1493410985, 187000000)));
 }
 
 #[test]

--- a/edn/tests/tests.rs
+++ b/edn/tests/tests.rs
@@ -11,6 +11,7 @@
 extern crate edn;
 extern crate num;
 extern crate ordered_float;
+extern crate uuid;
 
 use std::collections::{BTreeSet, BTreeMap, LinkedList};
 use std::iter::FromIterator;
@@ -55,7 +56,7 @@ macro_rules! fn_parse_into_value {
 }
 
 // These look exactly like their `parse::foo` counterparts, but
-// automatically convert the returned result into Value. Use `parse:foo`
+// automatically convert the returned result into Value. Use `parse::foo`
 // if you want the original ValueAndSpan instance.
 fn_parse_into_value!(nil);
 fn_parse_into_value!(nan);
@@ -240,6 +241,23 @@ fn test_span_integer() {
         inner: SpannedValue::Integer(9),
         span: Span(0, 3)
     });
+}
+
+#[test]
+fn test_uuid() {
+    assert!(parse::uuid("#uuid \"z50e8400-e29b-41d4-a716-446655440000\"").is_err());  // Not hex.
+    assert!(parse::uuid("\"z50e8400-e29b-41d4-a716-446655440000\"").is_err());        // No tag.
+    assert!(parse::uuid("#uuid \"aaaaaaaae29b-41d4-a716-446655440000\"").is_err());   // Hyphens.
+    assert!(parse::uuid("#uuid \"aaaaaaaa-e29b-41d4-a716-446655440\"").is_err());     // Truncated.
+    assert!(parse::uuid("#uuid \"A50e8400-e29b-41d4-a716-446655440000\"").is_err());  // Capital.
+
+    let expected = uuid::Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000")
+                       .expect("valid UUID");
+    let actual = parse::uuid("#uuid \"550e8400-e29b-41d4-a716-446655440000\"")
+                       .expect("parse success")
+                       .inner
+                       .into();
+    assert_eq!(self::Value::Uuid(expected), actual);
 }
 
 #[test]

--- a/edn/tests/tests.rs
+++ b/edn/tests/tests.rs
@@ -29,7 +29,6 @@ use edn::types::{
     Span,
     SpannedValue,
 };
-use uuid::Uuid;
 use chrono::{
     TimeZone,
     UTC,
@@ -256,6 +255,7 @@ fn test_span_integer() {
 
 #[test]
 fn test_uuid() {
+    assert!(parse::uuid("#uuid\"550e8400-e29b-41d4-a716-446655440000\"").is_err());   // No whitespace.
     assert!(parse::uuid("#uuid \"z50e8400-e29b-41d4-a716-446655440000\"").is_err());  // Not hex.
     assert!(parse::uuid("\"z50e8400-e29b-41d4-a716-446655440000\"").is_err());        // No tag.
     assert!(parse::uuid("#uuid \"aaaaaaaae29b-41d4-a716-446655440000\"").is_err());   // Hyphens.
@@ -425,7 +425,8 @@ fn test_value() {
     assert_eq!(value("{1 2}").unwrap(), Map(BTreeMap::from_iter(vec![(Integer(1), Integer(2))])));
     assert_eq!(value("#uuid \"e43c6f3e-3123-49b7-8098-9b47a7bc0fa4\"").unwrap(),
                Uuid(uuid::Uuid::parse_str("e43c6f3e-3123-49b7-8098-9b47a7bc0fa4").unwrap()));
-    assert_eq!(value("#inst 1493410985187").unwrap(), Instant(UTC.timestamp(1493410985, 187000000)));
+    assert_eq!(value("#instmillis 1493410985187").unwrap(), Instant(UTC.timestamp(1493410985, 187000000)));
+    assert_eq!(value("#instmicros 1493410985187123").unwrap(), Instant(UTC.timestamp(1493410985, 187123000)));
     assert_eq!(value("#inst \"2017-04-28T20:23:05.187Z\"").unwrap(),
                Instant(UTC.timestamp(1493410985, 187000000)));
 }

--- a/query-algebrizer/src/clauses/mod.rs
+++ b/query-algebrizer/src/clauses/mod.rs
@@ -568,7 +568,7 @@ impl ConjoiningClauses {
     fn constrain_to_tx(&mut self, tx: &PatternNonValuePlace) {
         match *tx {
             PatternNonValuePlace::Placeholder => (),
-            _ => unimplemented!(),           // TODO
+            _ => unimplemented!(),           // TODO: #440.
         }
     }
 

--- a/query-algebrizer/src/clauses/pattern.rs
+++ b/query-algebrizer/src/clauses/pattern.rs
@@ -81,7 +81,7 @@ impl ConjoiningClauses {
         // Sorry for the duplication; Rust makes it a pain to abstract this.
 
         // The transaction part of a pattern must be an entid, variable, or placeholder.
-        self.constrain_to_tx(&pattern.tx);
+        self.constrain_to_tx(&pattern.tx);            // See #440.
         self.constrain_to_ref(&pattern.entity);
         self.constrain_to_ref(&pattern.attribute);
 

--- a/query-algebrizer/src/clauses/resolve.rs
+++ b/query-algebrizer/src/clauses/resolve.rs
@@ -54,6 +54,7 @@ impl ConjoiningClauses {
             SrcVar(_) |
             Constant(NonIntegerConstant::Boolean(_)) |
             Constant(NonIntegerConstant::Text(_)) |
+            Constant(NonIntegerConstant::Uuid(_)) |
             Constant(NonIntegerConstant::BigInteger(_)) => {
                 self.mark_known_empty(EmptyBecause::NonNumericArgument);
                 bail!(ErrorKind::NonNumericArgument(function.clone(), position));
@@ -80,6 +81,7 @@ impl ConjoiningClauses {
             Constant(NonIntegerConstant::Boolean(val)) => Ok(QueryValue::TypedValue(TypedValue::Boolean(val))),
             Constant(NonIntegerConstant::Float(f)) => Ok(QueryValue::TypedValue(TypedValue::Double(f))),
             Constant(NonIntegerConstant::Text(s)) => Ok(QueryValue::TypedValue(TypedValue::typed_string(s.as_str()))),
+            Constant(NonIntegerConstant::Uuid(u)) => Ok(QueryValue::TypedValue(TypedValue::Uuid(u))),
             Constant(NonIntegerConstant::BigInteger(_)) => unimplemented!(),
             SrcVar(_) => unimplemented!(),
         }

--- a/query-algebrizer/src/clauses/resolve.rs
+++ b/query-algebrizer/src/clauses/resolve.rs
@@ -55,6 +55,7 @@ impl ConjoiningClauses {
             Constant(NonIntegerConstant::Boolean(_)) |
             Constant(NonIntegerConstant::Text(_)) |
             Constant(NonIntegerConstant::Uuid(_)) |
+            Constant(NonIntegerConstant::Instant(_)) |        // Instants are covered elsewhere.
             Constant(NonIntegerConstant::BigInteger(_)) => {
                 self.mark_known_empty(EmptyBecause::NonNumericArgument);
                 bail!(ErrorKind::NonNumericArgument(function.clone(), position));
@@ -82,6 +83,7 @@ impl ConjoiningClauses {
             Constant(NonIntegerConstant::Float(f)) => Ok(QueryValue::TypedValue(TypedValue::Double(f))),
             Constant(NonIntegerConstant::Text(s)) => Ok(QueryValue::TypedValue(TypedValue::typed_string(s.as_str()))),
             Constant(NonIntegerConstant::Uuid(u)) => Ok(QueryValue::TypedValue(TypedValue::Uuid(u))),
+            Constant(NonIntegerConstant::Instant(u)) => Ok(QueryValue::TypedValue(TypedValue::Instant(u))),
             Constant(NonIntegerConstant::BigInteger(_)) => unimplemented!(),
             SrcVar(_) => unimplemented!(),
         }

--- a/query-parser/Cargo.toml
+++ b/query-parser/Cargo.toml
@@ -11,6 +11,9 @@ matches = "0.1"
 [dependencies.edn]
   path = "../edn"
 
+[dependencies.mentat_core]
+  path = "../core"
+
 [dependencies.mentat_parser_utils]
   path = "../parser-utils"
 

--- a/query-translator/src/translate.rs
+++ b/query-translator/src/translate.rs
@@ -8,8 +8,6 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
-use std::rc::Rc;
-
 use mentat_core::{
     SQLValueType,
     TypedValue,

--- a/query-translator/tests/translate.rs
+++ b/query-translator/tests/translate.rs
@@ -76,8 +76,8 @@ fn prepopulated_schema() -> Schema {
     prepopulated_typed_schema(ValueType::String)
 }
 
-fn make_arg(name: &'static str, value: &'static str) -> (String, Rc<String>) {
-    (name.to_string(), Rc::new(value.to_string()))
+fn make_arg(name: &'static str, value: &'static str) -> (String, Rc<mentat_sql::Value>) {
+    (name.to_string(), Rc::new(mentat_sql::Value::Text(value.to_string())))
 }
 
 #[test]

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -42,8 +42,10 @@ use std::rc::Rc;
 
 use edn::{
     BigInt,
+    DateTime,
     OrderedFloat,
     Uuid,
+    UTC,
 };
 
 pub use edn::{
@@ -186,6 +188,7 @@ pub enum NonIntegerConstant {
     BigInteger(BigInt),
     Float(OrderedFloat<f64>),
     Text(Rc<String>),
+    Instant(DateTime<UTC>),
     Uuid(Uuid),
 }
 
@@ -196,6 +199,7 @@ impl NonIntegerConstant {
             NonIntegerConstant::Boolean(v) => TypedValue::Boolean(v),
             NonIntegerConstant::Float(v) => TypedValue::Double(v),
             NonIntegerConstant::Text(v) => TypedValue::String(v),
+            NonIntegerConstant::Instant(v) => TypedValue::Instant(v),
             NonIntegerConstant::Uuid(v) => TypedValue::Uuid(v),
         }
     }
@@ -320,6 +324,8 @@ impl FromValue<PatternValuePlace> for PatternValuePlace {
                 Some(PatternValuePlace::Constant(NonIntegerConstant::Float(x))),
             edn::SpannedValue::BigInteger(ref x) =>
                 Some(PatternValuePlace::Constant(NonIntegerConstant::BigInteger(x.clone()))),
+            edn::SpannedValue::Instant(x) =>
+                Some(PatternValuePlace::Constant(NonIntegerConstant::Instant(x))),
             edn::SpannedValue::Text(ref x) =>
                 // TODO: intern strings. #398.
                 Some(PatternValuePlace::Constant(NonIntegerConstant::Text(Rc::new(x.clone())))),

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -40,8 +40,16 @@ use std::collections::{
 use std::fmt;
 use std::rc::Rc;
 
-use edn::{BigInt, OrderedFloat};
-pub use edn::{NamespacedKeyword, PlainSymbol};
+use edn::{
+    BigInt,
+    OrderedFloat,
+    Uuid,
+};
+
+pub use edn::{
+    NamespacedKeyword,
+    PlainSymbol,
+};
 
 use mentat_core::{
     TypedValue,
@@ -178,6 +186,7 @@ pub enum NonIntegerConstant {
     BigInteger(BigInt),
     Float(OrderedFloat<f64>),
     Text(Rc<String>),
+    Uuid(Uuid),
 }
 
 impl NonIntegerConstant {
@@ -187,6 +196,7 @@ impl NonIntegerConstant {
             NonIntegerConstant::Boolean(v) => TypedValue::Boolean(v),
             NonIntegerConstant::Float(v) => TypedValue::Double(v),
             NonIntegerConstant::Text(v) => TypedValue::String(v),
+            NonIntegerConstant::Uuid(v) => TypedValue::Uuid(v),
         }
     }
 }
@@ -313,7 +323,17 @@ impl FromValue<PatternValuePlace> for PatternValuePlace {
             edn::SpannedValue::Text(ref x) =>
                 // TODO: intern strings. #398.
                 Some(PatternValuePlace::Constant(NonIntegerConstant::Text(Rc::new(x.clone())))),
-            _ => None,
+            edn::SpannedValue::Uuid(ref u) =>
+                Some(PatternValuePlace::Constant(NonIntegerConstant::Uuid(u.clone()))),
+
+            // These don't appear in queries.
+            edn::SpannedValue::Nil => None,
+            edn::SpannedValue::NamespacedSymbol(_) => None,
+            edn::SpannedValue::Keyword(_) => None,
+            edn::SpannedValue::Map(_) => None,
+            edn::SpannedValue::List(_) => None,
+            edn::SpannedValue::Set(_) => None,
+            edn::SpannedValue::Vector(_) => None,
         }
     }
 }

--- a/sql/Cargo.toml
+++ b/sql/Cargo.toml
@@ -7,5 +7,10 @@ workspace = ".."
 error-chain = "0.8.1"
 ordered-float = "0.4.0"
 
+[dependencies.rusqlite]
+version = "0.10.1"
+# System sqlite might be very old.
+features = ["bundled", "limits"]
+
 [dependencies.mentat_core]
 path = "../core"

--- a/sql/src/lib.rs
+++ b/sql/src/lib.rs
@@ -19,7 +19,10 @@ use std::rc::Rc;
 
 use ordered_float::OrderedFloat;
 
-use mentat_core::TypedValue;
+use mentat_core::{
+    ToMicros,
+    TypedValue,
+};
 
 pub use rusqlite::types::Value;
 
@@ -140,6 +143,9 @@ impl QueryBuilder for SQLiteQueryBuilder {
             &Boolean(v) => self.push_sql(if v { "1" } else { "0" }),
             &Long(v) => self.push_sql(v.to_string().as_str()),
             &Double(OrderedFloat(v)) => self.push_sql(v.to_string().as_str()),
+            &Instant(dt) => {
+                self.push_sql(format!("{}", dt.to_micros()).as_str());      // TODO: argument instead?
+            },
             &Uuid(ref u) => {
                 // Get a byte array.
                 let bytes = u.as_bytes().clone();

--- a/sql/src/lib.rs
+++ b/sql/src/lib.rs
@@ -140,6 +140,12 @@ impl QueryBuilder for SQLiteQueryBuilder {
             &Boolean(v) => self.push_sql(if v { "1" } else { "0" }),
             &Long(v) => self.push_sql(v.to_string().as_str()),
             &Double(OrderedFloat(v)) => self.push_sql(v.to_string().as_str()),
+            &Uuid(ref u) => {
+                // Get a byte array.
+                let bytes = u.as_bytes().clone();
+                let v = Rc::new(rusqlite::types::Value::Blob(bytes.to_vec()));
+                self.push_static_arg(v);
+            },
             // These are both `Rc`. Unfortunately, we can't use that fact when
             // turning these into rusqlite Values.
             &String(ref s) => {

--- a/sql/src/lib.rs
+++ b/sql/src/lib.rs
@@ -11,6 +11,8 @@
 #[macro_use]
 extern crate error_chain;
 extern crate ordered_float;
+extern crate rusqlite;
+
 extern crate mentat_core;
 
 use std::rc::Rc;
@@ -18,6 +20,8 @@ use std::rc::Rc;
 use ordered_float::OrderedFloat;
 
 use mentat_core::TypedValue;
+
+pub use rusqlite::types::Value;
 
 error_chain! {
     types {
@@ -47,7 +51,7 @@ pub struct SQLQuery {
     pub sql: String,
 
     /// These will eventually perhaps be rusqlite `ToSql` instances.
-    pub args: Vec<(String, Rc<String>)>,
+    pub args: Vec<(String, Rc<rusqlite::types::Value>)>,
 }
 
 /// Gratefully based on Diesel's QueryBuilder trait:
@@ -88,7 +92,7 @@ pub struct SQLiteQueryBuilder {
 
     arg_prefix: String,
     arg_counter: i64,
-    args: Vec<(String, Rc<String>)>,
+    args: Vec<(String, Rc<rusqlite::types::Value>)>,
 }
 
 impl SQLiteQueryBuilder {
@@ -105,7 +109,7 @@ impl SQLiteQueryBuilder {
         }
     }
 
-    fn push_static_arg(&mut self, val: Rc<String>) {
+    fn push_static_arg(&mut self, val: Rc<rusqlite::types::Value>) {
         let arg = format!("{}{}", self.arg_prefix, self.arg_counter);
         self.arg_counter = self.arg_counter + 1;
         self.push_named_arg(arg.as_str());
@@ -136,11 +140,16 @@ impl QueryBuilder for SQLiteQueryBuilder {
             &Boolean(v) => self.push_sql(if v { "1" } else { "0" }),
             &Long(v) => self.push_sql(v.to_string().as_str()),
             &Double(OrderedFloat(v)) => self.push_sql(v.to_string().as_str()),
-
-            // These are both `Rc`. We can just clone an `Rc<String>`, but we
-            // must make a new single `String`, wrapped in an `Rc`, for keywords.
-            &String(ref s) => self.push_static_arg(s.clone()),
-            &Keyword(ref s) => self.push_static_arg(Rc::new(s.as_ref().to_string())),
+            // These are both `Rc`. Unfortunately, we can't use that fact when
+            // turning these into rusqlite Values.
+            &String(ref s) => {
+                let v = Rc::new(rusqlite::types::Value::Text(s.as_ref().clone()));
+                self.push_static_arg(v);
+            },
+            &Keyword(ref s) => {
+                let v = Rc::new(rusqlite::types::Value::Text(s.as_ref().to_string()));
+                self.push_static_arg(v);
+            },
         }
         Ok(())
     }
@@ -180,6 +189,10 @@ impl QueryBuilder for SQLiteQueryBuilder {
 mod tests {
     use super::*;
 
+    fn string_arg(s: &str) -> Rc<rusqlite::types::Value> {
+        Rc::new(rusqlite::types::Value::Text(s.to_string()))
+    }
+
     #[test]
     fn test_sql() {
         let mut s = SQLiteQueryBuilder::new();
@@ -188,14 +201,14 @@ mod tests {
         s.push_sql(" WHERE ");
         s.push_identifier("bar").unwrap();
         s.push_sql(" = ");
-        s.push_static_arg(Rc::new("frobnicate".to_string()));
+        s.push_static_arg(string_arg("frobnicate"));
         s.push_sql(" OR ");
-        s.push_static_arg(Rc::new("swoogle".to_string()));
+        s.push_static_arg(string_arg("swoogle"));
         let q = s.finish();
 
         assert_eq!(q.sql.as_str(), "SELECT `foo` WHERE `bar` = $v0 OR $v1");
         assert_eq!(q.args,
-                   vec![("$v0".to_string(), Rc::new("frobnicate".to_string())),
-                        ("$v1".to_string(), Rc::new("swoogle".to_string()))]);
+                   vec![("$v0".to_string(), string_arg("frobnicate")),
+                        ("$v1".to_string(), string_arg("swoogle"))]);
     }
 }

--- a/tests/query.rs
+++ b/tests/query.rs
@@ -46,7 +46,7 @@ fn test_rel() {
     let end = time::PreciseTime::now();
 
     // This will need to change each time we add a default ident.
-    assert_eq!(37, results.len());
+    assert_eq!(39, results.len());
 
     // Every row is a pair of a Ref and a Keyword.
     if let QueryResults::Rel(ref rel) = results {
@@ -154,7 +154,7 @@ fn test_coll() {
         .expect("Query failed");
     let end = time::PreciseTime::now();
 
-    assert_eq!(37, results.len());
+    assert_eq!(39, results.len());
 
     if let QueryResults::Coll(ref coll) = results {
         assert!(coll.iter().all(|item| item.matches_type(ValueType::Ref)));

--- a/tests/query.rs
+++ b/tests/query.rs
@@ -231,7 +231,7 @@ fn test_instants_and_uuids() {
         [:db/add "u" :foo/uuid #uuid "cf62d552-6569-4d1b-b667-04703041dfc4"]
     ]"#).unwrap();
 
-    // We don't yet support getting the tx from a pattern, so run wild.
+    // We don't yet support getting the tx from a pattern (#440), so run wild.
     let r = conn.q_once(&mut c,
                         r#"[:find [?x ?u ?when]
                             :where [?x :foo/uuid ?u]


### PR DESCRIPTION
At present this means you can't write a query comparing timestamps (to timestamps or integers!). I'll do that in a follow-up.