### PR TITLE
Update cargo import for uuid to enable the V4 features for creating n…

### DIFF
--- a/edn/Cargo.toml
+++ b/edn/Cargo.toml
@@ -16,7 +16,7 @@ itertools = "0.7"
 num = "0.1"
 ordered-float = "0.5"
 pretty = "0.2"
-uuid = "0.5"
+uuid = { version = "0.5", features = ["v4"] }
 
 [build-dependencies]
 peg = "0.5"


### PR DESCRIPTION
…ew Uuids

I want to use `mentat_core::Uuid` in the storage prototype, but I want to access some features that are only enabled with the V4 features. This patch enables V4 features for the current version.