### PR TITLE
Support tx places in queries

### DIFF
--- a/query-algebrizer/src/clauses/mod.rs
+++ b/query-algebrizer/src/clauses/mod.rs
@@ -615,8 +615,10 @@ impl ConjoiningClauses {
     /// present.
     fn constrain_to_tx(&mut self, tx: &PatternNonValuePlace) {
         match *tx {
-            PatternNonValuePlace::Placeholder => (),
-            _ => unimplemented!(),           // TODO: #440.
+            PatternNonValuePlace::Variable(ref v) => self.constrain_var_to_type(v.clone(), ValueType::Ref),
+            PatternNonValuePlace::Placeholder |
+            PatternNonValuePlace::Entid(_) |
+            PatternNonValuePlace::Ident(_) => (),
         }
     }
 

--- a/query-algebrizer/src/clauses/mod.rs
+++ b/query-algebrizer/src/clauses/mod.rs
@@ -611,15 +611,8 @@ impl ConjoiningClauses {
     }
 
     /// Ensure that the given place has the correct types to be a tx-id.
-    /// Right now this is mostly unimplemented: we fail hard if anything but a placeholder is
-    /// present.
     fn constrain_to_tx(&mut self, tx: &PatternNonValuePlace) {
-        match *tx {
-            PatternNonValuePlace::Variable(ref v) => self.constrain_var_to_type(v.clone(), ValueType::Ref),
-            PatternNonValuePlace::Placeholder |
-            PatternNonValuePlace::Entid(_) |
-            PatternNonValuePlace::Ident(_) => (),
-        }
+        self.constrain_to_ref(tx);
     }
 
     /// Ensure that the given place can be an entity, and is congruent with existing types.

--- a/query-algebrizer/src/clauses/pattern.rs
+++ b/query-algebrizer/src/clauses/pattern.rs
@@ -247,9 +247,6 @@ impl ConjoiningClauses {
                 self.bind_column_to_var(schema, col.clone(), DatomsColumn::Tx, v.clone());
             },
             PatternNonValuePlace::Entid(entid) => {
-                // TODO: we want to check whether the tx-id is within range for the database's tx partition. 
-                // (That applies after ident lookup, too.)
-                // Possible solution: https://github.com/mozilla/mentat/tree/fluffyemily/tx-id-check
                 self.constrain_column_to_entity(col.clone(), DatomsColumn::Tx, entid);
             },
             PatternNonValuePlace::Ident(ref ident) => {

--- a/query-algebrizer/src/clauses/pattern.rs
+++ b/query-algebrizer/src/clauses/pattern.rs
@@ -241,14 +241,15 @@ impl ConjoiningClauses {
             },
         }
 
-        // TODO pattern.tx -> like handling entity place 
-        // carefully read Datomic query doc to check for correct handling
         match pattern.tx {
             PatternNonValuePlace::Placeholder => (),
             PatternNonValuePlace::Variable(ref v) => {
                 self.bind_column_to_var(schema, col.clone(), DatomsColumn::Tx, v.clone());
             },
             PatternNonValuePlace::Entid(entid) => {
+                // TODO: we want to check whether the tx-id is within range for the database's tx partition. 
+                // (That applies after ident lookup, too.)
+                // Possible solution: https://github.com/mozilla/mentat/tree/fluffyemily/tx-id-check
                 self.constrain_column_to_entity(col.clone(), DatomsColumn::Tx, entid);
             },
             PatternNonValuePlace::Ident(ref ident) => {

--- a/query-algebrizer/src/clauses/pattern.rs
+++ b/query-algebrizer/src/clauses/pattern.rs
@@ -81,7 +81,7 @@ impl ConjoiningClauses {
         // Sorry for the duplication; Rust makes it a pain to abstract this.
 
         // The transaction part of a pattern must be an entid, variable, or placeholder.
-        self.constrain_to_tx(&pattern.tx);            // See #440.
+        self.constrain_to_tx(&pattern.tx);         
         self.constrain_to_ref(&pattern.entity);
         self.constrain_to_ref(&pattern.attribute);
 
@@ -238,8 +238,28 @@ impl ConjoiningClauses {
                 if value_type.is_none() {
                     self.wheres.add_intersection(ColumnConstraint::HasType(col.clone(), typed_value_type));
                 }
-
             },
+        }
+
+        // TODO pattern.tx -> like handling entity place 
+        // carefully read Datomic query doc to check for correct handling
+        match pattern.tx {
+            PatternNonValuePlace::Placeholder => (),
+            PatternNonValuePlace::Variable(ref v) => {
+                self.bind_column_to_var(schema, col.clone(), DatomsColumn::Tx, v.clone());
+            },
+            PatternNonValuePlace::Entid(entid) => {
+                self.constrain_column_to_entity(col.clone(), DatomsColumn::Tx, entid);
+            },
+            PatternNonValuePlace::Ident(ref ident) => {
+                if let Some(entid) = self.entid_for_ident(schema, ident.as_ref()) {
+                    self.constrain_column_to_entity(col.clone(), DatomsColumn::Tx, entid)
+                } else {
+                    // A resolution failure means we're done here.
+                    self.mark_known_empty(EmptyBecause::UnresolvedIdent(ident.cloned()));
+                    return;
+                }
+            }
         }
     }
 


### PR DESCRIPTION
First pass. 

What this doesn't do is utilise an old use the tx id to fetch results from a previous version. Should that be included in this issue?