### PR TITLE
Implement a simple direct lookup API. Fixes #111

### DIFF
--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -646,6 +646,12 @@ pub struct Pattern {
 }
 
 impl Pattern {
+    pub fn simple(e: PatternNonValuePlace,
+                  a: PatternNonValuePlace,
+                  v: PatternValuePlace) -> Option<Pattern> {
+        Pattern::new(None, e, a, v, PatternNonValuePlace::Placeholder)
+    }
+
     pub fn new(src: Option<SrcVar>,
                e: PatternNonValuePlace,
                a: PatternNonValuePlace,
@@ -786,6 +792,21 @@ pub struct FindQuery {
     pub where_clauses: Vec<WhereClause>,
     pub order: Option<Vec<Order>>,
     // TODO: in_rules;
+}
+
+impl FindQuery {
+    pub fn simple(spec: FindSpec, where_clauses: Vec<WhereClause>) -> FindQuery {
+        FindQuery {
+            find_spec: spec,
+            default_source: SrcVar::DefaultSrc,
+            with: BTreeSet::default(),
+            in_vars: BTreeSet::default(),
+            in_sources: BTreeSet::default(),
+            limit: Limit::None,
+            where_clauses: where_clauses,
+            order: None,
+        }
+    }
 }
 
 impl OrJoin {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -16,6 +16,7 @@ use std::collections::BTreeSet;
 
 use edn;
 use mentat_db;
+use mentat_query;
 use mentat_query_algebrizer;
 use mentat_query_parser;
 use mentat_query_projector;
@@ -52,6 +53,11 @@ error_chain! {
         InvalidArgumentName(name: String) {
             description("invalid argument name")
             display("invalid argument name: '{}'", name)
+        }
+
+        UnknownAttribute(kw: mentat_query::NamespacedKeyword) {
+            description("unknown attribute")
+            display("unknown attribute: '{}'", kw)
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,8 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
+#![recursion_limit="128"]
+
 #[macro_use]
 extern crate error_chain;
 


### PR DESCRIPTION
Should be obvious how this makes Toodle simpler — getting a due date is now a one-liner.