### PR TITLE
Update some dependencies.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ rustc_version = "0.1.7"
 
 [dependencies]
 chrono = "0.4"
-error-chain = "0.8.1"
+error-chain = { git = "https://github.com/rnewman/error-chain", branch = "rnewman/sync" }
 time = "0.1"
 
 [dependencies.rusqlite]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ error-chain = "0.8.1"
 time = "0.1"
 
 [dependencies.rusqlite]
-version = "0.11"
+version = "0.12"
 # System sqlite might be very old.
 features = ["bundled", "limits"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = []
 rustc_version = "0.1.7"
 
 [dependencies]
-chrono = "0.3"
+chrono = "0.4"
 error-chain = "0.8.1"
 time = "0.1"
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -5,9 +5,9 @@ workspace = ".."
 
 [dependencies]
 enum-set = { git = "https://github.com/rnewman/enum-set" }
-lazy_static = "0.2.2"
-num = "0.1.35"
-ordered-float = "0.4.0"
+lazy_static = "0.2"
+num = "0.1"
+ordered-float = "0.5"
 
 [dependencies.edn]
 path = "../edn"

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -37,7 +37,7 @@ pub use edn::{
     DateTime,
     FromMicros,
     ToMicros,
-    UTC,
+    Utc,
 };
 
 /// Core types defining a Mentat knowledge base.
@@ -130,7 +130,7 @@ pub enum TypedValue {
     Boolean(bool),
     Long(i64),
     Double(OrderedFloat<f64>),
-    Instant(DateTime<UTC>),
+    Instant(DateTime<Utc>),
     // TODO: &str throughout?
     String(Rc<String>),
     Keyword(Rc<NamespacedKeyword>),
@@ -178,7 +178,7 @@ impl TypedValue {
     }
 
     pub fn current_instant() -> TypedValue {
-        TypedValue::Instant(UTC::now())
+        TypedValue::Instant(Utc::now())
     }
 }
 

--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -4,14 +4,14 @@ version = "0.0.1"
 workspace = ".."
 
 [dependencies]
-error-chain = "0.8.1"
+error-chain = { git = "https://github.com/rnewman/error-chain", branch = "rnewman/sync" }
 itertools = "0.7"
 lazy_static = "0.2"
 ordered-float = "0.5"
 time = "0.1"
 
 [dependencies.rusqlite]
-version = "0.11"
+version = "0.12"
 # System sqlite might be very old.
 features = ["bundled", "limits"]
 

--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -5,9 +5,9 @@ workspace = ".."
 
 [dependencies]
 error-chain = "0.8.1"
-itertools = "0.5"
+itertools = "0.7"
 lazy_static = "0.2"
-ordered-float = "0.4"
+ordered-float = "0.5"
 time = "0.1"
 
 [dependencies.rusqlite]

--- a/db/src/db.rs
+++ b/db/src/db.rs
@@ -1076,7 +1076,7 @@ impl PartitionMapping for PartitionMap {
     /// Allocate `n` fresh entids in the given `partition`.
     fn allocate_entids<S: ?Sized + Ord + Display>(&mut self, partition: &S, n: usize) -> Range<i64> where String: Borrow<S> {
         match self.get_mut(partition) {
-            Some(mut partition) => {
+            Some(partition) => {
                 let idx = partition.index;
                 partition.index += n as i64;
                 idx..partition.index

--- a/db/src/db.rs
+++ b/db/src/db.rs
@@ -29,7 +29,7 @@ use bootstrap;
 
 use edn::{
     DateTime,
-    UTC,
+    Utc,
     Uuid,
     Value,
 };
@@ -358,7 +358,7 @@ impl TypedSQLValue for TypedValue {
             (1, rusqlite::types::Value::Integer(x)) => Ok(TypedValue::Boolean(0 != x)),
 
             // Negative integers are simply times before 1970.
-            (4, rusqlite::types::Value::Integer(x)) => Ok(TypedValue::Instant(DateTime::<UTC>::from_micros(x))),
+            (4, rusqlite::types::Value::Integer(x)) => Ok(TypedValue::Instant(DateTime::<Utc>::from_micros(x))),
 
             // SQLite distinguishes integral from decimal types, allowing long and double to
             // share a tag.

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -30,7 +30,7 @@ use itertools::Itertools;
 
 use mentat_core::{
     DateTime,
-    UTC,
+    Utc,
 };
 
 pub use errors::{Error, ErrorKind, ResultExt, Result};
@@ -97,6 +97,6 @@ pub fn repeat_values(values_per_tuple: usize, tuples: usize) -> String {
 }
 
 /// Return the current time as a UTC `DateTime` instance.
-pub fn now() -> DateTime<UTC> {
-    UTC::now()
+pub fn now() -> DateTime<Utc> {
+    Utc::now()
 }

--- a/db/src/tx.rs
+++ b/db/src/tx.rs
@@ -590,16 +590,16 @@ impl<'conn, 'a> Tx<'conn, 'a> {
 
         { // TODO: Don't use this block to scope borrowing the schema; instead, extract a helper function.
 
-        /// Assertions that are :db.cardinality/one and not :db.fulltext.
+        // Assertions that are :db.cardinality/one and not :db.fulltext.
         let mut non_fts_one: Vec<db::ReducedEntity> = vec![];
 
-        /// Assertions that are :db.cardinality/many and not :db.fulltext.
+        // Assertions that are :db.cardinality/many and not :db.fulltext.
         let mut non_fts_many: Vec<db::ReducedEntity> = vec![];
 
-        /// Assertions that are :db.cardinality/one and :db.fulltext.
+        // Assertions that are :db.cardinality/one and :db.fulltext.
         let mut fts_one: Vec<db::ReducedEntity> = vec![];
 
-        /// Assertions that are :db.cardinality/many and :db.fulltext.
+        // Assertions that are :db.cardinality/many and :db.fulltext.
         let mut fts_many: Vec<db::ReducedEntity> = vec![];
 
         // We need to ensure that callers can't blindly transact entities that haven't been

--- a/db/src/tx.rs
+++ b/db/src/tx.rs
@@ -83,7 +83,7 @@ use mentat_core::util::Either;
 use mentat_core::{
     DateTime,
     Schema,
-    UTC,
+    Utc,
     attribute,
     intern_set,
 };
@@ -139,7 +139,7 @@ pub struct Tx<'conn, 'a> {
     tx_id: Entid,
 
     /// The timestamp when the transaction began to be committed.
-    tx_instant: DateTime<UTC>,
+    tx_instant: DateTime<Utc>,
 }
 
 impl<'conn, 'a> Tx<'conn, 'a> {
@@ -149,7 +149,7 @@ impl<'conn, 'a> Tx<'conn, 'a> {
         schema_for_mutation: &'a Schema,
         schema: &'a Schema,
         tx_id: Entid,
-        tx_instant: DateTime<UTC>) -> Tx<'conn, 'a> {
+        tx_instant: DateTime<Utc>) -> Tx<'conn, 'a> {
         Tx {
             store: store,
             partition_map: partition_map,

--- a/db/src/types.rs
+++ b/db/src/types.rs
@@ -23,7 +23,7 @@ pub use self::mentat_core::{
     Attribute,
     AttributeBitFlags,
     Schema,
-    UTC,
+    Utc,
 };
 
 /// Represents one partition of the entid space.
@@ -90,7 +90,7 @@ pub struct TxReport {
     pub tx_id: Entid,
 
     /// The timestamp when the transaction began to be committed.
-    pub tx_instant: DateTime<UTC>,
+    pub tx_instant: DateTime<Utc>,
 
     /// A map from string literal tempid to resolved or allocated entid.
     ///

--- a/edn/Cargo.toml
+++ b/edn/Cargo.toml
@@ -11,10 +11,10 @@ build = "build.rs"
 readme = "./README.md"
 
 [dependencies]
-chrono = "0.3"
-itertools = "0.5"
+chrono = "0.4"
+itertools = "0.7"
 num = "0.1"
-ordered-float = "0.4"
+ordered-float = "0.5"
 pretty = "0.2"
 uuid = "0.5"
 

--- a/edn/src/edn.rustpeg
+++ b/edn/src/edn.rustpeg
@@ -17,7 +17,7 @@ use std::f64::{NAN, INFINITY, NEG_INFINITY};
 use chrono::{
     DateTime,
     TimeZone,
-    UTC
+    Utc
 };
 use num::BigInt;
 use ordered_float::OrderedFloat;
@@ -152,7 +152,7 @@ pub text -> ValueAndSpan =
 // RFC 3339 timestamps. #inst "1985-04-12T23:20:50.52Z"
 // We accept an arbitrary depth of decimals.
 // Note that we discard the timezone information -- all times are translated to UTC.
-pub inst_string -> DateTime<UTC> =
+pub inst_string -> DateTime<Utc> =
     "#inst" whitespace+ "\"" d:$( [0-9]*<4> "-" [0-2][0-9] "-" [0-3][0-9]
               "T"
               [0-2][0-9] ":" [0-5][0-9] ":" [0-6][0-9]
@@ -161,24 +161,24 @@ pub inst_string -> DateTime<UTC> =
             )
     "\"" {?
         DateTime::parse_from_rfc3339(d)
-            .map(|t| t.with_timezone(&UTC))
+            .map(|t| t.with_timezone(&Utc))
             .map_err(|_| "invalid datetime")        // Oh, rustpeg.
     }
 
-pub inst_micros -> DateTime<UTC> =
+pub inst_micros -> DateTime<Utc> =
     "#instmicros" whitespace+ d:$( digit+ ) {
         let micros = d.parse::<i64>().unwrap();
         let seconds: i64 = micros / 1000000;
         let nanos: u32 = ((micros % 1000000).abs() as u32) * 1000;
-        UTC.timestamp(seconds, nanos)
+        Utc.timestamp(seconds, nanos)
     }
 
-pub inst_millis -> DateTime<UTC> =
+pub inst_millis -> DateTime<Utc> =
     "#instmillis" whitespace+ d:$( digit+ ) {
         let millis = d.parse::<i64>().unwrap();
         let seconds: i64 = millis / 1000;
         let nanos: u32 = ((millis % 1000).abs() as u32) * 1000000;
-        UTC.timestamp(seconds, nanos)
+        Utc.timestamp(seconds, nanos)
     }
 
 pub inst -> ValueAndSpan =

--- a/edn/src/lib.rs
+++ b/edn/src/lib.rs
@@ -26,7 +26,7 @@ pub mod parse {
 }
 
 // Re-export the types we use.
-pub use chrono::{DateTime, UTC};
+pub use chrono::{DateTime, Utc};
 pub use num::BigInt;
 pub use ordered_float::OrderedFloat;
 pub use uuid::Uuid;

--- a/edn/src/types.rs
+++ b/edn/src/types.rs
@@ -17,8 +17,8 @@ use std::f64;
 
 use chrono::{
     DateTime,
-    TimeZone,           // For UTC::timestamp. The compiler incorrectly complains that this is unused.
-    UTC,
+    TimeZone,           // For Utc::timestamp. The compiler incorrectly complains that this is unused.
+    Utc,
 };
 use num::BigInt;
 use ordered_float::OrderedFloat;
@@ -32,7 +32,7 @@ pub enum Value {
     Nil,
     Boolean(bool),
     Integer(i64),
-    Instant(DateTime<UTC>),
+    Instant(DateTime<Utc>),
     BigInteger(BigInt),
     Float(OrderedFloat<f64>),
     Text(String),
@@ -61,7 +61,7 @@ pub enum SpannedValue {
     Nil,
     Boolean(bool),
     Integer(i64),
-    Instant(DateTime<UTC>),
+    Instant(DateTime<Utc>),
     BigInteger(BigInt),
     Float(OrderedFloat<f64>),
     Text(String),
@@ -315,7 +315,7 @@ macro_rules! def_common_value_methods {
 
         def_as!(as_boolean, $t::Boolean, bool,);
         def_as!(as_integer, $t::Integer, i64,);
-        def_as!(as_instant, $t::Instant, DateTime<UTC>,);
+        def_as!(as_instant, $t::Instant, DateTime<Utc>,);
         def_as!(as_float, $t::Float, f64, |v: OrderedFloat<f64>| v.into_inner());
 
         def_as_ref!(as_big_integer, $t::BigInteger, BigInt);
@@ -333,7 +333,7 @@ macro_rules! def_common_value_methods {
 
         def_into!(into_boolean, $t::Boolean, bool,);
         def_into!(into_integer, $t::Integer, i64,);
-        def_into!(into_instant, $t::Instant, DateTime<UTC>,);
+        def_into!(into_instant, $t::Instant, DateTime<Utc>,);
         def_into!(into_big_integer, $t::BigInteger, BigInt,);
         def_into!(into_ordered_float, $t::Float, OrderedFloat<f64>,);
         def_into!(into_float, $t::Float, f64, |v: OrderedFloat<f64>| v.into_inner());
@@ -561,9 +561,9 @@ pub trait FromMicros {
     fn from_micros(ts: i64) -> Self;
 }
 
-impl FromMicros for DateTime<UTC> {
+impl FromMicros for DateTime<Utc> {
     fn from_micros(ts: i64) -> Self {
-        UTC.timestamp(ts / 1_000_000, ((ts % 1_000_000).abs() as u32) * 1_000)
+        Utc.timestamp(ts / 1_000_000, ((ts % 1_000_000).abs() as u32) * 1_000)
     }
 }
 
@@ -571,7 +571,7 @@ pub trait ToMicros {
     fn to_micros(&self) -> i64;
 }
 
-impl ToMicros for DateTime<UTC> {
+impl ToMicros for DateTime<Utc> {
     fn to_micros(&self) -> i64 {
         let major: i64 = self.timestamp() * 1_000_000;
         let minor: i64 = self.timestamp_subsec_micros() as i64;
@@ -596,7 +596,7 @@ mod test {
 
     use chrono::{
         DateTime,
-        UTC,
+        Utc,
     };
     use num::BigInt;
     use ordered_float::OrderedFloat;
@@ -604,7 +604,7 @@ mod test {
     #[test]
     fn test_micros_roundtrip() {
         let ts_micros: i64 = 1493399581314000;
-        let dt = DateTime::<UTC>::from_micros(ts_micros);
+        let dt = DateTime::<Utc>::from_micros(ts_micros);
         assert_eq!(dt.to_micros(), ts_micros);
     }
 

--- a/edn/tests/tests.rs
+++ b/edn/tests/tests.rs
@@ -31,7 +31,7 @@ use edn::types::{
 };
 use chrono::{
     TimeZone,
-    UTC,
+    Utc,
 };
 use edn::symbols;
 use edn::utils;
@@ -425,10 +425,10 @@ fn test_value() {
     assert_eq!(value("{1 2}").unwrap(), Map(BTreeMap::from_iter(vec![(Integer(1), Integer(2))])));
     assert_eq!(value("#uuid \"e43c6f3e-3123-49b7-8098-9b47a7bc0fa4\"").unwrap(),
                Uuid(uuid::Uuid::parse_str("e43c6f3e-3123-49b7-8098-9b47a7bc0fa4").unwrap()));
-    assert_eq!(value("#instmillis 1493410985187").unwrap(), Instant(UTC.timestamp(1493410985, 187000000)));
-    assert_eq!(value("#instmicros 1493410985187123").unwrap(), Instant(UTC.timestamp(1493410985, 187123000)));
+    assert_eq!(value("#instmillis 1493410985187").unwrap(), Instant(Utc.timestamp(1493410985, 187000000)));
+    assert_eq!(value("#instmicros 1493410985187123").unwrap(), Instant(Utc.timestamp(1493410985, 187123000)));
     assert_eq!(value("#inst \"2017-04-28T20:23:05.187Z\"").unwrap(),
-               Instant(UTC.timestamp(1493410985, 187000000)));
+               Instant(Utc.timestamp(1493410985, 187000000)));
 }
 
 #[test]

--- a/parser-utils/Cargo.toml
+++ b/parser-utils/Cargo.toml
@@ -6,7 +6,7 @@ workspace = ".."
 
 [dependencies]
 combine = "2.3.2"
-itertools = "0.5.9"
+itertools = "0.7"
 
 [dependencies.edn]
   path = "../edn"

--- a/query-algebrizer/Cargo.toml
+++ b/query-algebrizer/Cargo.toml
@@ -5,7 +5,7 @@ workspace = ".."
 
 [dependencies]
 enum-set = { git = "https://github.com/rnewman/enum-set" }
-error-chain = "0.8.1"
+error-chain = { git = "https://github.com/rnewman/error-chain", branch = "rnewman/sync" }
 
 [dependencies.mentat_core]
 path = "../core"

--- a/query-algebrizer/Cargo.toml
+++ b/query-algebrizer/Cargo.toml
@@ -18,5 +18,5 @@ path = "../query"
 path = "../query-parser"
 
 [dev-dependencies]
-itertools = "0.5"
+itertools = "0.7"
 maplit = "0.1"

--- a/query-algebrizer/tests/predicate.rs
+++ b/query-algebrizer/tests/predicate.rs
@@ -35,10 +35,8 @@ use mentat_query_algebrizer::{
     EmptyBecause,
     Error,
     ErrorKind,
-    QueryInputs,
     ValueTypeSet,
     algebrize,
-    algebrize_with_inputs,
 };
 
 // These are helpers that tests use to build Schema instances.

--- a/query-parser/Cargo.toml
+++ b/query-parser/Cargo.toml
@@ -5,7 +5,7 @@ workspace = ".."
 
 [dependencies]
 combine = "2.3.2"
-error-chain = "0.8.1"
+error-chain = { git = "https://github.com/rnewman/error-chain", branch = "rnewman/sync" }
 maplit = "0.1"
 matches = "0.1"
 

--- a/query-parser/src/parse.rs
+++ b/query-parser/src/parse.rs
@@ -830,19 +830,19 @@ mod test {
         let mut par = Query::natural_number();
         let x = par.parse(input.atom_stream()).err().expect("an error").errors;
         let result = format!("{:?}", x);
-        assert_eq!(result, "[Other(Error(InvalidLimit(Text(\"foo\")), State { next_error: None, backtrace: None })), Expected(Borrowed(\"natural_number\"))]");
+        assert_eq!(result, "[Other(Error(InvalidLimit(Text(\"foo\")), State { next_error: None, backtrace: None }))]");
 
         let input = neg.with_spans();
         let mut par = Query::natural_number();
         let x = par.parse(input.atom_stream()).err().expect("an error").errors;
         let result = format!("{:?}", x);
-        assert_eq!(result, "[Other(Error(InvalidLimit(Integer(-10)), State { next_error: None, backtrace: None })), Expected(Borrowed(\"natural_number\"))]");
+        assert_eq!(result, "[Other(Error(InvalidLimit(Integer(-10)), State { next_error: None, backtrace: None }))]");
 
         let input = zero.with_spans();
         let mut par = Query::natural_number();
         let x = par.parse(input.atom_stream()).err().expect("an error").errors;
         let result = format!("{:?}", x);
-        assert_eq!(result, "[Other(Error(InvalidLimit(Integer(0)), State { next_error: None, backtrace: None })), Expected(Borrowed(\"natural_number\"))]");
+        assert_eq!(result, "[Other(Error(InvalidLimit(Integer(0)), State { next_error: None, backtrace: None }))]");
 
         let input = pos.with_spans();
         let mut par = Query::natural_number();

--- a/query-projector/Cargo.toml
+++ b/query-projector/Cargo.toml
@@ -4,10 +4,10 @@ version = "0.0.1"
 workspace = ".."
 
 [dependencies]
-error-chain = "0.8.1"
+error-chain = { git = "https://github.com/rnewman/error-chain", branch = "rnewman/sync" }
 
 [dependencies.rusqlite]
-version = "0.11"
+version = "0.12"
 # System sqlite might be very old.
 features = ["bundled", "limits"]
 

--- a/query-translator/src/translate.rs
+++ b/query-translator/src/translate.rs
@@ -112,19 +112,19 @@ impl ToConstraint for ColumnConstraint {
                 let tag_column = qa.for_type_tag().to_column();
                 let value_column = qa.to_column();
 
-                /// A bare long in a query might match a ref, an instant, a long (obviously), or a
-                /// double. If it's negative, it can't match a ref, but that's OK -- it won't!
-                ///
-                /// However, '1' and '0' are used to represent booleans, and some integers are also
-                /// used to represent FTS values. We don't want to accidentally match those.
-                ///
-                /// We ask `SQLValueType` whether this value is in range for how booleans are
-                /// represented in the database.
-                ///
-                /// We only hit this code path when the attribute is unknown, so we're querying
-                /// `all_datoms`. That means we don't see FTS IDs at all -- they're transparently
-                /// replaced by their strings. If that changes, then you should also exclude the
-                /// string type code (10) here.
+                // A bare long in a query might match a ref, an instant, a long (obviously), or a
+                // double. If it's negative, it can't match a ref, but that's OK -- it won't!
+                //
+                // However, '1' and '0' are used to represent booleans, and some integers are also
+                // used to represent FTS values. We don't want to accidentally match those.
+                //
+                // We ask `SQLValueType` whether this value is in range for how booleans are
+                // represented in the database.
+                //
+                // We only hit this code path when the attribute is unknown, so we're querying
+                // `all_datoms`. That means we don't see FTS IDs at all -- they're transparently
+                // replaced by their strings. If that changes, then you should also exclude the
+                // string type code (10) here.
                 let must_exclude_boolean = ValueType::Boolean.accommodates_integer(value);
                 if must_exclude_boolean {
                     Constraint::And {

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -46,7 +46,7 @@ use edn::{
     DateTime,
     OrderedFloat,
     Uuid,
-    UTC,
+    Utc,
 };
 
 pub use edn::{
@@ -193,7 +193,7 @@ pub enum NonIntegerConstant {
     BigInteger(BigInt),
     Float(OrderedFloat<f64>),
     Text(Rc<String>),
-    Instant(DateTime<UTC>),
+    Instant(DateTime<Utc>),
     Uuid(Uuid),
 }
 

--- a/sql/Cargo.toml
+++ b/sql/Cargo.toml
@@ -8,7 +8,7 @@ error-chain = "0.8.1"
 ordered-float = "0.5"
 
 [dependencies.rusqlite]
-version = "0.11"
+version = "0.12"
 # System sqlite might be very old.
 features = ["bundled", "limits"]
 

--- a/sql/Cargo.toml
+++ b/sql/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 workspace = ".."
 
 [dependencies]
-error-chain = "0.8.1"
+error-chain = { git = "https://github.com/rnewman/error-chain", branch = "rnewman/sync" }
 ordered-float = "0.5"
 
 [dependencies.rusqlite]

--- a/sql/Cargo.toml
+++ b/sql/Cargo.toml
@@ -5,7 +5,7 @@ workspace = ".."
 
 [dependencies]
 error-chain = "0.8.1"
-ordered-float = "0.4.0"
+ordered-float = "0.5"
 
 [dependencies.rusqlite]
 version = "0.11"

--- a/tests/query.rs
+++ b/tests/query.rs
@@ -23,7 +23,7 @@ use chrono::FixedOffset;
 use mentat_core::{
     TypedValue,
     ValueType,
-    UTC,
+    Utc,
     Uuid,
 };
 
@@ -220,7 +220,7 @@ fn test_unbound_inputs() {
 fn test_instants_and_uuids() {
     // We assume, perhaps foolishly, that the clocks on test machines won't lose more than an
     // hour while this test is running.
-    let start = UTC::now() + FixedOffset::west(60 * 60);
+    let start = Utc::now() + FixedOffset::west(60 * 60);
 
     let mut c = new_connection("").expect("Couldn't open conn.");
     let mut conn = Conn::connect(&mut c).expect("Couldn't open DB.");

--- a/tx-parser/Cargo.toml
+++ b/tx-parser/Cargo.toml
@@ -5,7 +5,7 @@ workspace = ".."
 
 [dependencies]
 combine = "2.3.2"
-error-chain = "0.8.1"
+error-chain = { git = "https://github.com/rnewman/error-chain", branch = "rnewman/sync" }
 
 [dependencies.edn]
 path = "../edn"


### PR DESCRIPTION
I decided to fork `error-chain` to restore `Send + Sync`, so we're now up to date to v0.11.

The current `rustc` warns if you use `///` somewhere it's not expecting a docstring, so I fixed some of those, too.

Our date library decided to rename `UTC` to `Utc`. *sigh*