### PR TITLE
Support inequality predicates for instants

### DIFF
--- a/query-algebrizer/src/clauses/convert.rs
+++ b/query-algebrizer/src/clauses/convert.rs
@@ -89,10 +89,10 @@ impl ValueTypes for FnArg {
                 &FnArg::SrcVar(_) => bail!(ErrorKind::UnsupportedArgument),
 
                 // These are all straightforward.
-                &FnArg::Constant(NonIntegerConstant::Boolean(x)) => ValueTypeSet::of_one(ValueType::Boolean),
-                &FnArg::Constant(NonIntegerConstant::Instant(x)) => ValueTypeSet::of_one(ValueType::Instant),
-                &FnArg::Constant(NonIntegerConstant::Uuid(x)) => ValueTypeSet::of_one(ValueType::Uuid),
-                &FnArg::Constant(NonIntegerConstant::Float(x)) => ValueTypeSet::of_one(ValueType::Double),
+                &FnArg::Constant(NonIntegerConstant::Boolean(_)) => ValueTypeSet::of_one(ValueType::Boolean),
+                &FnArg::Constant(NonIntegerConstant::Instant(_)) => ValueTypeSet::of_one(ValueType::Instant),
+                &FnArg::Constant(NonIntegerConstant::Uuid(_)) => ValueTypeSet::of_one(ValueType::Uuid),
+                &FnArg::Constant(NonIntegerConstant::Float(_)) => ValueTypeSet::of_one(ValueType::Double),
                 &FnArg::Constant(NonIntegerConstant::Text(_)) => ValueTypeSet::of_one(ValueType::String),
             })
     }

