### PR TITLE
Begin moving web server to a separate crate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,7 @@ rustc_version = "0.1.7"
 
 [dependencies]
 chrono = "0.3"
-clap = "2.23"
 error-chain = "0.8.1"
-nickel = "0.9.0"
 time = "0.1"
 
 [dependencies.rusqlite]

--- a/tools/mentatweb/src/main.rs
+++ b/tools/mentatweb/src/main.rs
@@ -9,16 +9,18 @@
 // specific language governing permissions and limitations under the License.
 
 extern crate clap;
-#[macro_use] extern crate nickel;
 
-use nickel::{Nickel, HttpRouter};
+#[macro_use]
+extern crate nickel;
 
 extern crate mentat;
 
-use clap::{App, Arg, SubCommand, AppSettings};
-
 use std::u16;
 use std::str::FromStr;
+
+use clap::{App, Arg, SubCommand, AppSettings};
+
+use nickel::{Nickel, HttpRouter};
 
 fn main() {
     let app = App::new("Mentat").setting(AppSettings::ArgRequiredElseHelp);


### PR DESCRIPTION
This doesn't yet introduce a working Cargo.toml for 'mentatweb', but it
does allow RLS to build correctly without errors, and it reduces the
core library's dependency space, which is more important in the short
term.