### PR TITLE
Send queries and transactions to mentat and output the results

### DIFF
--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -43,7 +43,7 @@ mod entids;
 pub mod errors;
 mod metadata;
 mod schema;
-mod types;
+pub mod types;
 mod internal_types;
 mod upsert_resolution;
 mod tx;

--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -34,3 +34,12 @@ path = "../../parser-utils"
 
 [dependencies.edn]
 path = "../../edn"
+
+[dependencies.mentat_query]
+path = "../../query"
+
+[dependencies.mentat_core]
+path = "../../core"
+
+[dependencies.mentat_db]
+path = "../../db"

--- a/tools/cli/src/mentat_cli/command_parser.rs
+++ b/tools/cli/src/mentat_cli/command_parser.rs
@@ -68,6 +68,26 @@ impl Command {
             &Command::Close => true
         }
     }
+
+    pub fn output(&self) -> String {
+        match self {
+            &Command::Query(ref args) => {
+                format!(".{} {}", QUERY_COMMAND, args)
+            },
+            &Command::Transact(ref args) => {
+                format!(".{} {}", TRANSACT_COMMAND, args)
+            },
+            &Command::Help(ref args) => {
+                format!(".{} {:?}", HELP_COMMAND, args)
+            },
+            &Command::Open(ref args) => {
+                format!(".{} {}", OPEN_COMMAND, args)
+            }
+            &Command::Close => {
+                format!(".{}", CLOSE_COMMAND)
+            },
+        }
+    }
 }
 
 pub fn command(s: &str) -> Result<Command, cli::Error> {

--- a/tools/cli/src/mentat_cli/command_parser.rs
+++ b/tools/cli/src/mentat_cli/command_parser.rs
@@ -72,10 +72,10 @@ impl Command {
     pub fn output(&self) -> String {
         match self {
             &Command::Query(ref args) => {
-                format!(".{} {}", QUERY_COMMAND, args)
+                format!(".{} {}", LONG_QUERY_COMMAND, args)
             },
             &Command::Transact(ref args) => {
-                format!(".{} {}", TRANSACT_COMMAND, args)
+                format!(".{} {}", LONG_TRANSACT_COMMAND, args)
             },
             &Command::Help(ref args) => {
                 format!(".{} {:?}", HELP_COMMAND, args)
@@ -135,13 +135,13 @@ pub fn command(s: &str) -> Result<Command, cli::Error> {
     let query_parser = try(string(LONG_QUERY_COMMAND)).or(try(string(SHORT_QUERY_COMMAND)))
                         .with(edn_arg_parser())
                         .map(|x| {
-                            Ok(Command::Query(x.into_iter().collect()))
+                            Ok(Command::Query(x))
                         });
 
     let transact_parser = try(string(LONG_TRANSACT_COMMAND)).or(try(string(SHORT_TRANSACT_COMMAND)))
                     .with(edn_arg_parser())
                     .map( |x| {
-                        Ok(Command::Transact(x.into_iter().collect()))
+                        Ok(Command::Transact(x))
                     });
 
     spaces()

--- a/tools/cli/src/mentat_cli/command_parser.rs
+++ b/tools/cli/src/mentat_cli/command_parser.rs
@@ -115,13 +115,13 @@ pub fn command(s: &str) -> Result<Command, cli::Error> {
     let query_parser = try(string(LONG_QUERY_COMMAND)).or(try(string(SHORT_QUERY_COMMAND)))
                         .with(edn_arg_parser())
                         .map(|x| {
-                            Ok(Command::Query(x))
+                            Ok(Command::Query(x.into_iter().collect()))
                         });
 
     let transact_parser = try(string(LONG_TRANSACT_COMMAND)).or(try(string(SHORT_TRANSACT_COMMAND)))
                     .with(edn_arg_parser())
                     .map( |x| {
-                        Ok(Command::Transact(x))
+                        Ok(Command::Transact(x.into_iter().collect()))
                     });
 
     spaces()

--- a/tools/cli/src/mentat_cli/input.rs
+++ b/tools/cli/src/mentat_cli/input.rs
@@ -109,6 +109,9 @@ impl InputReader {
         match cmd {
             Command::Query(_) |
             Command::Transact(_) if !cmd.is_complete() => {
+                // a query or transact is complete if it contains a valid edn.
+                // if the command is not complete, ask for more from the repl and remember
+                // which type of command we've found here.
                 self.in_process_cmd = Some(cmd);
                 Ok(More)
             },

--- a/tools/cli/src/mentat_cli/lib.rs
+++ b/tools/cli/src/mentat_cli/lib.rs
@@ -42,6 +42,8 @@ pub fn run() -> i32 {
 
     opts.optopt("d", "", "The path to a database to open", "DATABASE");
     opts.optflag("h", "help", "Print this help message and exit");
+    opts.optopt("q", "query", "Execute a query on startup. Queries are executed after any transacts.", "QUERY");
+    opts.optopt("t", "transact", "Execute a transact on startup. Transacts are executed before queries.", "TRANSACT");
     opts.optflag("v", "version", "Print version and exit");
 
     let matches = match opts.parse(&args[1..]) {
@@ -64,9 +66,23 @@ pub fn run() -> i32 {
 
     let db_name = matches.opt_str("d");
 
+    let transacts = matches.opt_strs("t");
+    let queries = matches.opt_strs("q");
+
+    let mut cmds = Vec::with_capacity(transacts.len() + queries.len());
+
+    for transact in transacts {
+        cmds.push(command_parser::Command::Transact(transact));
+    }
+    for query in queries {
+        cmds.push(command_parser::Command::Query(query));
+    }
+
+
     let repl = repl::Repl::new(db_name);
     if repl.is_ok() {
-        repl.unwrap().run();
+        repl.unwrap().run(Some(cmds));
+
     } else {
         println!("{}", repl.err().unwrap());
     }

--- a/tools/cli/src/mentat_cli/lib.rs
+++ b/tools/cli/src/mentat_cli/lib.rs
@@ -22,6 +22,9 @@ extern crate rusqlite;
 
 extern crate mentat;
 extern crate edn;
+extern crate mentat_query;
+extern crate mentat_core;
+extern crate mentat_db;
 
 use getopts::Options;
 

--- a/tools/cli/src/mentat_cli/repl.rs
+++ b/tools/cli/src/mentat_cli/repl.rs
@@ -17,10 +17,10 @@ use command_parser::{
     Command, 
     HELP_COMMAND, 
     OPEN_COMMAND,
-    QUERY_COMMAND,
-    ALT_QUERY_COMMAND,
-    TRANSACT_COMMAND,
-    ALT_TRANSACT_COMMAND,
+    LONG_QUERY_COMMAND,
+    SHORT_QUERY_COMMAND,
+    LONG_TRANSACT_COMMAND,
+    SHORT_TRANSACT_COMMAND,
 };
 use input::InputReader;
 use input::InputResult::{
@@ -39,10 +39,10 @@ lazy_static! {
         let mut map = HashMap::new();
         map.insert(HELP_COMMAND, "Show help for commands.");
         map.insert(OPEN_COMMAND, "Open a database at path.");
-        map.insert(QUERY_COMMAND, "Execute a query against the current open database.");
-        map.insert(ALT_QUERY_COMMAND, "Shortcut for `.query`. Execute a query against the current open database.");
-        map.insert(TRANSACT_COMMAND, "Execute a transact against the current open database.");
-        map.insert(ALT_TRANSACT_COMMAND, "Shortcut for `.transact`. Execute a transact against the current open database.");
+        map.insert(LONG_QUERY_COMMAND, "Execute a query against the current open database.");
+        map.insert(SHORT_QUERY_COMMAND, "Shortcut for `.query`. Execute a query against the current open database.");
+        map.insert(LONG_TRANSACT_COMMAND, "Execute a transact against the current open database.");
+        map.insert(SHORT_TRANSACT_COMMAND, "Shortcut for `.transact`. Execute a transact against the current open database.");
         map
     };
 }

--- a/tools/cli/src/mentat_cli/repl.rs
+++ b/tools/cli/src/mentat_cli/repl.rs
@@ -16,7 +16,11 @@ use mentat_core::TypedValue;
 use command_parser::{
     Command, 
     HELP_COMMAND, 
-    OPEN_COMMAND
+    OPEN_COMMAND,
+    QUERY_COMMAND,
+    ALT_QUERY_COMMAND,
+    TRANSACT_COMMAND,
+    ALT_TRANSACT_COMMAND
 };
 use input::InputReader;
 use input::InputResult::{
@@ -35,6 +39,10 @@ lazy_static! {
         let mut map = HashMap::new();
         map.insert(HELP_COMMAND, "Show help for commands.");
         map.insert(OPEN_COMMAND, "Open a database at path.");
+        map.insert(QUERY_COMMAND, "Execute a query against the current open database.");
+        map.insert(ALT_QUERY_COMMAND, "Shortcut for `.query`. Execute a query against the current open database.");
+        map.insert(TRANSACT_COMMAND, "Execute a transact against the current open database.");
+        map.insert(ALT_TRANSACT_COMMAND, "Shortcut for `.transact`. Execute a transact against the current open database.");
         map
     };
 }

--- a/tools/cli/src/mentat_cli/repl.rs
+++ b/tools/cli/src/mentat_cli/repl.rs
@@ -54,9 +54,8 @@ pub struct Repl {
 
 impl Repl {
     /// Constructs a new `Repl`.
-    pub fn new(db_name: Option<String>) -> Result<Repl, String> {
-        let store = try!(Store::new(db_name.clone()).map_err(|e| e.to_string()));
-        println!("Database {:?} opened", db_output_name(&db_name.unwrap_or("".to_string())));
+    pub fn new() -> Result<Repl, String> {
+        let store = Store::new(None).map_err(|e| e.to_string())?;
         Ok(Repl{
             store: store,
         })
@@ -68,6 +67,7 @@ impl Repl {
 
         if let Some(cmds) = startup_commands {
             for command in cmds.iter() {
+                println!("{}", command.output());
                 self.handle_command(command.clone());
             }
         }

--- a/tools/cli/src/mentat_cli/store.rs
+++ b/tools/cli/src/mentat_cli/store.rs
@@ -9,13 +9,16 @@
 // specific language governing permissions and limitations under the License.
 
 use rusqlite;
+
+use errors as cli;
+
 use mentat::{
     new_connection,
 };
+use mentat::query::QueryResults;
 
 use mentat::conn::Conn;
-
-use errors as cli;
+use mentat_db::types::TxReport;
 
 pub struct Store {
     handle: rusqlite::Connection,
@@ -48,4 +51,11 @@ impl Store {
         self.open(None)
     }
 
+    pub fn query(&self, query: String) -> Result<QueryResults, cli::Error> {
+        Ok(try!(self.conn.q_once(&self.handle, &query, None)))
+    }
+
+    pub fn transact(&mut self, transaction: String) -> Result<TxReport, cli::Error> {
+        Ok(try!(self.conn.transact(&mut self.handle, &transaction)))
+    }
 }


### PR DESCRIPTION
move outputting query and transaction results out of store and into repl

https://github.com/mozilla/mentat/issues/454 & https://github.com/mozilla/mentat/issues/455

depends on https://github.com/mozilla/mentat/pull/465