--- a/query-algebrizer/src/clauses/not.rs
+++ b/query-algebrizer/src/clauses/not.rs
@@ -109,7 +109,7 @@ mod testing {
         ColumnIntersection, 
         DatomsColumn, 
         DatomsTable, 
-        NumericComparison, 
+        Inequality,
         QualifiedAlias,
         QueryValue, 
         SourceAlias, 
@@ -364,8 +364,8 @@ mod testing {
         assert!(!cc.is_known_empty());
         assert_eq!(cc.wheres, ColumnIntersection(vec![
                 ColumnConstraintOrAlternation::Constraint(ColumnConstraint::Equals(d0a.clone(), age.clone())),
-                ColumnConstraintOrAlternation::Constraint(ColumnConstraint::NumericInequality {
-                    operator: NumericComparison::LessThan,
+                ColumnConstraintOrAlternation::Constraint(ColumnConstraint::Inequality {
+                    operator: Inequality::LessThan,
                     left: QueryValue::Column(d0v.clone()),
                     right: QueryValue::TypedValue(TypedValue::Long(30)),
                 }),

--- a/query-algebrizer/src/clauses/or.rs
+++ b/query-algebrizer/src/clauses/or.rs
@@ -751,7 +751,7 @@ mod testing {
         ColumnConstraint,
         DatomsColumn,
         DatomsTable,
-        NumericComparison,
+        Inequality,
         QualifiedAlias,
         QueryValue,
         SourceAlias,
@@ -960,8 +960,8 @@ mod testing {
         assert!(!cc.is_known_empty());
         assert_eq!(cc.wheres, ColumnIntersection(vec![
             ColumnConstraintOrAlternation::Constraint(ColumnConstraint::Equals(d0a.clone(), age.clone())),
-            ColumnConstraintOrAlternation::Constraint(ColumnConstraint::NumericInequality {
-                operator: NumericComparison::LessThan,
+            ColumnConstraintOrAlternation::Constraint(ColumnConstraint::Inequality {
+                operator: Inequality::LessThan,
                 left: QueryValue::Column(d0v.clone()),
                 right: QueryValue::TypedValue(TypedValue::Long(30)),
             }),

--- a/query-algebrizer/src/errors.rs
+++ b/query-algebrizer/src/errors.rs
@@ -39,6 +39,11 @@ error_chain! {
     }
 
     errors {
+        UnsupportedArgument {
+            description("unexpected FnArg")
+            display("unexpected FnArg")
+        }
+
         InputTypeDisagreement(var: PlainSymbol, declared: ValueType, provided: ValueType) {
             description("input type disagreement")
             display("value of type {} provided for var {}, expected {}", provided, var, declared)

--- a/query-algebrizer/src/lib.rs
+++ b/query-algebrizer/src/lib.rs
@@ -56,6 +56,11 @@ pub use clauses::{
     QueryInputs,
 };
 
+pub use types::{
+    EmptyBecause,
+    ValueTypeSet,
+};
+
 #[derive(Debug)]
 pub struct AlgebraicQuery {
     default_source: SrcVar,

--- a/query-algebrizer/src/types.rs
+++ b/query-algebrizer/src/types.rs
@@ -468,7 +468,12 @@ impl Debug for ColumnConstraint {
 #[derive(PartialEq, Clone)]
 pub enum EmptyBecause {
     ConflictingBindings { var: Variable, existing: TypedValue, desired: TypedValue },
+
+    // A variable is known to be of two conflicting sets of types.
     TypeMismatch { var: Variable, existing: ValueTypeSet, desired: ValueTypeSet },
+
+    // The same, but for non-variables.
+    KnownTypeMismatch { left: ValueTypeSet, right: ValueTypeSet },
     NoValidTypes(Variable),
     NonAttributeArgument,
     NonInstantArgument,
@@ -493,6 +498,10 @@ impl Debug for EmptyBecause {
             &TypeMismatch { ref var, ref existing, ref desired } => {
                 write!(f, "Type mismatch: {:?} can't be {:?}, because it's already {:?}",
                        var, desired, existing)
+            },
+            &KnownTypeMismatch { ref left, ref right } => {
+                write!(f, "Type mismatch: {:?} can't be compared to {:?}",
+                       left, right)
             },
             &NoValidTypes(ref var) => {
                 write!(f, "Type mismatch: {:?} has no valid types", var)

--- a/query-algebrizer/src/types.rs
+++ b/query-algebrizer/src/types.rs
@@ -308,6 +308,13 @@ impl Inequality {
             _    => None,
         }
     }
+
+    // The built-in inequality operators apply to Long, Double, and Instant.
+    pub fn supported_types(&self) -> ValueTypeSet {
+        let mut ts = ValueTypeSet::of_numeric_types();
+        ts.insert(ValueType::Instant);
+        ts
+    }
 }
 
 impl Debug for Inequality {
@@ -464,6 +471,7 @@ pub enum EmptyBecause {
     TypeMismatch { var: Variable, existing: ValueTypeSet, desired: ValueTypeSet },
     NoValidTypes(Variable),
     NonAttributeArgument,
+    NonInstantArgument,
     NonNumericArgument,
     NonStringFulltextValue,
     UnresolvedIdent(NamespacedKeyword),
@@ -491,6 +499,9 @@ impl Debug for EmptyBecause {
             },
             &NonAttributeArgument => {
                 write!(f, "Non-attribute argument in attribute place")
+            },
+            &NonInstantArgument => {
+                write!(f, "Non-instant argument in instant place")
             },
             &NonNumericArgument => {
                 write!(f, "Non-numeric argument in numeric place")
@@ -609,6 +620,10 @@ impl ValueTypeSet {
     /// For a set containing a single type, this will be that type.
     pub fn exemplar(&self) -> Option<ValueType> {
         self.0.iter().next()
+    }
+
+    pub fn is_subset(&self, other: &ValueTypeSet) -> bool {
+        self.0.is_subset(&other.0)
     }
 
     pub fn contains(&self, vt: ValueType) -> bool {

--- a/query-algebrizer/src/types.rs
+++ b/query-algebrizer/src/types.rs
@@ -274,10 +274,11 @@ impl From<Order> for OrderBy {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq)]
-/// Define the different numeric inequality operators that we support.
+/// Define the different inequality operators that we support.
 /// Note that we deliberately don't just use "<=" and friends as strings:
 /// Datalog and SQL don't use the same operators (e.g., `<>` and `!=`).
-pub enum NumericComparison {
+/// These are applicable to numbers and instants.
+pub enum Inequality {
     LessThan,
     LessThanOrEquals,
     GreaterThan,
@@ -285,9 +286,9 @@ pub enum NumericComparison {
     NotEquals,
 }
 
-impl NumericComparison {
+impl Inequality {
     pub fn to_sql_operator(self) -> &'static str {
-        use self::NumericComparison::*;
+        use self::Inequality::*;
         match self {
             LessThan            => "<",
             LessThanOrEquals    => "<=",
@@ -297,21 +298,21 @@ impl NumericComparison {
         }
     }
 
-    pub fn from_datalog_operator(s: &str) -> Option<NumericComparison> {
+    pub fn from_datalog_operator(s: &str) -> Option<Inequality> {
         match s {
-            "<"  => Some(NumericComparison::LessThan),
-            "<=" => Some(NumericComparison::LessThanOrEquals),
-            ">"  => Some(NumericComparison::GreaterThan),
-            ">=" => Some(NumericComparison::GreaterThanOrEquals),
-            "!=" => Some(NumericComparison::NotEquals),
+            "<"  => Some(Inequality::LessThan),
+            "<=" => Some(Inequality::LessThanOrEquals),
+            ">"  => Some(Inequality::GreaterThan),
+            ">=" => Some(Inequality::GreaterThanOrEquals),
+            "!=" => Some(Inequality::NotEquals),
             _    => None,
         }
     }
 }
 
-impl Debug for NumericComparison {
+impl Debug for Inequality {
     fn fmt(&self, f: &mut Formatter) -> ::std::fmt::Result {
-        use self::NumericComparison::*;
+        use self::Inequality::*;
         f.write_str(match self {
             &LessThan => "<",
             &LessThanOrEquals => "<=",
@@ -325,15 +326,13 @@ impl Debug for NumericComparison {
 #[derive(PartialEq, Eq)]
 pub enum ColumnConstraint {
     Equals(QualifiedAlias, QueryValue),
-    NumericInequality {
-        operator: NumericComparison,
+    Inequality {
+        operator: Inequality,
         left: QueryValue,
         right: QueryValue,
     },
     HasType(TableAlias, ValueType),
     NotExists(ComputedTable),
-    // TODO: Merge this with NumericInequality?  I expect the fine-grained information to be
-    // valuable when optimizing.
     Matches(QualifiedAlias, QueryValue),
 }
 
@@ -441,7 +440,7 @@ impl Debug for ColumnConstraint {
                 write!(f, "{:?} = {:?}", qa1, thing)
             },
 
-            &NumericInequality { operator, ref left, ref right } => {
+            &Inequality { operator, ref left, ref right } => {
                 write!(f, "{:?} {:?} {:?}", left, operator, right)
             },
 

--- a/query-algebrizer/tests/predicate.rs
+++ b/query-algebrizer/tests/predicate.rs
@@ -1,0 +1,149 @@
+// Copyright 2016 Mozilla
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+extern crate mentat_core;
+extern crate mentat_query;
+extern crate mentat_query_algebrizer;
+extern crate mentat_query_parser;
+
+use std::collections::BTreeMap;
+
+use mentat_core::{
+    Attribute,
+    Entid,
+    Schema,
+    ValueType,
+    TypedValue,
+};
+
+use mentat_query_parser::{
+    parse_find_string,
+};
+
+use mentat_query::{
+    NamespacedKeyword,
+    PlainSymbol,
+    Variable,
+};
+
+use mentat_query_algebrizer::{
+    BindingError,
+    ConjoiningClauses,
+    ComputedTable,
+    EmptyBecause,
+    Error,
+    ErrorKind,
+    QueryInputs,
+    ValueTypeSet,
+    algebrize,
+    algebrize_with_inputs,
+};
+
+// These are helpers that tests use to build Schema instances.
+#[cfg(test)]
+fn associate_ident(schema: &mut Schema, i: NamespacedKeyword, e: Entid) {
+    schema.entid_map.insert(e, i.clone());
+    schema.ident_map.insert(i.clone(), e);
+}
+
+#[cfg(test)]
+fn add_attribute(schema: &mut Schema, e: Entid, a: Attribute) {
+    schema.schema_map.insert(e, a);
+}
+
+fn prepopulated_schema() -> Schema {
+    let mut schema = Schema::default();
+    associate_ident(&mut schema, NamespacedKeyword::new("foo", "date"), 65);
+    associate_ident(&mut schema, NamespacedKeyword::new("foo", "double"), 66);
+    add_attribute(&mut schema, 65, Attribute {
+        value_type: ValueType::Instant,
+        multival: false,
+        ..Default::default()
+    });
+    add_attribute(&mut schema, 66, Attribute {
+        value_type: ValueType::Double,
+        multival: false,
+        ..Default::default()
+    });
+    schema
+}
+
+fn bails(schema: &Schema, input: &str) -> Error {
+    let parsed = parse_find_string(input).expect("query input to have parsed");
+    algebrize(schema.into(), parsed).expect_err("algebrize to have failed")
+}
+
+fn bails_with_inputs(schema: &Schema, input: &str, inputs: QueryInputs) -> Error {
+    let parsed = parse_find_string(input).expect("query input to have parsed");
+    algebrize_with_inputs(schema, parsed, 0, inputs).expect_err("algebrize to have failed")
+}
+
+fn alg(schema: &Schema, input: &str) -> ConjoiningClauses {
+    let parsed = parse_find_string(input).expect("query input to have parsed");
+    algebrize(schema.into(), parsed).expect("algebrizing to have succeeded").cc
+}
+
+#[test]
+fn test_instant_predicates_require_instants() {
+    let schema = prepopulated_schema();
+
+    // You can't use a string for an inequality: this is a straight-up error.
+    let query = r#"[:find ?e
+                    :where
+                    [?e :foo/date ?t]
+                    [(> ?t "2017-06-16T00:56:41.257Z")]]"#;
+    match bails(&schema, query).0 {
+        ErrorKind::InvalidArgument(op, why, idx) => {
+            assert_eq!(op, PlainSymbol::new(">"));
+            assert_eq!(why, "numeric or instant");
+            assert_eq!(idx, 1);
+        },
+        _ => panic!("Expected InvalidArgument."),
+    }
+
+    let query = r#"[:find ?e
+                    :where
+                    [?e :foo/date ?t]
+                    [(> "2017-06-16T00:56:41.257Z", ?t)]]"#;
+    match bails(&schema, query).0 {
+        ErrorKind::InvalidArgument(op, why, idx) => {
+            assert_eq!(op, PlainSymbol::new(">"));
+            assert_eq!(why, "numeric or instant");
+            assert_eq!(idx, 0);                      // We get this right.
+        },
+        _ => panic!("Expected InvalidArgument."),
+    }
+
+    // You can try using a number, which is valid input to a numeric predicate.
+    // In this store and query, though, that means we expect `?t` to be both
+    // an instant and a number, so the query is known-empty.
+    let query = r#"[:find ?e
+                    :where
+                    [?e :foo/date ?t]
+                    [(> ?t 1234512345)]]"#;
+    let cc = alg(&schema, query);
+    assert!(cc.is_known_empty());
+    assert_eq!(cc.empty_because.unwrap(),
+               EmptyBecause::TypeMismatch {
+                   var: Variable::from_valid_name("?t"),
+                   existing: ValueTypeSet::of_one(ValueType::Instant),
+                   desired: ValueTypeSet::of_numeric_types(),
+    });
+
+    // You can compare doubles to longs.
+    let query = r#"[:find ?e
+                    :where
+                    [?e :foo/double ?t]
+                    [(< ?t 1234512345)]]"#;
+    let cc = alg(&schema, query);
+    assert!(!cc.is_known_empty());
+    assert_eq!(cc.known_type(&Variable::from_valid_name("?t")).expect("?t is known"),
+               ValueType::Double);
+}

--- a/query-translator/src/translate.rs
+++ b/query-translator/src/translate.rs
@@ -140,7 +140,7 @@ impl ToConstraint for ColumnConstraint {
                 }
             },
 
-            NumericInequality { operator, left, right } => {
+            Inequality { operator, left, right } => {
                 Constraint::Infix {
                     op: Op(operator.to_sql_operator()),
                     left: left.into(),

--- a/query-translator/tests/translate.rs
+++ b/query-translator/tests/translate.rs
@@ -318,6 +318,56 @@ fn test_numeric_not_equals_known_attribute() {
 }
 
 #[test]
+fn test_compare_long_to_double_constants() {
+    let schema = prepopulated_typed_schema(ValueType::Double);
+
+    let query = r#"[:find ?e .
+                    :where
+                    [?e :foo/bar ?v]
+                    [(< 99.0 1234512345)]]"#;
+    let SQLQuery { sql, args } = translate(&schema, query);
+    assert_eq!(sql, "SELECT `datoms00`.e AS `?e` FROM `datoms` AS `datoms00` \
+                     WHERE `datoms00`.a = 99 \
+                       AND 9.9e1 < 1234512345 \
+                     LIMIT 1");
+    assert_eq!(args, vec![]);
+}
+
+#[test]
+fn test_compare_long_to_double() {
+    let schema = prepopulated_typed_schema(ValueType::Double);
+
+    // You can compare longs to doubles.
+    let query = r#"[:find ?e .
+                    :where
+                    [?e :foo/bar ?t]
+                    [(< ?t 1234512345)]]"#;
+    let SQLQuery { sql, args } = translate(&schema, query);
+    assert_eq!(sql, "SELECT `datoms00`.e AS `?e` FROM `datoms` AS `datoms00` \
+                     WHERE `datoms00`.a = 99 \
+                       AND `datoms00`.v < 1234512345 \
+                     LIMIT 1");
+    assert_eq!(args, vec![]);
+}
+
+#[test]
+fn test_compare_double_to_long() {
+    let schema = prepopulated_typed_schema(ValueType::Long);
+
+    // You can compare doubles to longs.
+    let query = r#"[:find ?e .
+                    :where
+                    [?e :foo/bar ?t]
+                    [(< ?t 1234512345.0)]]"#;
+    let SQLQuery { sql, args } = translate(&schema, query);
+    assert_eq!(sql, "SELECT `datoms00`.e AS `?e` FROM `datoms` AS `datoms00` \
+                     WHERE `datoms00`.a = 99 \
+                       AND `datoms00`.v < 1.234512345e9 \
+                     LIMIT 1");
+    assert_eq!(args, vec![]);
+}
+
+#[test]
 fn test_simple_or_join() {
     let mut schema = Schema::default();
     associate_ident(&mut schema, NamespacedKeyword::new("page", "url"), 97);

--- a/query-translator/tests/translate.rs
+++ b/query-translator/tests/translate.rs
@@ -888,3 +888,20 @@ fn test_fulltext_inputs() {
                        AND `datoms02`.a = 99");
     assert_eq!(args, vec![make_arg("$v0", "hello"),]);
 }
+
+#[test]
+fn test_instant_range() {
+    let schema = prepopulated_typed_schema(ValueType::Instant);
+    let query = r#"[:find ?e
+                    :where
+                    [?e :foo/bar ?t]
+                    [(> ?t #inst "2017-06-16T00:56:41.257Z")]]"#;
+
+    let SQLQuery { sql, args } = translate(&schema, query);
+    assert_eq!(sql, "SELECT DISTINCT `datoms00`.e AS `?e` \
+                     FROM \
+                     `datoms` AS `datoms00` \
+                     WHERE `datoms00`.a = 99 \
+                       AND `datoms00`.v > 1497574601257000");
+    assert_eq!(args, vec![]);
+}

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -259,6 +259,15 @@ impl FromValue<FnArg> for FnArg {
     }
 }
 
+impl FnArg {
+    pub fn as_variable(&self) -> Option<&Variable> {
+        match self {
+            &FnArg::Variable(ref v) => Some(v),
+            _ => None,
+        }
+    }
+}
+
 /// e, a, tx can't be values -- no strings, no floats -- and so
 /// they can only be variables, entity IDs, ident keywords, or
 /// placeholders.


### PR DESCRIPTION
This issue fixes #439.

#481 and #480 are fixes necessary for this to work correctly.