### PR TITLE
Handle :attribute/_reverse in transactor. Fixes #187.

### DIFF
--- a/db/src/db.rs
+++ b/db/src/db.rs
@@ -2170,6 +2170,27 @@ mod tests {
                         "{\"s\" 65542
                           \"t\" 65543}");
 
+        // Check that we can use the same attribute in both forward and backward form in the same
+        // transaction.
+        let report = assert_transact!(conn, "[[:db/add 888 :test/dangling 889]
+                                              [:db/add 888 :test/_dangling 889]]");
+        assert_matches!(conn.last_transaction(),
+                        "[[888 :test/dangling 889 ?tx true]
+                          [889 :test/dangling 888 ?tx true]
+                          [?tx :db/txInstant ?ms ?tx true]]");
+        assert_matches!(tempids(&report),
+                        "{}");
+
+        // Check that we can use the same attribute in both forward and backward form in the same
+        // transaction in map notation.
+        let report = assert_transact!(conn, "[{:db/id 998 :test/dangling 999 :test/_dangling 999}]");
+        assert_matches!(conn.last_transaction(),
+                        "[[998 :test/dangling 999 ?tx true]
+                          [999 :test/dangling 998 ?tx true]
+                          [?tx :db/txInstant ?ms ?tx true]]");
+        assert_matches!(tempids(&report),
+                        "{}");
+
         // Verify that we can't explode direct reverse notation with nested value maps.
         assert_transact!(conn,
                          "[[:db/add \"t\" :test/_dangling {:test/many 11}]]",

--- a/db/src/db.rs
+++ b/db/src/db.rs
@@ -2087,4 +2087,127 @@ mod tests {
         // dangling, if we give a :db/id explicitly.
         assert_transact!(conn, "[{:test/dangling {:db/id \"t\" :test/many 11}}]");
     }
+
+    #[test]
+    fn test_explode_reversed_notation() {
+        let mut conn = TestConn::default();
+
+        // Start by installing a few attributes.
+        assert_transact!(conn, "[[:db/add 111 :db/ident :test/many]
+                                 [:db/add 111 :db/valueType :db.type/long]
+                                 [:db/add 111 :db/cardinality :db.cardinality/many]
+                                 [:db/add 222 :db/ident :test/component]
+                                 [:db/add 222 :db/isComponent true]
+                                 [:db/add 222 :db/valueType :db.type/ref]
+                                 [:db/add 333 :db/ident :test/unique]
+                                 [:db/add 333 :db/unique :db.unique/identity]
+                                 [:db/add 333 :db/index true]
+                                 [:db/add 333 :db/valueType :db.type/long]
+                                 [:db/add 444 :db/ident :test/dangling]
+                                 [:db/add 444 :db/valueType :db.type/ref]]");
+
+        // Check that we can explode direct reversed notation, entids.
+        let report = assert_transact!(conn, "[[:db/add 100 :test/_dangling 200]]");
+        assert_matches!(conn.last_transaction(),
+                        "[[200 :test/dangling 100 ?tx true]
+                          [?tx :db/txInstant ?ms ?tx true]]");
+        assert_matches!(tempids(&report),
+                        "{}");
+
+        // Check that we can explode direct reversed notation, idents.
+        let report = assert_transact!(conn, "[[:db/add :test/many :test/_dangling :test/unique]]");
+        assert_matches!(conn.last_transaction(),
+                        "[[333 :test/dangling :test/many ?tx true]
+                          [?tx :db/txInstant ?ms ?tx true]]");
+        assert_matches!(tempids(&report),
+                        "{}");
+
+        // Check that we can explode direct reversed notation, tempids.
+        let report = assert_transact!(conn, "[[:db/add \"s\" :test/_dangling \"t\"]]");
+        assert_matches!(conn.last_transaction(),
+                        "[[65537 :test/dangling 65536 ?tx true]
+                          [?tx :db/txInstant ?ms ?tx true]]");
+        // This is implementation specific, but it should be deterministic.
+        assert_matches!(tempids(&report),
+                        "{\"s\" 65536
+                          \"t\" 65537}");
+
+        // Check that we can explode reversed notation in map notation without :db/id.
+        let report = assert_transact!(conn, "[{:test/_dangling 501}
+                                              {:test/_dangling :test/many}
+                                              {:test/_dangling \"t\"}]");
+        assert_matches!(conn.last_transaction(),
+                        "[[111 :test/dangling ?e1 ?tx true]
+                          [501 :test/dangling ?e2 ?tx true]
+                          [65538 :test/dangling ?e3 ?tx true]
+                          [?tx :db/txInstant ?ms ?tx true]]");
+        assert_matches!(tempids(&report),
+                        "{\"t\" 65538}");
+
+        // Check that we can explode reversed notation in map notation with :db/id, entid.
+        let report = assert_transact!(conn, "[{:db/id 600 :test/_dangling 601}]");
+        assert_matches!(conn.last_transaction(),
+                        "[[601 :test/dangling 600 ?tx true]
+                          [?tx :db/txInstant ?ms ?tx true]]");
+        assert_matches!(tempids(&report),
+                        "{}");
+
+        // Check that we can explode reversed notation in map notation with :db/id, ident.
+        let report = assert_transact!(conn, "[{:db/id :test/component :test/_dangling :test/component}]");
+        assert_matches!(conn.last_transaction(),
+                        "[[222 :test/dangling :test/component ?tx true]
+                          [?tx :db/txInstant ?ms ?tx true]]");
+        assert_matches!(tempids(&report),
+                        "{}");
+
+        // Check that we can explode reversed notation in map notation with :db/id, tempid.
+        let report = assert_transact!(conn, "[{:db/id \"s\" :test/_dangling \"t\"}]");
+        assert_matches!(conn.last_transaction(),
+                        "[[65543 :test/dangling 65542 ?tx true]
+                          [?tx :db/txInstant ?ms ?tx true]]");
+        // This is implementation specific, but it should be deterministic.
+        assert_matches!(tempids(&report),
+                        "{\"s\" 65542
+                          \"t\" 65543}");
+
+        // Verify that we can't explode direct reverse notation with nested value maps.
+        assert_transact!(conn,
+                         "[[:db/add \"t\" :test/_dangling {:test/many 11}]]",
+                         Err("not yet implemented: Cannot explode map notation value in :attr/_reversed notation for attribute 444"));
+
+        // Verify that we can't explode reverse notation in map notation with nested value maps.
+        assert_transact!(conn,
+                         "[{:test/_dangling {:test/many 11}}]",
+                         Err("not yet implemented: Cannot explode map notation value in :attr/_reversed notation for attribute 444"));
+
+        // Verify that we can't explode direct reverse notation with nested value vectors.
+        assert_transact!(conn,
+                         "[[:db/add \"t\" :test/_dangling [:test/many]]]",
+                         Err("not yet implemented: Cannot explode vector value in :attr/_reversed notation for attribute 444"));
+
+        // Verify that we can't explode reverse notation in map notation with nested value vectors.
+        assert_transact!(conn,
+                         "[{:test/_dangling [:test/many]}]",
+                         Err("not yet implemented: Cannot explode vector value in :attr/_reversed notation for attribute 444"));
+
+        // Verify that we can't use reverse notation with non-:db.type/ref attributes.
+        assert_transact!(conn,
+                         "[{:test/_unique 500}]",
+                         Err("not yet implemented: Cannot use :attr/_reversed notation for attribute 333 that is not :db/valueType :db.type/ref"));
+
+        // Verify that we can't use reverse notation with unrecognized attributes.
+        assert_transact!(conn,
+                         "[{:test/_unknown 500}]",
+                         Err("no entid found for ident: :test/unknown")); // TODO: make this error reference the original :test/_unknown.
+
+        // Verify that we can't use reverse notation with bad value types: here, an unknown keyword
+        // that can't be coerced to a ref.
+        assert_transact!(conn,
+                         "[{:test/_dangling :test/unknown}]",
+                         Err("no entid found for ident: :test/unknown"));
+        // And here, a float.
+        assert_transact!(conn,
+                         "[{:test/_dangling 1.23}]",
+                         Err("EDN value \'1.23\' is not the expected Mentat value type Ref"));
+    }
 }

--- a/db/src/internal_types.rs
+++ b/db/src/internal_types.rs
@@ -39,6 +39,27 @@ pub enum Either<L, R> {
     Right(R),
 }
 
+// Cribbed from https://github.com/bluss/either/blob/f793721f3fdeb694f009e731b23a2858286bc0d6/src/lib.rs#L219-L259.
+impl<L, R> Either<L, R> {
+    pub fn map_left<F, M>(self, f: F) -> Either<M, R>
+        where F: FnOnce(L) -> M
+    {
+        match self {
+            Left(l) => Left(f(l)),
+            Right(r) => Right(r),
+        }
+    }
+
+    pub fn map_right<F, S>(self, f: F) -> Either<L, S>
+        where F: FnOnce(R) -> S
+    {
+        match self {
+            Left(l) => Left(l),
+            Right(r) => Right(f(r)),
+        }
+    }
+}
+
 use self::Either::*;
 
 pub type EntidOr<T> = Either<Entid, T>;

--- a/db/src/tx.rs
+++ b/db/src/tx.rs
@@ -205,7 +205,7 @@ impl<'conn, 'a> Tx<'conn, 'a> {
                 bail!(ErrorKind::NotYetImplemented(format!("Cannot resolve (lookup-ref {} {}) with attribute that is not :db/unique", lr_a, lookup_ref.v)))
             }
 
-            let lr_typed_value: TypedValue = self.schema.to_typed_value(&lookup_ref.v, &lr_attribute)?;
+            let lr_typed_value: TypedValue = self.schema.to_typed_value(&lookup_ref.v, lr_attribute.value_type)?;
             Ok(lookup_refs.intern((lr_a, lr_typed_value)))
         };
 
