### PR TITLE
[tx] Forbid insertion of unknown entity IDs

### DIFF
--- a/db/src/errors.rs
+++ b/db/src/errors.rs
@@ -76,9 +76,11 @@ error_chain! {
         }
 
         /// An entid->ident mapping failed.
+        /// We also use this error if you try to transact an entid that we didn't allocate,
+        /// in part because we blow the stack in error_chain if we define a new enum!
         UnrecognizedEntid(entid: Entid) {
-            description("no ident found for entid")
-            display("no ident found for entid: {}", entid)
+            description("unrecognized or no ident found for entid")
+            display("unrecognized or no ident found for entid: {}", entid)
         }
     }
 }

--- a/db/src/internal_types.rs
+++ b/db/src/internal_types.rs
@@ -41,11 +41,15 @@ pub enum Either<L, R> {
 
 use self::Either::*;
 
-pub type EntidOr<T> = Either<Entid, T>;
+/// An entid that's either already in the store, or newly allocated to a tempid.
+#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
+pub struct KnownEntid(pub Entid);
+
+pub type KnownEntidOr<T> = Either<KnownEntid, T>;
 pub type TypedValueOr<T> = Either<TypedValue, T>;
 
 pub type TempIdHandle = Rc<TempId>;
-pub type TempIdMap = HashMap<TempIdHandle, Entid>;
+pub type TempIdMap = HashMap<TempIdHandle, KnownEntid>;
 
 pub type LookupRef = Rc<AVPair>;
 
@@ -58,9 +62,9 @@ pub enum LookupRefOrTempId {
     TempId(TempIdHandle)
 }
 
-pub type TermWithTempIdsAndLookupRefs = Term<EntidOr<LookupRefOrTempId>, TypedValueOr<LookupRefOrTempId>>;
-pub type TermWithTempIds = Term<EntidOr<TempIdHandle>, TypedValueOr<TempIdHandle>>;
-pub type TermWithoutTempIds = Term<Entid, TypedValue>;
+pub type TermWithTempIdsAndLookupRefs = Term<KnownEntidOr<LookupRefOrTempId>, TypedValueOr<LookupRefOrTempId>>;
+pub type TermWithTempIds = Term<KnownEntidOr<TempIdHandle>, TypedValueOr<TempIdHandle>>;
+pub type TermWithoutTempIds = Term<KnownEntid, TypedValue>;
 pub type Population = Vec<TermWithTempIds>;
 
 impl TermWithTempIds {
@@ -75,7 +79,7 @@ impl TermWithTempIds {
     }
 }
 
-/// Given an `EntidOr` or a `TypedValueOr`, replace any internal `LookupRef` with the entid from
+/// Given a `KnownEntidOr` or a `TypedValueOr`, replace any internal `LookupRef` with the entid from
 /// the given map.  Fail if any `LookupRef` cannot be replaced.
 ///
 /// `lift` allows to specify how the entid found is mapped into the output type.  (This could

--- a/db/src/types.rs
+++ b/db/src/types.rs
@@ -40,6 +40,10 @@ impl Partition {
         assert!(start <= next, "A partition represents a monotonic increasing sequence of entids.");
         Partition { start: start, index: next }
     }
+
+    pub fn contains_entid(&self, e: i64) -> bool {
+        (e >= self.start) && (e < self.index)
+    }
 }
 
 /// Map partition names to `Partition` instances.

