### PR TITLE
Atomic multi-tx

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,9 @@ path = "query-sql"
 [dependencies.mentat_query_translator]
 path = "query-translator"
 
+[dependencies.mentat_tx]
+path = "tx"
+
 [dependencies.mentat_tx_parser]
 path = "tx-parser"
 

--- a/db/src/bootstrap.rs
+++ b/db/src/bootstrap.rs
@@ -32,6 +32,9 @@ use types::{Partition, PartitionMap};
 /// This is the start of the :db.part/tx partition.
 pub const TX0: i64 = 0x10000000;
 
+/// This is the start of the :db.part/user partition.
+pub const USER0: i64 = 0x10000;
+
 lazy_static! {
     static ref V1_IDENTS: Vec<(symbols::NamespacedKeyword, i64)> = {
         vec![(ns_keyword!("db", "ident"),             entids::DB_IDENT),
@@ -78,7 +81,7 @@ lazy_static! {
 
     static ref V1_PARTS: Vec<(symbols::NamespacedKeyword, i64, i64)> = {
         vec![(ns_keyword!("db.part", "db"), 0, (1 + V1_IDENTS.len()) as i64),
-             (ns_keyword!("db.part", "user"), 0x10000, 0x10000),
+             (ns_keyword!("db.part", "user"), USER0, USER0),
              (ns_keyword!("db.part", "tx"), TX0, TX0),
         ]
     };

--- a/db/src/db.rs
+++ b/db/src/db.rs
@@ -21,8 +21,9 @@ use std::rc::Rc;
 use itertools;
 use itertools::Itertools;
 use rusqlite;
-use rusqlite::types::{ToSql, ToSqlOutput};
+use rusqlite::TransactionBehavior;
 use rusqlite::limits::Limit;
+use rusqlite::types::{ToSql, ToSqlOutput};
 
 use ::{repeat_values, to_namespaced_keyword};
 use bootstrap;
@@ -208,7 +209,7 @@ fn get_user_version(conn: &rusqlite::Connection) -> Result<i32> {
 
 // TODO: rename "SQL" functions to align with "datoms" functions.
 pub fn create_current_version(conn: &mut rusqlite::Connection) -> Result<DB> {
-    let tx = conn.transaction()?;
+    let tx = conn.transaction_with_behavior(TransactionBehavior::Exclusive)?;
 
     for statement in (&V1_STATEMENTS).iter() {
         tx.execute(statement, &[])?;
@@ -1163,7 +1164,8 @@ mod tests {
 
             let details = {
                 // The block scopes the borrow of self.sqlite.
-                let tx = self.sqlite.transaction()?;
+                // We're about to write, so go straight ahead and get an IMMEDIATE transaction.
+                let tx = self.sqlite.transaction_with_behavior(TransactionBehavior::Immediate)?;
                 // Applying the transaction can fail, so we don't unwrap.
                 let details = transact(&tx, self.partition_map.clone(), &self.schema, &self.schema, entities)?;
                 tx.commit()?;

--- a/db/src/db.rs
+++ b/db/src/db.rs
@@ -518,7 +518,7 @@ pub trait MentatStoring {
     ///
     /// Use this to create temporary tables, prepare indices, set pragmas, etc, before the initial
     /// `insert_non_fts_searches` invocation.
-    fn begin_transaction(&self) -> Result<()>;
+    fn begin_tx_application(&self) -> Result<()>;
 
     // TODO: this is not a reasonable abstraction, but I don't want to really consider non-SQL storage just yet.
     fn insert_non_fts_searches<'a>(&self, entities: &'a [ReducedEntity], search_type: SearchType) -> Result<()>;
@@ -710,7 +710,7 @@ impl MentatStoring for rusqlite::Connection {
     }
 
     /// Create empty temporary tables for search parameters and search results.
-    fn begin_transaction(&self) -> Result<()> {
+    fn begin_tx_application(&self) -> Result<()> {
         // We can't do this in one shot, since we can't prepare a batch statement.
         let statements = [
             r#"DROP TABLE IF EXISTS temp.exact_searches"#,

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -48,6 +48,13 @@ mod internal_types;
 mod upsert_resolution;
 mod tx;
 
+// Export these for reference from tests. cfg(test) should work, but doesn't.
+// #[cfg(test)]
+pub use bootstrap::{
+    TX0,
+    USER0,
+};
+
 pub use db::{
     TypedSQLValue,
     new_connection,

--- a/db/src/tx.rs
+++ b/db/src/tx.rs
@@ -700,7 +700,7 @@ pub fn transact<'conn, 'a, I>(
     let tx_instant = ::now(); // Label the transaction with the timestamp when we first see it: leading edge.
     let tx_id = partition_map.allocate_entid(":db.part/tx");
 
-    conn.begin_transaction()?;
+    conn.begin_tx_application()?;
 
     let mut tx = Tx::new(conn, partition_map, schema_for_mutation, schema, tx_id, tx_instant);
 

--- a/query-projector/src/lib.rs
+++ b/query-projector/src/lib.rs
@@ -27,11 +27,9 @@ use rusqlite::{
 
 use mentat_core::{
     SQLValueType,
-    SQLValueTypeSet,
     TypedValue,
     ValueType,
     ValueTypeTag,
-    ValueTypeSet,
 };
 
 use mentat_db::{

--- a/query-projector/src/lib.rs
+++ b/query-projector/src/lib.rs
@@ -73,7 +73,7 @@ error_chain! {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum QueryResults {
     Scalar(Option<TypedValue>),
     Tuple(Option<Vec<TypedValue>>),

--- a/query-translator/src/translate.rs
+++ b/query-translator/src/translate.rs
@@ -10,7 +10,6 @@
 
 use mentat_core::{
     SQLValueType,
-    SQLValueTypeSet,
     TypedValue,
     ValueType,
 };

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -13,6 +13,9 @@
 use std::sync::{Arc, Mutex};
 
 use rusqlite;
+use rusqlite::{
+    TransactionBehavior,
+};
 
 use edn;
 
@@ -132,7 +135,8 @@ impl Conn {
         let assertion_vector = edn::parse::value(transaction)?;
         let entities = mentat_tx_parser::Tx::parse(&assertion_vector)?;
 
-        let tx = sqlite.transaction()?;
+        // We're about to write, so go straight ahead and get an IMMEDIATE transaction.
+        let tx = sqlite.transaction_with_behavior(TransactionBehavior::Immediate)?;
 
         let (current_generation, current_partition_map, current_schema) =
         {

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -254,7 +254,6 @@ mod tests {
 
     extern crate mentat_parser_utils;
     use mentat_core::{
-        Entid,
         TypedValue,
     };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ extern crate mentat_query_parser;
 extern crate mentat_query_projector;
 extern crate mentat_query_translator;
 extern crate mentat_sql;
+extern crate mentat_tx;
 extern crate mentat_tx_parser;
 
 use rusqlite::Connection;


### PR DESCRIPTION
This is the basic primitive needed to implement atomic schema migration: the ability to establish a transaction and run queries and transact within it, rolling back or committing in its entirety when done.

This is a long way from being ready — I need to introduce some kind of equivalent of `Conn` that I can query within this, and perhaps maintains mutable state rather than invoking `transact` directly — but I wanted to get to a POC first.