@@ -260,7 +260,7 @@ impl<'conn, 'a> Tx<'conn, 'a> {
                                 // Here is where we do schema-aware typechecking: we either assert that
                                 // the given value is in the attribute's value set, or (in limited
                                 // cases) coerce the value into the attribute's value set.
-                                let typed_value: TypedValue = self.schema.to_typed_value(&v.without_spans(), &attribute)?;
+                                let typed_value: TypedValue = self.schema.to_typed_value(&v.without_spans(), attribute.value_type)?;
                                 Either::Left(typed_value)
                             }
                         },

--- a/db/src/tx.rs
+++ b/db/src/tx.rs
@@ -194,7 +194,7 @@ impl<'conn, 'a> Tx<'conn, 'a> {
         let mut temp_ids: intern_set::InternSet<TempId> = intern_set::InternSet::new();
         let mut lookup_refs: intern_set::InternSet<AVPair> = intern_set::InternSet::new();
 
-        let intern_lookup_ref = |lookup_refs: &mut intern_set::InternSet<AVPair>, lookup_ref: entmod::LookupRef| -> Result<LookupRef> {
+        let intern_lookup_ref = |lookup_refs: &mut intern_set::InternSet<AVPair>, lookup_ref: &entmod::LookupRef| -> Result<LookupRef> {
             let lr_a: i64 = match lookup_ref.a {
                 entmod::Entid::Entid(ref a) => *a,
                 entmod::Entid::Ident(ref a) => self.schema.require_entid(&a)?,
@@ -265,7 +265,7 @@ impl<'conn, 'a> Tx<'conn, 'a> {
                             }
                         },
 
-                        entmod::AtomOrLookupRefOrVectorOrMapNotation::LookupRef(lookup_ref) => {
+                        entmod::AtomOrLookupRefOrVectorOrMapNotation::LookupRef(ref lookup_ref) => {
                             if attribute.value_type != ValueType::Ref {
                                 bail!(ErrorKind::NotYetImplemented(format!("Cannot resolve value lookup ref for attribute {} that is not :db/valueType :db.type/ref", a)))
                             }
@@ -360,7 +360,7 @@ impl<'conn, 'a> Tx<'conn, 'a> {
                                     Either::Right(LookupRefOrTempId::TempId(temp_ids.intern(e)))
                                 },
 
-                                entmod::EntidOrLookupRefOrTempId::LookupRef(lookup_ref) => {
+                                entmod::EntidOrLookupRefOrTempId::LookupRef(ref lookup_ref) => {
                                     Either::Right(LookupRefOrTempId::LookupRef(intern_lookup_ref(&mut lookup_refs, lookup_ref)?))
                                 },
                             }
@@ -380,7 +380,7 @@ impl<'conn, 'a> Tx<'conn, 'a> {
                             Either::Right(LookupRefOrTempId::TempId(temp_ids.intern(e)))
                         },
 
-                        entmod::EntidOrLookupRefOrTempId::LookupRef(lookup_ref) => {
+                        entmod::EntidOrLookupRefOrTempId::LookupRef(ref lookup_ref) => {
                             Either::Right(LookupRefOrTempId::LookupRef(intern_lookup_ref(&mut lookup_refs, lookup_ref)?))
                         },
                     };
@@ -395,7 +395,7 @@ impl<'conn, 'a> Tx<'conn, 'a> {
     /// Pipeline stage 2: rewrite `Term` instances with lookup refs into `Term` instances without
     /// lookup refs.
     ///
-    /// The `Term` instances produce share interned TempId handles and have no LookupRef references.
+    /// The `Term` instances produced share interned TempId handles and have no LookupRef references.
     fn resolve_lookup_refs<I>(&self, lookup_ref_map: &AVMap, terms: I) -> Result<Vec<TermWithTempIds>> where I: IntoIterator<Item=TermWithTempIdsAndLookupRefs> {
         terms.into_iter().map(|term: TermWithTempIdsAndLookupRefs| -> Result<TermWithTempIds> {
             match term {

--- a/edn/src/symbols.rs
+++ b/edn/src/symbols.rs
@@ -214,6 +214,30 @@ impl NamespacedKeyword {
             namespace: self.namespace.clone(),
         }
     }
+
+    /// If this `NamespacedKeyword` is 'backward' (see `symbols::NamespacedKeyword::is_backward`),
+    /// return `Some('forward name')`; otherwise, return `None`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use edn::symbols::NamespacedKeyword;
+    /// let nsk = NamespacedKeyword::new("foo", "bar");
+    /// assert_eq!(None, nsk.unreversed());
+    ///
+    /// let reversed = nsk.to_reversed();
+    /// assert_eq!(Some(nsk), reversed.unreversed());
+    /// ```
+    pub fn unreversed(&self) -> Option<NamespacedKeyword> {
+        if self.is_backward() {
+            Some(NamespacedKeyword {
+                name: self.name[1..].to_string(),
+                namespace: self.namespace.clone(),
+            })
+        } else {
+            None
+        }
+    }
 }
 
 //

--- a/edn/src/types.rs
+++ b/edn/src/types.rs
@@ -594,7 +594,6 @@ mod test {
 
     use chrono::{
         DateTime,
-        TimeZone,
         UTC,
     };
     use num::BigInt;

--- a/parser-utils/src/value_and_span.rs
+++ b/parser-utils/src/value_and_span.rs
@@ -452,6 +452,26 @@ pub fn namespaced_keyword<'a>() -> Expected<FnParser<Stream<'a>, fn(Stream<'a>) 
     parser(namespaced_keyword_ as fn(Stream<'a>) -> ParseResult<&'a edn::NamespacedKeyword, Stream<'a>>).expected("namespaced_keyword")
 }
 
+pub fn forward_keyword_<'a>(input: Stream<'a>) -> ParseResult<&'a edn::NamespacedKeyword, Stream<'a>> {
+    satisfy_map(|v: &'a edn::ValueAndSpan| v.inner.as_namespaced_keyword().and_then(|k| if k.is_forward() { Some(k) } else { None }))
+        .parse_lazy(input)
+        .into()
+}
+
+pub fn forward_keyword<'a>() -> Expected<FnParser<Stream<'a>, fn(Stream<'a>) -> ParseResult<&'a edn::NamespacedKeyword, Stream<'a>>>> {
+    parser(forward_keyword_ as fn(Stream<'a>) -> ParseResult<&'a edn::NamespacedKeyword, Stream<'a>>).expected("forward_keyword")
+}
+
+pub fn backward_keyword_<'a>(input: Stream<'a>) -> ParseResult<&'a edn::NamespacedKeyword, Stream<'a>> {
+    satisfy_map(|v: &'a edn::ValueAndSpan| v.inner.as_namespaced_keyword().and_then(|k| if k.is_backward() { Some(k) } else { None }))
+        .parse_lazy(input)
+        .into()
+}
+
+pub fn backward_keyword<'a>() -> Expected<FnParser<Stream<'a>, fn(Stream<'a>) -> ParseResult<&'a edn::NamespacedKeyword, Stream<'a>>>> {
+    parser(backward_keyword_ as fn(Stream<'a>) -> ParseResult<&'a edn::NamespacedKeyword, Stream<'a>>).expected("backward_keyword")
+}
+
 /// Generate a `satisfy` expression that matches a `PlainSymbol` value with the given name.
 ///
 /// We do this rather than using `combine::token` so that we don't need to allocate a new `String`

--- a/tx-parser/tests/parser.rs
+++ b/tx-parser/tests/parser.rs
@@ -85,4 +85,22 @@ fn test_entities() {
                ]);
 }
 
+#[test]
+fn test_reverse_notation_illegal_nested_values() {
+    // Verify that we refuse to parse direct reverse notation with nested value maps or vectors.
+
+    let input = "[[:db/add 100 :test/_dangling {:test/many 13}]]";
+    let edn = parse::value(input).expect("to parse test input");
+    let result = Tx::parse(&edn);
+    // TODO: it would be much better to assert details about the error (here and below), but right
+    // now the error message isn't clear that the given value isn't valid for the backward attribute
+    // :test/_dangling.
+    assert!(result.is_err());
+
+    let input = "[[:db/add 100 :test/_dangling [:test/many 13]]]";
+    let edn = parse::value(input).expect("to parse test input");
+    let result = Tx::parse(&edn);
+    assert!(result.is_err());
+}
+
 // TODO: test error handling in select cases.

--- a/tx/src/entities.rs
+++ b/tx/src/entities.rs
@@ -56,6 +56,22 @@ pub enum Entid {
     Ident(NamespacedKeyword),
 }
 
+impl Entid {
+    pub fn is_backward(&self) -> bool {
+        match self {
+            &Entid::Entid(_) => false,
+            &Entid::Ident(ref a) => a.is_backward(),
+        }
+    }
+
+    pub fn to_reversed(&self) -> Option<Entid> {
+        match self {
+            &Entid::Entid(_) => None,
+            &Entid::Ident(ref a) => Some(Entid::Ident(a.to_reversed())),
+        }
+    }
+}
+
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialOrd, PartialEq)]
 pub struct LookupRef {
     pub a: Entid,

--- a/tx/src/entities.rs
+++ b/tx/src/entities.rs
@@ -70,6 +70,13 @@ impl Entid {
             &Entid::Ident(ref a) => Some(Entid::Ident(a.to_reversed())),
         }
     }
+
+    pub fn unreversed(&self) -> Option<Entid> {
+        match self {
+            &Entid::Entid(_) => None,
+            &Entid::Ident(ref a) => a.unreversed().map(Entid::Ident),
+        }
+    }
 }
 
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialOrd, PartialEq)]


### PR DESCRIPTION
See commit comments.  I've intentionally not accepted reverse notation with nested vectors and maps; it's difficult to handle with our current parse-then-apply model.  I think it's a reasonable trade-off, and the error message is clear.