--- a/db/src/upsert_resolution.rs
+++ b/db/src/upsert_resolution.rs
@@ -153,8 +153,8 @@ impl Generation {
 
         for UpsertEV(t1, a, t2) in self.upserts_ev {
             match (temp_id_map.get(&*t1), temp_id_map.get(&*t2)) {
-                (Some(&n1), Some(&n2)) => next.resolved.push(Term::AddOrRetract(OpType::Add, n1, a, TypedValue::Ref(n2))),
-                (None, Some(&n2)) => next.upserts_e.push(UpsertE(t1, a, TypedValue::Ref(n2))),
+                (Some(&n1), Some(&n2)) => next.resolved.push(Term::AddOrRetract(OpType::Add, n1, a, TypedValue::Ref(n2.0))),
+                (None, Some(&n2)) => next.upserts_e.push(UpsertE(t1, a, TypedValue::Ref(n2.0))),
                 (Some(&n1), None) => next.allocations.push(Term::AddOrRetract(OpType::Add, Left(n1), a, Right(t2))),
                 (None, None) => next.allocations.push(Term::AddOrRetract(OpType::Add, Right(t1), a, Right(t2))),
             }
@@ -168,8 +168,8 @@ impl Generation {
             match term {
                 Term::AddOrRetract(op, Right(t1), a, Right(t2)) => {
                     match (temp_id_map.get(&*t1), temp_id_map.get(&*t2)) {
-                        (Some(&n1), Some(&n2)) => next.resolved.push(Term::AddOrRetract(op, n1, a, TypedValue::Ref(n2))),
-                        (None, Some(&n2)) => next.allocations.push(Term::AddOrRetract(op, Right(t1), a, Left(TypedValue::Ref(n2)))),
+                        (Some(&n1), Some(&n2)) => next.resolved.push(Term::AddOrRetract(op, n1, a, TypedValue::Ref(n2.0))),
+                        (None, Some(&n2)) => next.allocations.push(Term::AddOrRetract(op, Right(t1), a, Left(TypedValue::Ref(n2.0)))),
                         (Some(&n1), None) => next.allocations.push(Term::AddOrRetract(op, Left(n1), a, Right(t2))),
                         (None, None) => next.allocations.push(Term::AddOrRetract(op, Right(t1), a, Right(t2))),
                     }
@@ -182,7 +182,7 @@ impl Generation {
                 },
                 Term::AddOrRetract(op, Left(e), a, Right(t)) => {
                     match temp_id_map.get(&*t) {
-                        Some(&n) => next.resolved.push(Term::AddOrRetract(op, e, a, TypedValue::Ref(n))),
+                        Some(&n) => next.resolved.push(Term::AddOrRetract(op, e, a, TypedValue::Ref(n.0))),
                         None => next.allocations.push(Term::AddOrRetract(op, Left(e), a, Right(t))),
                     }
                 },
@@ -253,7 +253,7 @@ impl Generation {
                 // TODO: consider require implementing require on temp_id_map.
                 Term::AddOrRetract(op, Right(t1), a, Right(t2)) => {
                     match (op, temp_id_map.get(&*t1), temp_id_map.get(&*t2)) {
-                        (op, Some(&n1), Some(&n2)) => Term::AddOrRetract(op, n1, a, TypedValue::Ref(n2)),
+                        (op, Some(&n1), Some(&n2)) => Term::AddOrRetract(op, n1, a, TypedValue::Ref(n2.0)),
                         (OpType::Add, _, _) => unreachable!(), // This is a coding error -- every tempid in a :db/add entity should resolve or be allocated.
                         (OpType::Retract, _, _) => bail!(ErrorKind::NotYetImplemented(format!("[:db/retract ...] entity referenced tempid that did not upsert: one of {}, {}", t1, t2))),
                     }
@@ -267,7 +267,7 @@ impl Generation {
                 },
                 Term::AddOrRetract(op, Left(e), a, Right(t)) => {
                     match (op, temp_id_map.get(&*t)) {
-                        (op, Some(&n)) => Term::AddOrRetract(op, e, a, TypedValue::Ref(n)),
+                        (op, Some(&n)) => Term::AddOrRetract(op, e, a, TypedValue::Ref(n.0)),
                         (OpType::Add, _) => unreachable!(), // This is a coding error.
                         (OpType::Retract, _) => bail!(ErrorKind::NotYetImplemented(format!("[:db/retract ...] entity referenced tempid that did not upsert: {}", t))),
                     }

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -179,6 +179,59 @@ mod tests {
     extern crate mentat_parser_utils;
 
     #[test]
+    fn test_transact_does_not_collide_existing_entids() {
+        let mut sqlite = db::new_connection("").unwrap();
+        let mut conn = Conn::connect(&mut sqlite).unwrap();
+
+        // Let's find out the next ID that'll be allocated. We're going to try to collide with it
+        // a bit later.
+        let next = conn.metadata.lock().expect("metadata")
+                       .partition_map[":db.part/user"].index;
+        let t = format!("[[:db/add {} :db.schema/attribute \"tempid\"]]", next + 1);
+
+        match conn.transact(&mut sqlite, t.as_str()).unwrap_err() {
+            Error(ErrorKind::DbError(::mentat_db::errors::ErrorKind::UnrecognizedEntid(e)), _) => {
+                assert_eq!(e, next + 1);
+            },
+            x => panic!("expected transact error, got {:?}", x),
+        }
+
+        // Transact two more tempids.
+        let t = "[[:db/add \"one\" :db.schema/attribute \"more\"]]";
+        let report = conn.transact(&mut sqlite, t)
+                         .expect("transact succeeded");
+        assert_eq!(report.tempids["more"], next);
+        assert_eq!(report.tempids["one"], next + 1);
+    }
+
+    #[test]
+    fn test_transact_does_not_collide_new_entids() {
+        let mut sqlite = db::new_connection("").unwrap();
+        let mut conn = Conn::connect(&mut sqlite).unwrap();
+
+        // Let's find out the next ID that'll be allocated. We're going to try to collide with it.
+        let next = conn.metadata.lock().expect("metadata").partition_map[":db.part/user"].index;
+
+        // If this were to be resolved, we'd get [:db/add 65537 :db.schema/attribute 65537], but
+        // we should reject this, because the first ID was provided by the user!
+        let t = format!("[[:db/add {} :db.schema/attribute \"tempid\"]]", next);
+
+        match conn.transact(&mut sqlite, t.as_str()).unwrap_err() {
+            Error(ErrorKind::DbError(::mentat_db::errors::ErrorKind::UnrecognizedEntid(e)), _) => {
+                // All this, despite this being the ID we were about to allocate!
+                assert_eq!(e, next);
+            },
+            x => panic!("expected transact error, got {:?}", x),
+        }
+
+        // And if we subsequently transact in a way that allocates one ID, we _will_ use that one.
+        let t = "[[:db/add 10 :db.schema/attribute \"temp\"]]";
+        let report = conn.transact(&mut sqlite, t)
+                         .expect("transact succeeded");
+        assert_eq!(report.tempids["temp"], next);
+    }
+
+    #[test]
     fn test_transact_errors() {
         let mut sqlite = db::new_connection("").unwrap();
         let mut conn = Conn::connect(&mut sqlite).unwrap();


### PR DESCRIPTION
The Datomic docs state the following:

>  There are three ways to sepcify an entity id:
> - a temporary id for a new entity being added to the database
> - an existing id for an entity that's already in the database
> - an identifier for an entity that's already in the database

Note that _not_ mentioned is "by making up a new entity ID".

The problem with simply making up a new entity ID is that it'll collide with tempid allocations, either within a transact itself, or with a later tempid allocation colliding with an existing entity.

I've written a couple of failing tests for this. I believe the most straightforward and robust solution is for non-syncing code to simply be forbidden from transacting new raw entity IDs: it should use upserting or tempids to define new entities.

A simple and cheap check is to ensure that every entid in transact input is within the used part ranges. A more thorough solution would be to maintain a set of every mentioned entity ID. We might be doing this anyway for syncing.