### PR TITLE
Programmatic transact, vocabulary management

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ rustc_version = "0.1.7"
 [dependencies]
 chrono = "0.4"
 error-chain = { git = "https://github.com/rnewman/error-chain", branch = "rnewman/sync" }
+lazy_static = "0.2"
 time = "0.1"
 
 [dependencies.rusqlite]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ authors = [
   "Emily Toop <etoop@mozilla.com>",
 ]
 name = "mentat"
-version = "0.4.0"
+version = "0.5.0"
 build = "build/version.rs"
 
 [workspace]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.1"
 workspace = ".."
 
 [dependencies]
+chrono = "0.4"
 enum-set = { git = "https://github.com/rnewman/enum-set" }
 lazy_static = "0.2"
 num = "0.1"

--- a/core/src/intern_set.rs
+++ b/core/src/intern_set.rs
@@ -33,6 +33,10 @@ impl<T> InternSet<T> where T: Eq + Hash {
         }
     }
 
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
     /// Intern a value, providing a ref-counted handle to the interned value.
     ///
     /// ```

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -690,6 +690,8 @@ pub struct Schema {
 }
 
 pub trait HasSchema {
+    fn entid_for_type(&self, t: ValueType) -> Option<KnownEntid>;
+
     fn get_ident<T>(&self, x: T) -> Option<&NamespacedKeyword> where T: Into<Entid>;
     fn get_entid(&self, x: &NamespacedKeyword) -> Option<KnownEntid>;
     fn attribute_for_entid<T>(&self, x: T) -> Option<&Attribute> where T: Into<Entid>;
@@ -719,6 +721,11 @@ impl Schema {
 }
 
 impl HasSchema for Schema {
+    fn entid_for_type(&self, t: ValueType) -> Option<KnownEntid> {
+        // TODO: this can be made more efficient.
+        self.get_entid(&t.into_keyword())
+    }
+
     fn get_ident<T>(&self, x: T) -> Option<&NamespacedKeyword> where T: Into<Entid> {
         self.entid_map.get(&x.into())
     }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -31,9 +31,6 @@ use std::rc::Rc;
 use enum_set::EnumSet;
 
 use self::ordered_float::OrderedFloat;
-use self::edn::{
-    NamespacedKeyword,
-};
 
 pub use uuid::Uuid;
 
@@ -44,6 +41,7 @@ pub use chrono::{
 
 pub use edn::{
     FromMicros,
+    NamespacedKeyword,
     ToMicros,
     Utc,
 };

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -100,7 +100,7 @@ impl enum_set::CLike for ValueType {
 }
 
 impl ValueType {
-    pub fn to_keyword(self) -> NamespacedKeyword {
+    pub fn into_keyword(self) -> NamespacedKeyword {
         NamespacedKeyword::new("db.type", match self {
             ValueType::Ref => "ref",
             ValueType::Boolean => "boolean",
@@ -113,7 +113,7 @@ impl ValueType {
         })
     }
 
-    pub fn to_typed_value(self) -> TypedValue {
+    pub fn into_typed_value(self) -> TypedValue {
         TypedValue::typed_ns_keyword("db.type", match self {
             ValueType::Ref => "ref",
             ValueType::Boolean => "boolean",
@@ -126,7 +126,7 @@ impl ValueType {
         })
     }
 
-    pub fn to_edn_value(self) -> edn::Value {
+    pub fn into_edn_value(self) -> edn::Value {
         match self {
             ValueType::Ref => values::DB_TYPE_REF.clone(),
             ValueType::Boolean => values::DB_TYPE_BOOLEAN.clone(),
@@ -514,7 +514,7 @@ pub mod attribute {
 
     impl Unique {
         // This is easier than rejigging DB_UNIQUE_VALUE to not be EDN.
-        pub fn to_typed_value(self) -> TypedValue {
+        pub fn into_typed_value(self) -> TypedValue {
             match self {
                 Unique::Value => TypedValue::typed_ns_keyword("db.unique", "value"),
                 Unique::Identity => TypedValue::typed_ns_keyword("db.unique", "identity"),
@@ -597,7 +597,7 @@ impl Attribute {
             attribute_map.insert(values::DB_IDENT.clone(), edn::Value::NamespacedKeyword(ident));
         }
 
-        attribute_map.insert(values::DB_VALUE_TYPE.clone(), self.value_type.to_edn_value());
+        attribute_map.insert(values::DB_VALUE_TYPE.clone(), self.value_type.into_edn_value());
 
         attribute_map.insert(values::DB_CARDINALITY.clone(), if self.multival { values::DB_CARDINALITY_MANY.clone() } else { values::DB_CARDINALITY_ONE.clone() });
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -100,7 +100,20 @@ impl enum_set::CLike for ValueType {
 }
 
 impl ValueType {
-    pub fn to_keyword(self) -> TypedValue {
+    pub fn to_keyword(self) -> NamespacedKeyword {
+        NamespacedKeyword::new("db.type", match self {
+            ValueType::Ref => "ref",
+            ValueType::Boolean => "boolean",
+            ValueType::Instant => "instant",
+            ValueType::Long => "long",
+            ValueType::Double => "double",
+            ValueType::String => "string",
+            ValueType::Keyword => "keyword",
+            ValueType::Uuid => "uuid",
+        })
+    }
+
+    pub fn to_typed_value(self) -> TypedValue {
         TypedValue::typed_ns_keyword("db.type", match self {
             ValueType::Ref => "ref",
             ValueType::Boolean => "boolean",
@@ -501,7 +514,7 @@ pub mod attribute {
 
     impl Unique {
         // This is easier than rejigging DB_UNIQUE_VALUE to not be EDN.
-        pub fn to_keyword(self) -> TypedValue {
+        pub fn to_typed_value(self) -> TypedValue {
             match self {
                 Unique::Value => TypedValue::typed_ns_keyword("db.unique", "value"),
                 Unique::Identity => TypedValue::typed_ns_keyword("db.unique", "identity"),

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -644,7 +644,7 @@ pub type IdentMap = BTreeMap<NamespacedKeyword, Entid>;
 pub type EntidMap = BTreeMap<Entid, NamespacedKeyword>;
 
 /// Map attribute entids to `Attribute` instances.
-pub type SchemaMap = BTreeMap<Entid, Attribute>;
+pub type AttributeMap = BTreeMap<Entid, Attribute>;
 
 /// Represents a Mentat schema.
 ///
@@ -669,7 +669,7 @@ pub struct Schema {
     ///
     /// Invariant: key-set is the same as the key-set of `entid_map` (equivalently, the value-set of
     /// `ident_map`).
-    pub schema_map: SchemaMap,
+    pub attribute_map: AttributeMap,
 }
 
 impl Schema {
@@ -682,7 +682,7 @@ impl Schema {
     }
 
     pub fn attribute_for_entid(&self, x: Entid) -> Option<&Attribute> {
-        self.schema_map.get(&x)
+        self.attribute_map.get(&x)
     }
 
     pub fn attribute_for_ident(&self, ident: &NamespacedKeyword) -> Option<&Attribute> {
@@ -692,7 +692,7 @@ impl Schema {
 
     /// Return true if the provided entid identifies an attribute in this schema.
     pub fn is_attribute(&self, x: Entid) -> bool {
-        self.schema_map.contains_key(&x)
+        self.attribute_map.contains_key(&x)
     }
 
     /// Return true if the provided ident identifies an attribute in this schema.
@@ -702,7 +702,7 @@ impl Schema {
 
     /// Returns an symbolic representation of the schema suitable for applying across Mentat stores.
     pub fn to_edn_value(&self) -> edn::Value {
-        edn::Value::Vector((&self.schema_map).iter()
+        edn::Value::Vector((&self.attribute_map).iter()
             .map(|(entid, attribute)| 
                 attribute.to_edn_value(self.get_ident(*entid).cloned()))
             .collect())
@@ -721,7 +721,7 @@ mod test {
     }
 
     fn add_attribute(schema: &mut Schema, e: Entid, a: Attribute) {
-        schema.schema_map.insert(e, a);
+        schema.attribute_map.insert(e, a);
     }
 
     #[test]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -100,6 +100,19 @@ impl enum_set::CLike for ValueType {
 }
 
 impl ValueType {
+    pub fn to_keyword(self) -> TypedValue {
+        TypedValue::typed_ns_keyword("db.type", match self {
+            ValueType::Ref => "ref",
+            ValueType::Boolean => "boolean",
+            ValueType::Instant => "instant",
+            ValueType::Long => "long",
+            ValueType::Double => "double",
+            ValueType::String => "string",
+            ValueType::Keyword => "keyword",
+            ValueType::Uuid => "uuid",
+        })
+    }
+
     pub fn to_edn_value(self) -> edn::Value {
         match self {
             ValueType::Ref => values::DB_TYPE_REF.clone(),
@@ -478,10 +491,22 @@ pub enum AttributeBitFlags {
 }
 
 pub mod attribute {
-    #[derive(Clone,Debug,Eq,Hash,Ord,PartialOrd,PartialEq)]
+    use TypedValue;
+
+    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialOrd, PartialEq)]
     pub enum Unique {
         Value,
         Identity,
+    }
+
+    impl Unique {
+        // This is easier than rejigging DB_UNIQUE_VALUE to not be EDN.
+        pub fn to_keyword(self) -> TypedValue {
+            match self {
+                Unique::Value => TypedValue::typed_ns_keyword("db.unique", "value"),
+                Unique::Identity => TypedValue::typed_ns_keyword("db.unique", "identity"),
+            }
+        }
     }
 }
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -693,6 +693,8 @@ pub trait HasSchema {
     fn get_ident<T>(&self, x: T) -> Option<&NamespacedKeyword> where T: Into<Entid>;
     fn get_entid(&self, x: &NamespacedKeyword) -> Option<KnownEntid>;
     fn attribute_for_entid<T>(&self, x: T) -> Option<&Attribute> where T: Into<Entid>;
+
+    // Returns the attribute and the entid named by the provided ident.
     fn attribute_for_ident(&self, ident: &NamespacedKeyword) -> Option<(&Attribute, KnownEntid)>;
 
     /// Return true if the provided entid identifies an attribute in this schema.

--- a/db/src/db.rs
+++ b/db/src/db.rs
@@ -1217,12 +1217,12 @@ mod tests {
 
             // Does not include :db/txInstant.
             let datoms = debug::datoms_after(&conn, &db.schema, 0).unwrap();
-            assert_eq!(datoms.0.len(), 76);
+            assert_eq!(datoms.0.len(), 94);
 
             // Includes :db/txInstant.
             let transactions = debug::transactions_after(&conn, &db.schema, 0).unwrap();
             assert_eq!(transactions.0.len(), 1);
-            assert_eq!(transactions.0[0].0.len(), 77);
+            assert_eq!(transactions.0[0].0.len(), 95);
 
             let mut parts = db.partition_map;
 

--- a/db/src/db.rs
+++ b/db/src/db.rs
@@ -1106,6 +1106,8 @@ mod tests {
     use debug;
     use edn;
     use mentat_core::{
+        HasSchema,
+        Schema,
         attribute,
     };
     use mentat_tx_parser;

--- a/db/src/db.rs
+++ b/db/src/db.rs
@@ -44,7 +44,7 @@ use mentat_core::{
     FromMicros,
     IdentMap,
     Schema,
-    SchemaMap,
+    AttributeMap,
     TypedValue,
     ToMicros,
     ValueType,
@@ -479,11 +479,11 @@ fn read_ident_map(conn: &rusqlite::Connection) -> Result<IdentMap> {
 }
 
 /// Read the schema materialized view from the given SQL store.
-fn read_schema_map(conn: &rusqlite::Connection) -> Result<SchemaMap> {
+fn read_attribute_map(conn: &rusqlite::Connection) -> Result<AttributeMap> {
     let entid_triples = read_materialized_view(conn, "schema")?;
-    let mut schema_map = SchemaMap::default();
-    metadata::update_schema_map_from_entid_triples(&mut schema_map, entid_triples)?;
-    Ok(schema_map)
+    let mut attribute_map = AttributeMap::default();
+    metadata::update_attribute_map_from_entid_triples(&mut attribute_map, entid_triples)?;
+    Ok(attribute_map)
 }
 
 /// Read the materialized views from the given SQL store and return a Mentat `DB` for querying and
@@ -491,8 +491,8 @@ fn read_schema_map(conn: &rusqlite::Connection) -> Result<SchemaMap> {
 pub fn read_db(conn: &rusqlite::Connection) -> Result<DB> {
     let partition_map = read_partition_map(conn)?;
     let ident_map = read_ident_map(conn)?;
-    let schema_map = read_schema_map(conn)?;
-    let schema = Schema::from_ident_map_and_schema_map(ident_map, schema_map)?;
+    let attribute_map = read_attribute_map(conn)?;
+    let schema = Schema::from_ident_map_and_attribute_map(ident_map, attribute_map)?;
     Ok(DB::new(partition_map, schema))
 }
 
@@ -1158,9 +1158,9 @@ mod tests {
     impl TestConn {
         fn assert_materialized_views(&self) {
             let materialized_ident_map = read_ident_map(&self.sqlite).expect("ident map");
-            let materialized_schema_map = read_schema_map(&self.sqlite).expect("schema map");
+            let materialized_attribute_map = read_attribute_map(&self.sqlite).expect("schema map");
 
-            let materialized_schema = Schema::from_ident_map_and_schema_map(materialized_ident_map, materialized_schema_map).expect("schema");
+            let materialized_schema = Schema::from_ident_map_and_attribute_map(materialized_ident_map, materialized_attribute_map).expect("schema");
             assert_eq!(materialized_schema, self.schema);
         }
 

--- a/db/src/debug.rs
+++ b/db/src/debug.rs
@@ -27,6 +27,7 @@ use edn;
 use entids;
 use errors::Result;
 use mentat_core::{
+    HasSchema,
     SQLValueType,
     TypedValue,
     ValueType,

--- a/db/src/entids.rs
+++ b/db/src/entids.rs
@@ -56,6 +56,7 @@ pub const DB_UNIQUE_IDENTITY: Entid = 36;
 pub const DB_DOC: Entid = 37;
 pub const DB_SCHEMA_VERSION: Entid = 38;
 pub const DB_SCHEMA_ATTRIBUTE: Entid = 39;
+pub const DB_SCHEMA_CORE: Entid = 40;
 
 /// Return `false` if the given attribute will not change the metadata: recognized idents, schema,
 /// partitions in the partition map.

--- a/db/src/internal_types.rs
+++ b/db/src/internal_types.rs
@@ -15,6 +15,8 @@
 use std::collections::HashMap;
 use std::rc::Rc;
 
+use mentat_core::KnownEntid;
+
 use mentat_core::util::Either;
 
 use errors;
@@ -36,10 +38,6 @@ pub enum Term<E, V> {
 }
 
 use self::Either::*;
-
-/// An entid that's either already in the store, or newly allocated to a tempid.
-#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
-pub struct KnownEntid(pub Entid);
 
 pub type KnownEntidOr<T> = Either<KnownEntid, T>;
 pub type TypedValueOr<T> = Either<TypedValue, T>;

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -44,7 +44,7 @@ pub mod errors;
 mod metadata;
 mod schema;
 pub mod types;
-mod internal_types;
+pub mod internal_types;    // pub because we need them for building entities programmatically.
 mod upsert_resolution;
 mod tx;
 

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -57,6 +57,14 @@ pub use bootstrap::{
 
 pub use schema::AttributeBuilder;
 
+pub use bootstrap::{
+    CORE_SCHEMA_VERSION,
+};
+
+pub use entids::{
+    DB_SCHEMA_CORE,
+};
+
 pub use db::{
     TypedSQLValue,
     new_connection,

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -55,6 +55,8 @@ pub use bootstrap::{
     USER0,
 };
 
+pub use schema::AttributeBuilder;
+
 pub use db::{
     TypedSQLValue,
     new_connection,

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -70,7 +70,11 @@ pub use db::{
     new_connection,
 };
 
-pub use tx::transact;
+pub use tx::{
+    transact,
+    transact_terms,
+};
+
 pub use types::{
     DB,
     PartitionMap,

--- a/db/src/metadata.rs
+++ b/db/src/metadata.rs
@@ -142,8 +142,8 @@ pub fn update_attribute_map_from_entid_triples<U>(attribute_map: &mut AttributeM
                     //     builder.unique_value(false);
                     //     builder.unique_identity(false);
                     // },
-                    TypedValue::Ref(entids::DB_UNIQUE_VALUE) => { builder.unique(Some(attribute::Unique::Value)); },
-                    TypedValue::Ref(entids::DB_UNIQUE_IDENTITY) => { builder.unique(Some(attribute::Unique::Identity)); },
+                    TypedValue::Ref(entids::DB_UNIQUE_VALUE) => { builder.unique(attribute::Unique::Value); },
+                    TypedValue::Ref(entids::DB_UNIQUE_IDENTITY) => { builder.unique(attribute::Unique::Identity); },
                     _ => bail!(ErrorKind::BadSchemaAssertion(format!("Expected [... :db/unique :db.unique/value|:db.unique/identity] but got [... :db/unique {:?}]", value)))
                 }
             },

--- a/db/src/metadata.rs
+++ b/db/src/metadata.rs
@@ -43,7 +43,7 @@ use mentat_core::{
     attribute,
     Entid,
     Schema,
-    SchemaMap,
+    AttributeMap,
     TypedValue,
     ValueType,
 };
@@ -78,24 +78,24 @@ pub enum IdentAlteration {
 /// Summarizes changes to metadata such as a a `Schema` and (in the future) a `PartitionMap`.
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialOrd, PartialEq)]
 pub struct MetadataReport {
-    // Entids that were not present in the original `SchemaMap` that was mutated.
+    // Entids that were not present in the original `AttributeMap` that was mutated.
     pub attributes_installed: BTreeSet<Entid>,
 
-    // Entids that were present in the original `SchemaMap` that was mutated, together with a
+    // Entids that were present in the original `AttributeMap` that was mutated, together with a
     // representation of the mutations that were applied.
     pub attributes_altered: BTreeMap<Entid, Vec<AttributeAlteration>>,
 
-    // Idents that were installed into the `SchemaMap`.
+    // Idents that were installed into the `AttributeMap`.
     pub idents_altered: BTreeMap<Entid, IdentAlteration>,
 }
 
-/// Update a `SchemaMap` in place from the given `[e a typed_value]` triples.
+/// Update a `AttributeMap` in place from the given `[e a typed_value]` triples.
 ///
-/// This is suitable for producing a `SchemaMap` from the `schema` materialized view, which does not
+/// This is suitable for producing a `AttributeMap` from the `schema` materialized view, which does not
 /// contain install and alter markers.
 ///
 /// Returns a report summarizing the mutations that were applied.
-pub fn update_schema_map_from_entid_triples<U>(schema_map: &mut SchemaMap, assertions: U) -> Result<MetadataReport>
+pub fn update_attribute_map_from_entid_triples<U>(attribute_map: &mut AttributeMap, assertions: U) -> Result<MetadataReport>
     where U: IntoIterator<Item=(Entid, Entid, TypedValue)> {
 
     // Group mutations by impacted entid.
@@ -179,7 +179,7 @@ pub fn update_schema_map_from_entid_triples<U>(schema_map: &mut SchemaMap, asser
     let mut attributes_altered: BTreeMap<Entid, Vec<AttributeAlteration>> = BTreeMap::default();
 
     for (entid, builder) in builders.into_iter() {
-        match schema_map.entry(entid) {
+        match attribute_map.entry(entid) {
             Entry::Vacant(entry) => {
                 builder.validate_install_attribute()
                     .chain_err(|| ErrorKind::BadSchemaAssertion(format!("Schema alteration for new attribute with entid {} is not valid", entid)))?;
@@ -245,7 +245,7 @@ pub fn update_schema_from_entid_quadruples<U>(schema: &mut Schema, assertions: U
     let asserted_triples = attribute_set.asserted.into_iter().map(|((e, a), typed_value)| (e, a, typed_value));
     let altered_triples = attribute_set.altered.into_iter().map(|((e, a), (_old_value, new_value))| (e, a, new_value));
 
-    let report = update_schema_map_from_entid_triples(&mut schema.schema_map, asserted_triples.chain(altered_triples))?;
+    let report = update_attribute_map_from_entid_triples(&mut schema.attribute_map, asserted_triples.chain(altered_triples))?;
 
     let mut idents_altered: BTreeMap<Entid, IdentAlteration> = BTreeMap::new();
 

--- a/db/src/schema.rs
+++ b/db/src/schema.rs
@@ -21,7 +21,7 @@ use mentat_core::{
     EntidMap,
     IdentMap,
     Schema,
-    SchemaMap,
+    AttributeMap,
     TypedValue,
     ValueType,
 };
@@ -30,9 +30,9 @@ use metadata::{
     AttributeAlteration,
 };
 
-/// Return `Ok(())` if `schema_map` defines a valid Mentat schema.
-fn validate_schema_map(entid_map: &EntidMap, schema_map: &SchemaMap) -> Result<()> {
-    for (entid, attribute) in schema_map {
+/// Return `Ok(())` if `attribute_map` defines a valid Mentat schema.
+fn validate_attribute_map(entid_map: &EntidMap, attribute_map: &AttributeMap) -> Result<()> {
+    for (entid, attribute) in attribute_map {
         let ident = || entid_map.get(entid).map(|ident| ident.to_string()).unwrap_or(entid.to_string());
         if attribute.unique == Some(attribute::Unique::Value) && !attribute.index {
             bail!(ErrorKind::BadSchemaAssertion(format!(":db/unique :db/unique_value without :db/index true for entid: {}", ident())))
@@ -174,7 +174,7 @@ pub trait SchemaBuilding {
     fn require_ident(&self, entid: Entid) -> Result<&symbols::NamespacedKeyword>;
     fn require_entid(&self, ident: &symbols::NamespacedKeyword) -> Result<Entid>;
     fn require_attribute_for_entid(&self, entid: Entid) -> Result<&Attribute>;
-    fn from_ident_map_and_schema_map(ident_map: IdentMap, schema_map: SchemaMap) -> Result<Schema>;
+    fn from_ident_map_and_attribute_map(ident_map: IdentMap, attribute_map: AttributeMap) -> Result<Schema>;
     fn from_ident_map_and_triples<U>(ident_map: IdentMap, assertions: U) -> Result<Schema>
         where U: IntoIterator<Item=(symbols::NamespacedKeyword, symbols::NamespacedKeyword, TypedValue)>;
 }
@@ -193,15 +193,15 @@ impl SchemaBuilding for Schema {
     }
 
     /// Create a valid `Schema` from the constituent maps.
-    fn from_ident_map_and_schema_map(ident_map: IdentMap, schema_map: SchemaMap) -> Result<Schema> {
+    fn from_ident_map_and_attribute_map(ident_map: IdentMap, attribute_map: AttributeMap) -> Result<Schema> {
         let entid_map: EntidMap = ident_map.iter().map(|(k, v)| (v.clone(), k.clone())).collect();
 
-        validate_schema_map(&entid_map, &schema_map)?;
+        validate_attribute_map(&entid_map, &attribute_map)?;
 
         Ok(Schema {
             ident_map: ident_map,
             entid_map: entid_map,
-            schema_map: schema_map,
+            attribute_map: attribute_map,
         })
     }
 
@@ -214,8 +214,8 @@ impl SchemaBuilding for Schema {
             let attr: i64 = *ident_map.get(&symbolic_attr).ok_or(ErrorKind::UnrecognizedIdent(symbolic_attr.to_string()))?;
             Ok((ident, attr, value))
         }).collect();
-        let mut schema = Schema::from_ident_map_and_schema_map(ident_map, SchemaMap::default())?;
-        metadata::update_schema_map_from_entid_triples(&mut schema.schema_map, entid_assertions?)?;
+        let mut schema = Schema::from_ident_map_and_attribute_map(ident_map, AttributeMap::default())?;
+        metadata::update_attribute_map_from_entid_triples(&mut schema.attribute_map, entid_assertions?)?;
         Ok(schema)
     }
 }
@@ -283,11 +283,11 @@ mod test {
         schema.entid_map.insert(entid, ident.clone());
         schema.ident_map.insert(ident.clone(), entid);
 
-        schema.schema_map.insert(entid, attribute);
+        schema.attribute_map.insert(entid, attribute);
     }
 
     #[test]
-    fn validate_schema_map_success() {
+    fn validate_attribute_map_success() {
         let mut schema = Schema::default();
         // attribute that is not an index has no uniqueness
         add_attribute(&mut schema, NamespacedKeyword::new("foo", "bar"), 97, Attribute {
@@ -335,7 +335,7 @@ mod test {
             component: false,
         });
 
-        assert!(validate_schema_map(&schema.entid_map, &schema.schema_map).is_ok());
+        assert!(validate_attribute_map(&schema.entid_map, &schema.attribute_map).is_ok());
     }
 
     #[test]
@@ -352,7 +352,7 @@ mod test {
             component: false,
         });
         
-        let err = validate_schema_map(&schema.entid_map, &schema.schema_map).err();
+        let err = validate_attribute_map(&schema.entid_map, &schema.attribute_map).err();
         assert!(err.is_some());
         
         match err.unwrap() {
@@ -374,7 +374,7 @@ mod test {
             component: false,
         });
         
-        let err = validate_schema_map(&schema.entid_map, &schema.schema_map).err();
+        let err = validate_attribute_map(&schema.entid_map, &schema.attribute_map).err();
         assert!(err.is_some());
         
         match err.unwrap() {
@@ -396,7 +396,7 @@ mod test {
             component: true,
         });
         
-        let err = validate_schema_map(&schema.entid_map, &schema.schema_map).err();
+        let err = validate_attribute_map(&schema.entid_map, &schema.attribute_map).err();
         assert!(err.is_some());
         
         match err.unwrap() {
@@ -418,7 +418,7 @@ mod test {
             component: false,
         });
         
-        let err = validate_schema_map(&schema.entid_map, &schema.schema_map).err();
+        let err = validate_attribute_map(&schema.entid_map, &schema.attribute_map).err();
         assert!(err.is_some());
         
         match err.unwrap() {
@@ -439,7 +439,7 @@ mod test {
             component: false,
         });
         
-        let err = validate_schema_map(&schema.entid_map, &schema.schema_map).err();
+        let err = validate_attribute_map(&schema.entid_map, &schema.attribute_map).err();
         assert!(err.is_some());
         
         match err.unwrap() {

--- a/db/src/schema.rs
+++ b/db/src/schema.rs
@@ -21,6 +21,7 @@ use mentat_core::{
     EntidMap,
     HasSchema,
     IdentMap,
+    KnownEntid,
     Schema,
     AttributeMap,
     TypedValue,
@@ -173,7 +174,7 @@ impl AttributeBuilder {
 
 pub trait SchemaBuilding {
     fn require_ident(&self, entid: Entid) -> Result<&symbols::NamespacedKeyword>;
-    fn require_entid(&self, ident: &symbols::NamespacedKeyword) -> Result<Entid>;
+    fn require_entid(&self, ident: &symbols::NamespacedKeyword) -> Result<KnownEntid>;
     fn require_attribute_for_entid(&self, entid: Entid) -> Result<&Attribute>;
     fn from_ident_map_and_attribute_map(ident_map: IdentMap, attribute_map: AttributeMap) -> Result<Schema>;
     fn from_ident_map_and_triples<U>(ident_map: IdentMap, assertions: U) -> Result<Schema>
@@ -185,7 +186,7 @@ impl SchemaBuilding for Schema {
         self.get_ident(entid).ok_or(ErrorKind::UnrecognizedEntid(entid).into())
     }
 
-    fn require_entid(&self, ident: &symbols::NamespacedKeyword) -> Result<Entid> {
+    fn require_entid(&self, ident: &symbols::NamespacedKeyword) -> Result<KnownEntid> {
         self.get_entid(&ident).ok_or(ErrorKind::UnrecognizedIdent(ident.to_string()).into())
     }
 
@@ -248,7 +249,7 @@ impl SchemaTypeChecking for Schema {
                 (ValueType::Keyword, tv @ TypedValue::Keyword(_)) => Ok(tv),
                 // Ref coerces a little: we interpret some things depending on the schema as a Ref.
                 (ValueType::Ref, TypedValue::Long(x)) => Ok(TypedValue::Ref(x)),
-                (ValueType::Ref, TypedValue::Keyword(ref x)) => self.require_entid(&x).map(|entid| TypedValue::Ref(entid)),
+                (ValueType::Ref, TypedValue::Keyword(ref x)) => self.require_entid(&x).map(|entid| entid.into()),
 
                 // Otherwise, we have a type mismatch.
                 // Enumerate all of the types here to allow the compiler to help us.

--- a/db/src/schema.rs
+++ b/db/src/schema.rs
@@ -79,8 +79,8 @@ impl AttributeBuilder {
         self
     }
 
-    pub fn unique<'a>(&'a mut self, unique: Option<attribute::Unique>) -> &'a mut Self {
-        self.unique = Some(unique);
+    pub fn unique<'a>(&'a mut self, unique: attribute::Unique) -> &'a mut Self {
+        self.unique = Some(Some(unique));
         self
     }
 

--- a/db/src/schema.rs
+++ b/db/src/schema.rs
@@ -19,6 +19,7 @@ use mentat_core::{
     Attribute,
     Entid,
     EntidMap,
+    HasSchema,
     IdentMap,
     Schema,
     AttributeMap,

--- a/db/src/tx.rs
+++ b/db/src/tx.rs
@@ -510,9 +510,6 @@ impl<'conn, 'a> Tx<'conn, 'a> {
     /// This approach is explained in https://github.com/mozilla/mentat/wiki/Transacting.
     // TODO: move this to the transactor layer.
     pub fn transact_entities<I>(&mut self, entities: I) -> Result<TxReport> where I: IntoIterator<Item=Entity> {
-        // TODO: push these into an internal transaction report?
-        let mut tempids: BTreeMap<TempId, KnownEntid> = BTreeMap::default();
-
         // Pipeline stage 1: entities -> terms with tempids and lookup refs.
         let (terms_with_temp_ids_and_lookup_refs, tempid_set, lookup_ref_set) = self.entities_into_terms_with_temp_ids_and_lookup_refs(entities)?;
 
@@ -522,9 +519,16 @@ impl<'conn, 'a> Tx<'conn, 'a> {
 
         let terms_with_temp_ids = self.resolve_lookup_refs(&lookup_ref_map, terms_with_temp_ids_and_lookup_refs)?;
 
+        self.transact_simple_terms(terms_with_temp_ids, tempid_set)
+    }
+
+    pub fn transact_simple_terms<I>(&mut self, terms: I, tempid_set: InternSet<TempId>) -> Result<TxReport> where I: IntoIterator<Item=TermWithTempIds> {
+        // TODO: push these into an internal transaction report?
+        let mut tempids: BTreeMap<TempId, KnownEntid> = BTreeMap::default();
+
         // Pipeline stage 3: upsert tempids -> terms without tempids or lookup refs.
         // Now we can collect upsert populations.
-        let (mut generation, inert_terms) = Generation::from(terms_with_temp_ids, &self.schema)?;
+        let (mut generation, inert_terms) = Generation::from(terms, &self.schema)?;
 
         // And evolve them forward.
         while generation.can_evolve() {
@@ -685,32 +689,56 @@ impl<'conn, 'a> Tx<'conn, 'a> {
     }
 }
 
-/// Transact the given `entities` against the given SQLite `conn`, using the given metadata.
-/// If you want this work to occur inside a SQLite transaction, establish one on the connection
-/// prior to calling this function.
-///
-/// This approach is explained in https://github.com/mozilla/mentat/wiki/Transacting.
-// TODO: move this to the transactor layer.
-pub fn transact<'conn, 'a, I>(
-    conn: &'conn rusqlite::Connection,
-    mut partition_map: PartitionMap,
-    schema_for_mutation: &'a Schema,
-    schema: &'a Schema,
-    entities: I) -> Result<(TxReport, PartitionMap, Option<Schema>)> where I: IntoIterator<Item=Entity> {
-
+/// Initialize a new Tx object with a new tx id and a tx instant. Kick off the SQLite conn, too.
+fn start_tx<'conn, 'a>(conn: &'conn rusqlite::Connection,
+                       mut partition_map: PartitionMap,
+                       schema_for_mutation: &'a Schema,
+                       schema: &'a Schema) -> Result<Tx<'conn, 'a>> {
     let tx_instant = ::now(); // Label the transaction with the timestamp when we first see it: leading edge.
     let tx_id = partition_map.allocate_entid(":db.part/tx");
 
     conn.begin_tx_application()?;
 
-    let mut tx = Tx::new(conn, partition_map, schema_for_mutation, schema, tx_id, tx_instant);
+    Ok(Tx::new(conn, partition_map, schema_for_mutation, schema, tx_id, tx_instant))
+}
 
-    let report = tx.transact_entities(entities)?;
-
+fn conclude_tx(tx: Tx, report: TxReport) -> Result<(TxReport, PartitionMap, Option<Schema>)> {
     // If the schema has moved on, return it.
     let next_schema = match tx.schema_for_mutation {
         Cow::Borrowed(_) => None,
         Cow::Owned(next_schema) => Some(next_schema),
     };
     Ok((report, tx.partition_map, next_schema))
+}
+
+/// Transact the given `entities` against the given SQLite `conn`, using the given metadata.
+/// If you want this work to occur inside a SQLite transaction, establish one on the connection
+/// prior to calling this function.
+///
+/// This approach is explained in https://github.com/mozilla/mentat/wiki/Transacting.
+// TODO: move this to the transactor layer.
+pub fn transact<'conn, 'a, I>(conn: &'conn rusqlite::Connection,
+                              partition_map: PartitionMap,
+                              schema_for_mutation: &'a Schema,
+                              schema: &'a Schema,
+                              entities: I) -> Result<(TxReport, PartitionMap, Option<Schema>)>
+    where I: IntoIterator<Item=Entity> {
+
+    let mut tx = start_tx(conn, partition_map, schema_for_mutation, schema)?;
+    let report = tx.transact_entities(entities)?;
+    conclude_tx(tx, report)
+}
+
+/// Just like `transact`, but accepts lower-level inputs to allow bypassing the parser interface.
+pub fn transact_terms<'conn, 'a, I>(conn: &'conn rusqlite::Connection,
+                                    partition_map: PartitionMap,
+                                    schema_for_mutation: &'a Schema,
+                                    schema: &'a Schema,
+                                    terms: I,
+                                    tempid_set: InternSet<TempId>) -> Result<(TxReport, PartitionMap, Option<Schema>)>
+    where I: IntoIterator<Item=TermWithTempIds> {
+
+    let mut tx = start_tx(conn, partition_map, schema_for_mutation, schema)?;
+    let report = tx.transact_simple_terms(terms, tempid_set)?;
+    conclude_tx(tx, report)
 }

--- a/db/src/tx.rs
+++ b/db/src/tx.rs
@@ -64,7 +64,6 @@ use edn::{
 use entids;
 use errors::{ErrorKind, Result};
 use internal_types::{
-    KnownEntid,
     KnownEntidOr,
     LookupRef,
     LookupRefOrTempId,
@@ -82,6 +81,7 @@ use mentat_core::util::Either;
 
 use mentat_core::{
     DateTime,
+    KnownEntid,
     Schema,
     Utc,
     attribute,
@@ -230,14 +230,13 @@ impl<'conn, 'a> Tx<'conn, 'a> {
             }
 
             fn ensure_ident_exists(&self, e: &NamespacedKeyword) -> Result<KnownEntid> {
-                let entid = self.schema.require_entid(e)?;
-                Ok(KnownEntid(entid))
+                self.schema.require_entid(e)
             }
 
             fn intern_lookup_ref(&mut self, lookup_ref: &entmod::LookupRef) -> Result<LookupRef> {
                 let lr_a: i64 = match lookup_ref.a {
                     entmod::Entid::Entid(ref a) => *a,
-                    entmod::Entid::Ident(ref a) => self.schema.require_entid(&a)?,
+                    entmod::Entid::Ident(ref a) => self.schema.require_entid(&a)?.into(),
                 };
                 let lr_attribute: &Attribute = self.schema.require_attribute_for_entid(lr_a)?;
 
@@ -283,7 +282,7 @@ impl<'conn, 'a> Tx<'conn, 'a> {
             fn entity_a_into_term_a(&mut self, x: entmod::Entid) -> Result<Entid> {
                 let a = match x {
                     entmod::Entid::Entid(ref a) => *a,
-                    entmod::Entid::Ident(ref a) => self.schema.require_entid(&a)?,
+                    entmod::Entid::Ident(ref a) => self.schema.require_entid(&a)?.into(),
                 };
                 Ok(a)
             }

--- a/db/src/tx.rs
+++ b/db/src/tx.rs
@@ -85,8 +85,10 @@ use mentat_core::{
     Schema,
     Utc,
     attribute,
-    intern_set,
 };
+
+use mentat_core::intern_set::InternSet;
+
 use mentat_tx::entities as entmod;
 use mentat_tx::entities::{
     Entity,
@@ -199,13 +201,13 @@ impl<'conn, 'a> Tx<'conn, 'a> {
     ///
     /// The `Term` instances produce share interned TempId and LookupRef handles, and we return the
     /// interned handle sets so that consumers can ensure all handles are used appropriately.
-    fn entities_into_terms_with_temp_ids_and_lookup_refs<I>(&self, entities: I) -> Result<(Vec<TermWithTempIdsAndLookupRefs>, intern_set::InternSet<TempId>, intern_set::InternSet<AVPair>)> where I: IntoIterator<Item=Entity> {
+    fn entities_into_terms_with_temp_ids_and_lookup_refs<I>(&self, entities: I) -> Result<(Vec<TermWithTempIdsAndLookupRefs>, InternSet<TempId>, InternSet<AVPair>)> where I: IntoIterator<Item=Entity> {
         struct InProcess<'a> {
             partition_map: &'a PartitionMap,
             schema: &'a Schema,
             mentat_id_count: i64,
-            temp_ids: intern_set::InternSet<TempId>,
-            lookup_refs: intern_set::InternSet<AVPair>,
+            temp_ids: InternSet<TempId>,
+            lookup_refs: InternSet<AVPair>,
         }
 
         impl<'a> InProcess<'a> {
@@ -214,8 +216,8 @@ impl<'conn, 'a> Tx<'conn, 'a> {
                     partition_map,
                     schema,
                     mentat_id_count: 0,
-                    temp_ids: intern_set::InternSet::new(),
-                    lookup_refs: intern_set::InternSet::new(),
+                    temp_ids: InternSet::new(),
+                    lookup_refs: InternSet::new(),
                 }
             }
 

--- a/db/src/tx.rs
+++ b/db/src/tx.rs
@@ -685,6 +685,8 @@ impl<'conn, 'a> Tx<'conn, 'a> {
 }
 
 /// Transact the given `entities` against the given SQLite `conn`, using the given metadata.
+/// If you want this work to occur inside a SQLite transaction, establish one on the connection
+/// prior to calling this function.
 ///
 /// This approach is explained in https://github.com/mozilla/mentat/wiki/Transacting.
 // TODO: move this to the transactor layer.
@@ -694,8 +696,6 @@ pub fn transact<'conn, 'a, I>(
     schema_for_mutation: &'a Schema,
     schema: &'a Schema,
     entities: I) -> Result<(TxReport, PartitionMap, Option<Schema>)> where I: IntoIterator<Item=Entity> {
-    // Eventually, this function will be responsible for managing a SQLite transaction.  For
-    // now, it's just about the tx details.
 
     let tx_instant = ::now(); // Label the transaction with the timestamp when we first see it: leading edge.
     let tx_id = partition_map.allocate_entid(":db.part/tx");

--- a/db/src/types.rs
+++ b/db/src/types.rs
@@ -83,7 +83,6 @@ pub type AVPair = (Entid, TypedValue);
 pub type AVMap<'a> = HashMap<&'a AVPair, Entid>;
 
 /// A transaction report summarizes an applied transaction.
-// TODO: include map of resolved tempids.
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialOrd, PartialEq)]
 pub struct TxReport {
     /// The transaction ID of the transaction.

--- a/query-algebrizer/src/clauses/convert.rs
+++ b/query-algebrizer/src/clauses/convert.rs
@@ -11,6 +11,7 @@
 use std::rc::Rc;
 
 use mentat_core::{
+    HasSchema,
     Schema,
     SQLValueType,
     TypedValue,

--- a/query-algebrizer/src/clauses/convert.rs
+++ b/query-algebrizer/src/clauses/convert.rs
@@ -170,7 +170,7 @@ impl ConjoiningClauses {
                     },
                     (true, false) => {
                         // This can only be an ident. Look it up!
-                        match schema.get_entid(&x).map(TypedValue::Ref) {
+                        match schema.get_entid(&x).map(|k| k.into()) {
                             Some(e) => Ok(Val(e)),
                             None => Ok(Impossible(EmptyBecause::UnresolvedIdent(x.clone()))),
                         }

--- a/query-algebrizer/src/clauses/fulltext.rs
+++ b/query-algebrizer/src/clauses/fulltext.rs
@@ -9,6 +9,7 @@
 // specific language governing permissions and limitations under the License.
 
 use mentat_core::{
+    HasSchema,
     Schema,
     TypedValue,
     ValueType,

--- a/query-algebrizer/src/clauses/fulltext.rs
+++ b/query-algebrizer/src/clauses/fulltext.rs
@@ -102,7 +102,7 @@ impl ConjoiningClauses {
         //
         // TODO: improve the expression of this matching, possibly by using attribute_for_* uniformly.
         let a = match args.next().unwrap() {
-            FnArg::IdentOrKeyword(i) => schema.get_entid(&i),
+            FnArg::IdentOrKeyword(i) => schema.get_entid(&i).map(|k| k.into()),
             // Must be an entid.
             FnArg::EntidOrInteger(e) => Some(e),
             FnArg::Variable(v) => {

--- a/query-algebrizer/src/clauses/mod.rs
+++ b/query-algebrizer/src/clauses/mod.rs
@@ -917,7 +917,7 @@ fn associate_ident(schema: &mut Schema, i: NamespacedKeyword, e: Entid) {
 
 #[cfg(test)]
 fn add_attribute(schema: &mut Schema, e: Entid, a: Attribute) {
-    schema.schema_map.insert(e, a);
+    schema.attribute_map.insert(e, a);
 }
 
 #[cfg(test)]

--- a/query-algebrizer/src/clauses/mod.rs
+++ b/query-algebrizer/src/clauses/mod.rs
@@ -26,6 +26,7 @@ use mentat_core::{
     Attribute,
     Entid,
     HasSchema,
+    KnownEntid,
     Schema,
     TypedValue,
     ValueType,
@@ -441,7 +442,7 @@ impl ConjoiningClauses {
                     match bound_val {
                         TypedValue::Keyword(ref kw) => {
                             if let Some(entid) = self.entid_for_ident(schema, kw) {
-                                self.constrain_column_to_entity(table, column, entid);
+                                self.constrain_column_to_entity(table, column, entid.into());
                             } else {
                                 // Impossible.
                                 // For attributes this shouldn't occur, because we check the binding in
@@ -649,7 +650,7 @@ impl ConjoiningClauses {
         self.empty_because = Some(why);
     }
 
-    fn entid_for_ident<'s, 'a>(&self, schema: &'s Schema, ident: &'a NamespacedKeyword) -> Option<Entid> {
+    fn entid_for_ident<'s, 'a>(&self, schema: &'s Schema, ident: &'a NamespacedKeyword) -> Option<KnownEntid> {
         schema.get_entid(&ident)
     }
 
@@ -714,7 +715,7 @@ impl ConjoiningClauses {
             &PatternNonValuePlace::Ident(ref kw) =>
                 schema.attribute_for_ident(kw)
                       .ok_or_else(|| EmptyBecause::InvalidAttributeIdent(kw.cloned()))
-                      .and_then(|attribute| self.table_for_attribute_and_value(attribute, value)),
+                      .and_then(|(attribute, _)| self.table_for_attribute_and_value(attribute, value)),
             &PatternNonValuePlace::Entid(id) =>
                 schema.attribute_for_entid(id)
                       .ok_or_else(|| EmptyBecause::InvalidAttributeEntid(id))
@@ -737,7 +738,7 @@ impl ConjoiningClauses {
                         // Don't recurse: avoid needing to clone the keyword.
                         schema.attribute_for_ident(kw)
                               .ok_or_else(|| EmptyBecause::InvalidAttributeIdent(kw.cloned()))
-                              .and_then(|attribute| self.table_for_attribute_and_value(attribute, value)),
+                              .and_then(|(attribute, _entid)| self.table_for_attribute_and_value(attribute, value)),
                     Some(v) => {
                         // This pattern cannot match: the caller has bound a non-entity value to an
                         // attribute place.
@@ -770,18 +771,20 @@ impl ConjoiningClauses {
             .ok()
     }
 
-    fn get_attribute_for_value<'s>(&self, schema: &'s Schema, value: &TypedValue) -> Option<&'s Attribute> {
+    fn get_attribute_for_value<'s>(&self, schema: &'s Schema, value: &TypedValue) -> Option<(&'s Attribute, KnownEntid)> {
         match value {
-            &TypedValue::Ref(id) => schema.attribute_for_entid(id),
+            // We know this one is known if the attribute lookup succeeds…
+            &TypedValue::Ref(id) => schema.attribute_for_entid(id).map(|a| (a, KnownEntid(id))),
             &TypedValue::Keyword(ref kw) => schema.attribute_for_ident(kw),
             _ => None,
         }
     }
 
-    fn get_attribute<'s, 'a>(&self, schema: &'s Schema, pattern: &'a Pattern) -> Option<&'s Attribute> {
+    fn get_attribute<'s, 'a>(&self, schema: &'s Schema, pattern: &'a Pattern) -> Option<(&'s Attribute, KnownEntid)> {
         match pattern.attribute {
             PatternNonValuePlace::Entid(id) =>
-                schema.attribute_for_entid(id),
+                // We know this one is known if the attribute lookup succeeds…
+                schema.attribute_for_entid(id).map(|a| (a, KnownEntid(id))),
             PatternNonValuePlace::Ident(ref kw) =>
                 schema.attribute_for_ident(kw),
             PatternNonValuePlace::Variable(ref var) =>
@@ -796,7 +799,7 @@ impl ConjoiningClauses {
     }
 
     fn get_value_type<'s, 'a>(&self, schema: &'s Schema, pattern: &'a Pattern) -> Option<ValueType> {
-        self.get_attribute(schema, pattern).map(|x| x.value_type)
+        self.get_attribute(schema, pattern).map(|x| x.0.value_type)
     }
 }
 

--- a/query-algebrizer/src/clauses/mod.rs
+++ b/query-algebrizer/src/clauses/mod.rs
@@ -715,7 +715,7 @@ impl ConjoiningClauses {
             &PatternNonValuePlace::Ident(ref kw) =>
                 schema.attribute_for_ident(kw)
                       .ok_or_else(|| EmptyBecause::InvalidAttributeIdent(kw.cloned()))
-                      .and_then(|(attribute, _)| self.table_for_attribute_and_value(attribute, value)),
+                      .and_then(|(attribute, _entid)| self.table_for_attribute_and_value(attribute, value)),
             &PatternNonValuePlace::Entid(id) =>
                 schema.attribute_for_entid(id)
                       .ok_or_else(|| EmptyBecause::InvalidAttributeEntid(id))

--- a/query-algebrizer/src/clauses/mod.rs
+++ b/query-algebrizer/src/clauses/mod.rs
@@ -25,6 +25,7 @@ use std::fmt::{
 use mentat_core::{
     Attribute,
     Entid,
+    HasSchema,
     Schema,
     TypedValue,
     ValueType,

--- a/query-algebrizer/src/clauses/mod.rs
+++ b/query-algebrizer/src/clauses/mod.rs
@@ -771,22 +771,22 @@ impl ConjoiningClauses {
             .ok()
     }
 
-    fn get_attribute_for_value<'s>(&self, schema: &'s Schema, value: &TypedValue) -> Option<(&'s Attribute, KnownEntid)> {
+    fn get_attribute_for_value<'s>(&self, schema: &'s Schema, value: &TypedValue) -> Option<&'s Attribute> {
         match value {
             // We know this one is known if the attribute lookup succeeds…
-            &TypedValue::Ref(id) => schema.attribute_for_entid(id).map(|a| (a, KnownEntid(id))),
-            &TypedValue::Keyword(ref kw) => schema.attribute_for_ident(kw),
+            &TypedValue::Ref(id) => schema.attribute_for_entid(id),
+            &TypedValue::Keyword(ref kw) => schema.attribute_for_ident(kw).map(|(a, _id)| a),
             _ => None,
         }
     }
 
-    fn get_attribute<'s, 'a>(&self, schema: &'s Schema, pattern: &'a Pattern) -> Option<(&'s Attribute, KnownEntid)> {
+    fn get_attribute<'s, 'a>(&self, schema: &'s Schema, pattern: &'a Pattern) -> Option<&'s Attribute> {
         match pattern.attribute {
             PatternNonValuePlace::Entid(id) =>
                 // We know this one is known if the attribute lookup succeeds…
-                schema.attribute_for_entid(id).map(|a| (a, KnownEntid(id))),
+                schema.attribute_for_entid(id),
             PatternNonValuePlace::Ident(ref kw) =>
-                schema.attribute_for_ident(kw),
+                schema.attribute_for_ident(kw).map(|(a, _id)| a),
             PatternNonValuePlace::Variable(ref var) =>
                 // If the pattern has a variable, we've already determined that the binding -- if
                 // any -- is acceptable and yields a table. Here, simply look to see if it names
@@ -799,7 +799,7 @@ impl ConjoiningClauses {
     }
 
     fn get_value_type<'s, 'a>(&self, schema: &'s Schema, pattern: &'a Pattern) -> Option<ValueType> {
-        self.get_attribute(schema, pattern).map(|x| x.0.value_type)
+        self.get_attribute(schema, pattern).map(|a| a.value_type)
     }
 }
 

--- a/query-algebrizer/src/clauses/not.rs
+++ b/query-algebrizer/src/clauses/not.rs
@@ -79,6 +79,7 @@ mod testing {
 
     use mentat_core::{
         Attribute, 
+        Schema,
         TypedValue, 
         ValueType,
         ValueTypeSet,

--- a/query-algebrizer/src/clauses/pattern.rs
+++ b/query-algebrizer/src/clauses/pattern.rs
@@ -100,7 +100,7 @@ impl ConjoiningClauses {
                 self.constrain_column_to_entity(col.clone(), DatomsColumn::Entity, entid),
             PatternNonValuePlace::Ident(ref ident) => {
                 if let Some(entid) = self.entid_for_ident(schema, ident.as_ref()) {
-                    self.constrain_column_to_entity(col.clone(), DatomsColumn::Entity, entid)
+                    self.constrain_column_to_entity(col.clone(), DatomsColumn::Entity, entid.into())
                 } else {
                     // A resolution failure means we're done here.
                     self.mark_known_empty(EmptyBecause::UnresolvedIdent(ident.cloned()));
@@ -125,7 +125,7 @@ impl ConjoiningClauses {
             },
             PatternNonValuePlace::Ident(ref ident) => {
                 if let Some(entid) = self.entid_for_ident(schema, ident) {
-                    self.constrain_attribute(col.clone(), entid);
+                    self.constrain_attribute(col.clone(), entid.into());
 
                     if !schema.is_attribute(entid) {
                         self.mark_known_empty(EmptyBecause::InvalidAttributeIdent(ident.cloned()));
@@ -191,7 +191,7 @@ impl ConjoiningClauses {
                 // such.
                 if let Some(ValueType::Ref) = value_type {
                     if let Some(entid) = self.entid_for_ident(schema, kw) {
-                        self.constrain_column_to_entity(col.clone(), DatomsColumn::Value, entid)
+                        self.constrain_column_to_entity(col.clone(), DatomsColumn::Value, entid.into())
                     } else {
                         // A resolution failure means we're done here: this attribute must have an
                         // entity value.
@@ -252,7 +252,7 @@ impl ConjoiningClauses {
             },
             PatternNonValuePlace::Ident(ref ident) => {
                 if let Some(entid) = self.entid_for_ident(schema, ident.as_ref()) {
-                    self.constrain_column_to_entity(col.clone(), DatomsColumn::Tx, entid)
+                    self.constrain_column_to_entity(col.clone(), DatomsColumn::Tx, entid.into())
                 } else {
                     // A resolution failure means we're done here.
                     self.mark_known_empty(EmptyBecause::UnresolvedIdent(ident.cloned()));

--- a/query-algebrizer/src/clauses/pattern.rs
+++ b/query-algebrizer/src/clauses/pattern.rs
@@ -9,6 +9,7 @@
 // specific language governing permissions and limitations under the License.
 
 use mentat_core::{
+    HasSchema,
     Schema,
     TypedValue,
     ValueType,

--- a/query-algebrizer/tests/fulltext.rs
+++ b/query-algebrizer/tests/fulltext.rs
@@ -41,7 +41,7 @@ fn associate_ident(schema: &mut Schema, i: NamespacedKeyword, e: Entid) {
 }
 
 fn add_attribute(schema: &mut Schema, e: Entid, a: Attribute) {
-    schema.schema_map.insert(e, a);
+    schema.attribute_map.insert(e, a);
 }
 
 fn prepopulated_schema() -> Schema {

--- a/query-algebrizer/tests/ground.rs
+++ b/query-algebrizer/tests/ground.rs
@@ -53,7 +53,7 @@ fn associate_ident(schema: &mut Schema, i: NamespacedKeyword, e: Entid) {
 
 #[cfg(test)]
 fn add_attribute(schema: &mut Schema, e: Entid, a: Attribute) {
-    schema.schema_map.insert(e, a);
+    schema.attribute_map.insert(e, a);
 }
 
 fn prepopulated_schema() -> Schema {

--- a/query-algebrizer/tests/predicate.rs
+++ b/query-algebrizer/tests/predicate.rs
@@ -48,7 +48,7 @@ fn associate_ident(schema: &mut Schema, i: NamespacedKeyword, e: Entid) {
 
 #[cfg(test)]
 fn add_attribute(schema: &mut Schema, e: Entid, a: Attribute) {
-    schema.schema_map.insert(e, a);
+    schema.attribute_map.insert(e, a);
 }
 
 fn prepopulated_schema() -> Schema {

--- a/query-translator/tests/translate.rs
+++ b/query-translator/tests/translate.rs
@@ -50,7 +50,7 @@ fn associate_ident(schema: &mut Schema, i: NamespacedKeyword, e: Entid) {
 }
 
 fn add_attribute(schema: &mut Schema, e: Entid, a: Attribute) {
-    schema.schema_map.insert(e, a);
+    schema.attribute_map.insert(e, a);
 }
 
 fn translate_with_inputs(schema: &Schema, query: &'static str, inputs: QueryInputs) -> SQLQuery {

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -21,6 +21,7 @@ use edn;
 
 use mentat_core::{
     Entid,
+    HasSchema,
     Schema,
     TypedValue,
 };

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -294,6 +294,10 @@ impl<'a, 'c> InProgress<'a, 'c> {
 
         if self.schema != *(metadata.schema) {
             metadata.schema = Arc::new(self.schema);
+
+            // TODO: rebuild vocabularies and notify consumers that they've changed -- it's possible
+            // that a change has arrived over the wire and invalidated some local module.
+            // TODO: consider making vocabulary lookup lazy -- we won't need it much of the time.
         }
 
         Ok(())

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -100,14 +100,22 @@ pub struct InProgress<'a, 'c> {
 }
 
 impl<'a, 'c> InProgress<'a, 'c> {
-    pub fn transact_entities<I>(mut self, entities: I) -> Result<InProgress<'a, 'c>> where I: IntoIterator<Item=mentat_tx::entities::Entity> {
-        let (report, next_partition_map, next_schema) = transact(&self.transaction, self.partition_map, &self.schema, &self.schema, entities)?;
+    pub fn transact_entities<I>(&mut self, entities: I) -> Result<()> where I: IntoIterator<Item=mentat_tx::entities::Entity> {
+        // We clone the partition map here, rather than trying to use a Cell or using a mutable
+        // reference, for two reasons:
+        // 1. `transact` allocates new IDs in partitions before and while doing work that might
+        //    fail! We don't want to mutate this map on failure, so we can't just use &mut.
+        // 2. Even if we could roll that back, we end up putting this `PartitionMap` into our
+        //    `Metadata` on return. If we used `Cell` or other mechanisms, we'd be using
+        //    `Default::default` in those situations to extract the partition map, and so there
+        //    would still be some cost.
+        let (report, next_partition_map, next_schema) = transact(&self.transaction, self.partition_map.clone(), &self.schema, &self.schema, entities)?;
         self.partition_map = next_partition_map;
         if let Some(schema) = next_schema {
             self.schema = schema;
         }
         self.last_report = Some(report);
-        Ok(self)
+        Ok(())
     }
 
     /// Query the Mentat store, using the given connection and the current metadata.
@@ -129,7 +137,7 @@ impl<'a, 'c> InProgress<'a, 'c> {
         lookup_value_for_attribute(&*(self.transaction), &self.schema, entity, attribute)
     }
 
-    pub fn transact(self, transaction: &str) -> Result<InProgress<'a, 'c>> {
+    pub fn transact(&mut self, transaction: &str) -> Result<()> {
         let assertion_vector = edn::parse::value(transaction)?;
         let entities = mentat_tx_parser::Tx::parse(&assertion_vector)?;
         self.transact_entities(entities)
@@ -261,10 +269,9 @@ impl Conn {
         let assertion_vector = edn::parse::value(transaction)?;
         let entities = mentat_tx_parser::Tx::parse(&assertion_vector)?;
 
-        let report = self.begin_transaction(sqlite)?
-                         .transact_entities(entities)?
-                         .commit()?
-                         .expect("we always get a report");
+        let mut in_progress = self.begin_transaction(sqlite)?;
+        in_progress.transact_entities(entities)?;
+        let report = in_progress.commit()?.expect("we always get a report");
 
         Ok(report)
     }
@@ -356,8 +363,8 @@ mod tests {
 
         // Scoped borrow of `conn`.
         {
-            let in_progress = conn.begin_transaction(&mut sqlite).expect("begun successfully");
-            let in_progress = in_progress.transact(t).expect("transacted successfully");
+            let mut in_progress = conn.begin_transaction(&mut sqlite).expect("begun successfully");
+            in_progress.transact(t).expect("transacted successfully");
             let one = in_progress.last_report().unwrap().tempids.get("one").expect("found one").clone();
             let two = in_progress.last_report().unwrap().tempids.get("two").expect("found two").clone();
             assert!(one != two);
@@ -368,9 +375,8 @@ mod tests {
                                     .expect("query succeeded");
             assert_eq!(during, QueryResults::Scalar(Some(TypedValue::Ref(one))));
 
-            let report = in_progress.transact(t2)
-                                    .expect("t2 succeeded")
-                                    .commit()
+            in_progress.transact(t2).expect("t2 succeeded");
+            let report = in_progress.commit()
                                     .expect("commit succeeded");
             let three = report.unwrap().tempids.get("three").expect("found three").clone();
             assert!(one != three);
@@ -397,8 +403,8 @@ mod tests {
 
         // Scoped borrow of `sqlite`.
         {
-            let in_progress = conn.begin_transaction(&mut sqlite).expect("begun successfully");
-            let in_progress = in_progress.transact(t).expect("transacted successfully");
+            let mut in_progress = conn.begin_transaction(&mut sqlite).expect("begun successfully");
+            in_progress.transact(t).expect("transacted successfully");
 
             let one = in_progress.last_report().unwrap().tempids.get("one").expect("found it").clone();
             let two = in_progress.last_report().unwrap().tempids.get("two").expect("found it").clone();

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -23,6 +23,7 @@ use mentat_core::{
     Attribute,
     Entid,
     HasSchema,
+    KnownEntid,
     NamespacedKeyword,
     Schema,
     TypedValue,
@@ -153,24 +154,24 @@ impl<'a, 'c> Queryable for InProgress<'a, 'c> {
 }
 
 impl<'a, 'c> HasSchema for QueryableTransaction<'a, 'c> {
-    fn get_ident(&self, x: Entid) -> Option<&NamespacedKeyword> {
+    fn get_ident<T>(&self, x: T) -> Option<&NamespacedKeyword> where T: Into<Entid> {
         self.0.get_ident(x)
     }
 
-    fn get_entid(&self, x: &NamespacedKeyword) -> Option<Entid> {
+    fn get_entid(&self, x: &NamespacedKeyword) -> Option<KnownEntid> {
         self.0.get_entid(x)
     }
 
-    fn attribute_for_entid(&self, x: Entid) -> Option<&Attribute> {
+    fn attribute_for_entid<T>(&self, x: T) -> Option<&Attribute> where T: Into<Entid> {
         self.0.attribute_for_entid(x)
     }
 
-    fn attribute_for_ident(&self, ident: &NamespacedKeyword) -> Option<&Attribute> {
+    fn attribute_for_ident(&self, ident: &NamespacedKeyword) -> Option<(&Attribute, KnownEntid)> {
         self.0.attribute_for_ident(ident)
     }
 
     /// Return true if the provided entid identifies an attribute in this schema.
-    fn is_attribute(&self, x: Entid) -> bool {
+    fn is_attribute<T>(&self, x: T) -> bool where T: Into<Entid> {
         self.0.is_attribute(x)
     }
 
@@ -181,24 +182,24 @@ impl<'a, 'c> HasSchema for QueryableTransaction<'a, 'c> {
 }
 
 impl<'a, 'c> HasSchema for InProgress<'a, 'c> {
-    fn get_ident(&self, x: Entid) -> Option<&NamespacedKeyword> {
+    fn get_ident<T>(&self, x: T) -> Option<&NamespacedKeyword> where T: Into<Entid> {
         self.schema.get_ident(x)
     }
 
-    fn get_entid(&self, x: &NamespacedKeyword) -> Option<Entid> {
+    fn get_entid(&self, x: &NamespacedKeyword) -> Option<KnownEntid> {
         self.schema.get_entid(x)
     }
 
-    fn attribute_for_entid(&self, x: Entid) -> Option<&Attribute> {
+    fn attribute_for_entid<T>(&self, x: T) -> Option<&Attribute> where T: Into<Entid> {
         self.schema.attribute_for_entid(x)
     }
 
-    fn attribute_for_ident(&self, ident: &NamespacedKeyword) -> Option<&Attribute> {
+    fn attribute_for_ident(&self, ident: &NamespacedKeyword) -> Option<(&Attribute, KnownEntid)> {
         self.schema.attribute_for_ident(ident)
     }
 
     /// Return true if the provided entid identifies an attribute in this schema.
-    fn is_attribute(&self, x: Entid) -> bool {
+    fn is_attribute<T>(&self, x: T) -> bool where T: Into<Entid> {
         self.schema.is_attribute(x)
     }
 

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -27,6 +27,7 @@ use mentat_core::{
     NamespacedKeyword,
     Schema,
     TypedValue,
+    ValueType,
 };
 
 use mentat_core::intern_set::InternSet;
@@ -56,6 +57,9 @@ use query::{
     QueryResults,
 };
 
+use entity_builder::{
+    InProgressBuilder,
+};
 
 /// Connection metadata required to query from, or apply transactions to, a Mentat store.
 ///
@@ -225,6 +229,10 @@ impl<'a, 'c> HasSchema for InProgress<'a, 'c> {
 
 
 impl<'a, 'c> InProgress<'a, 'c> {
+    pub fn builder(self) -> InProgressBuilder<'a, 'c> {
+        InProgressBuilder::new(self)
+    }
+
     pub fn transact_terms<I>(&mut self, terms: I, tempid_set: InternSet<TempId>) -> Result<TxReport> where I: IntoIterator<Item=TermWithTempIds> {
         let (report, next_partition_map, next_schema) = transact_terms(&self.transaction,
                                                                        self.partition_map.clone(),

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -154,6 +154,10 @@ impl<'a, 'c> Queryable for InProgress<'a, 'c> {
 }
 
 impl<'a, 'c> HasSchema for QueryableTransaction<'a, 'c> {
+    fn entid_for_type(&self, t: ValueType) -> Option<KnownEntid> {
+        self.0.entid_for_type(t)
+    }
+
     fn get_ident<T>(&self, x: T) -> Option<&NamespacedKeyword> where T: Into<Entid> {
         self.0.get_ident(x)
     }
@@ -182,6 +186,10 @@ impl<'a, 'c> HasSchema for QueryableTransaction<'a, 'c> {
 }
 
 impl<'a, 'c> HasSchema for InProgress<'a, 'c> {
+    fn entid_for_type(&self, t: ValueType) -> Option<KnownEntid> {
+        self.schema.entid_for_type(t)
+    }
+
     fn get_ident<T>(&self, x: T) -> Option<&NamespacedKeyword> where T: Into<Entid> {
         self.schema.get_ident(x)
     }

--- a/src/entity_builder.rs
+++ b/src/entity_builder.rs
@@ -1,0 +1,437 @@
+// Copyright 2016 Mozilla
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// We have a little bit of a dilemma in Mentat.
+// The public data format for transacting is, fundamentally, a big string: EDN.
+// The internal data format for transacting is required to encode the complexities of
+// processing that format: temporary IDs, lookup refs, input spans, etc.
+//
+// See mentat_tx::entities::Entity and all of its child enums to see how complex this gets.
+//
+// A programmatic consumer doesn't want to build something that looks like:
+//
+//     Entity::AddOrRetract {
+//         op: OpType::Add,
+//         e: EntidOrLookupRefOrTempId::LookupRef(LookupRef {
+//             a: Entid::Ident(NamespacedKeyword::new("test", "a1")),
+//             v: Value::Text("v1".into()),
+//         }),
+//         a: Entid::Ident(NamespacedKeyword::new("test", "a")),
+//         v: AtomOrLookupRefOrVectorOrMapNotation::Atom(ValueAndSpan::new(SpannedValue::Text("v".into()), Span(44, 47))),
+//     }));
+//
+// but neither do they want to pay the cost of parsing
+//
+//    [[:test/a1 "v1"] :test/a "v"]
+//
+// at runtime.
+//
+// It's tempting to think that we can do something 'easy' here -- to skip the hard work of transacting
+// tempids, for example -- but to do so will hobble the system for little payoff. It's also worth
+// remembering that the transactor does significant validation work, which we don't want to
+// reimplement here.
+//
+// The win we seek is to make it easier to _write_ these inputs without significantly restricting
+// what can be said.
+//
+// There are two ways we could go from here.
+//
+// The first is to expose tx parsing as a macro: parse that string at compile time into the
+// equivalent `Entity` data structure. That's fine for completely static input data.
+//
+// The second is to expose a declarative, programmatic builder pattern for constructing entities.
+//
+// We probably need both, but this file provides the latter. Unfortunately, Entity -- the input to
+// the transactor -- is intimately tied to EDN and to spanned values.
+
+use mentat_core::{
+    KnownEntid,
+    TypedValue,
+};
+
+use mentat_core::intern_set::InternSet;
+use mentat_core::util::Either;
+
+use mentat_db::{
+    TxReport,
+};
+
+use mentat_db::internal_types::{
+    KnownEntidOr,
+    TempIdHandle,
+    Term,
+    TermWithTempIds,
+    TypedValueOr,
+};
+
+use mentat_tx::entities::{
+    OpType,
+    TempId,
+};
+
+use conn::{
+    InProgress,
+};
+
+use errors::{
+    Result,
+};
+
+pub type Terms = (Vec<TermWithTempIds>, InternSet<TempId>);
+
+pub struct TermBuilder {
+    tempids: InternSet<TempId>,
+    terms: Vec<TermWithTempIds>,
+}
+
+pub struct EntityBuilder<T: BuildTerms + Sized> {
+    builder: T,
+    entity: KnownEntidOr<TempIdHandle>,
+}
+
+pub trait BuildTerms where Self: Sized {
+    fn describe_tempid(self, name: &str) -> EntityBuilder<Self>;
+    fn describe<E>(self, entity: E) -> EntityBuilder<Self> where E: IntoThing<KnownEntidOr<TempIdHandle>>;
+    fn add<E, V>(&mut self, e: E, a: KnownEntid, v: V) -> Result<()>
+    where E: IntoThing<KnownEntidOr<TempIdHandle>>,
+          V: IntoThing<TypedValueOr<TempIdHandle>>;
+}
+
+impl BuildTerms for TermBuilder {
+    fn describe_tempid(mut self, name: &str) -> EntityBuilder<Self> {
+        let e = self.named_tempid(name.into());
+        self.describe(e)
+    }
+
+    fn describe<E>(self, entity: E) -> EntityBuilder<Self> where E: IntoThing<KnownEntidOr<TempIdHandle>> {
+        EntityBuilder {
+            builder: self,
+            entity: entity.into_thing(),
+        }
+    }
+
+    fn add<E, V>(&mut self, e: E, a: KnownEntid, v: V) -> Result<()>
+    where E: IntoThing<KnownEntidOr<TempIdHandle>>,
+          V: IntoThing<TypedValueOr<TempIdHandle>> {
+        let e = e.into_thing();
+        let v = v.into_thing();
+        self.terms.push(Term::AddOrRetract(OpType::Add, e, a.into(), v));
+        Ok(())
+    }
+}
+
+impl TermBuilder {
+    pub fn build(self) -> Result<Terms> {
+        Ok((self.terms, self.tempids))
+    }
+
+    pub fn new() -> TermBuilder {
+        TermBuilder {
+            tempids: InternSet::new(),
+            terms: vec![],
+        }
+    }
+
+    pub fn named_tempid(&mut self, name: String) -> TempIdHandle {
+        self.tempids.intern(TempId::External(name))
+    }
+
+    #[allow(dead_code)]
+    pub fn numbered_tempid(&mut self, id: i64) -> TempIdHandle {
+        self.tempids.intern(TempId::Internal(id))
+    }
+}
+
+impl<T> EntityBuilder<T> where T: BuildTerms {
+    pub fn finish(self) -> (T, KnownEntidOr<TempIdHandle>) {
+        (self.builder, self.entity)
+    }
+
+    pub fn add<V>(&mut self, a: KnownEntid, v: V) -> Result<()>
+    where V: IntoThing<TypedValueOr<TempIdHandle>> {
+        self.builder.add(self.entity.clone(), a, v)
+    }
+}
+
+pub struct InProgressBuilder<'a, 'c> {
+    in_progress: InProgress<'a, 'c>,
+    builder: TermBuilder,
+}
+
+impl<'a, 'c> InProgressBuilder<'a, 'c> {
+    pub fn new(in_progress: InProgress<'a, 'c>) -> Self {
+        InProgressBuilder {
+            in_progress: in_progress,
+            builder: TermBuilder::new(),
+        }
+    }
+
+    /// Build the terms from this builder and transact them against the current
+    /// `InProgress`. This method _always_ returns the `InProgress` -- failure doesn't
+    /// imply an automatic rollback.
+    pub fn transact(self) -> (InProgress<'a, 'c>, Result<TxReport>)  {
+        let mut in_progress = self.in_progress;
+        let result = self.builder
+                         .build()
+                         .and_then(|(terms, tempid_set)| {
+                             in_progress.transact_terms(terms, tempid_set)
+                         });
+        (in_progress, result)
+    }
+
+    /// Transact the contents of the builder and commit the `InProgress`. If any
+    /// step fails, roll back. Return the `TxReport`.
+    pub fn commit(self) -> Result<TxReport> {
+        let mut in_progress = self.in_progress;
+        self.builder
+            .build()
+            .and_then(|(terms, tempid_set)| {
+                in_progress.transact_terms(terms, tempid_set)
+                           .and_then(|report| {
+                               in_progress.commit()?;
+                               Ok(report)
+                           })
+            })
+    }
+}
+
+impl<'a, 'c> BuildTerms for InProgressBuilder<'a, 'c> {
+    fn describe_tempid(mut self, name: &str) -> EntityBuilder<InProgressBuilder<'a, 'c>> {
+        let e = self.builder.named_tempid(name.into());
+        self.describe(e)
+    }
+
+    fn describe<E>(self, entity: E) -> EntityBuilder<InProgressBuilder<'a, 'c>> where E: IntoThing<KnownEntidOr<TempIdHandle>> {
+        EntityBuilder {
+            builder: self,
+            entity: entity.into_thing(),
+        }
+    }
+
+    fn add<E, V>(&mut self, e: E, a: KnownEntid, v: V) -> Result<()>
+    where E: IntoThing<KnownEntidOr<TempIdHandle>>,
+          V: IntoThing<TypedValueOr<TempIdHandle>> {
+        self.builder.add(e, a, v)
+    }
+}
+
+impl<'a, 'c> EntityBuilder<InProgressBuilder<'a, 'c>> {
+    /// Build the terms from this builder and transact them against the current
+    /// `InProgress`. This method _always_ returns the `InProgress` -- failure doesn't
+    /// imply an automatic rollback.
+    pub fn transact(self) -> (InProgress<'a, 'c>, Result<TxReport>)  {
+        self.finish().0.transact()
+    }
+
+    /// Transact the contents of the builder and commit the `InProgress`. If any
+    /// step fails, roll back. Return the `TxReport`.
+    pub fn commit(self) -> Result<TxReport> {
+        self.finish().0.commit()
+    }
+}
+
+// Can't implement Into for Rc<T>.
+pub trait IntoThing<T>: Sized {
+    fn into_thing(self) -> T;
+}
+
+pub trait FromThing<T> {
+    fn from_thing(v: T) -> Self;
+}
+
+impl<T> FromThing<T> for T {
+    fn from_thing(v: T) -> T {
+        v
+    }
+}
+
+impl<I, F> IntoThing<I> for F where I: FromThing<F> {
+    fn into_thing(self) -> I {
+        I::from_thing(self)
+    }
+}
+
+impl<'a> FromThing<&'a TempIdHandle> for TypedValueOr<TempIdHandle> {
+    fn from_thing(v: &'a TempIdHandle) -> Self {
+        Either::Right(v.clone())
+    }
+}
+
+impl FromThing<TempIdHandle> for TypedValueOr<TempIdHandle> {
+    fn from_thing(v: TempIdHandle) -> Self {
+        Either::Right(v)
+    }
+}
+
+impl FromThing<TypedValue> for TypedValueOr<TempIdHandle> {
+    fn from_thing(v: TypedValue) -> Self {
+        Either::Left(v)
+    }
+}
+
+impl FromThing<TempIdHandle> for KnownEntidOr<TempIdHandle> {
+    fn from_thing(v: TempIdHandle) -> Self {
+        Either::Right(v)
+    }
+}
+
+impl<'a> FromThing<&'a KnownEntid> for KnownEntidOr<TempIdHandle> {
+    fn from_thing(v: &'a KnownEntid) -> Self {
+        Either::Left(v.clone())
+    }
+}
+
+impl FromThing<KnownEntid> for KnownEntidOr<TempIdHandle> {
+    fn from_thing(v: KnownEntid) -> Self {
+        Either::Left(v)
+    }
+}
+
+impl FromThing<KnownEntid> for TypedValueOr<TempIdHandle> {
+    fn from_thing(v: KnownEntid) -> Self {
+        Either::Left(v.into())
+    }
+}
+
+#[cfg(test)]
+mod testing {
+    extern crate mentat_db;
+
+    use mentat_core::{
+        Entid,
+        HasSchema,
+        NamespacedKeyword,
+        TypedValue,
+    };
+
+    use errors::{
+        Error,
+    };
+
+    use errors::ErrorKind::{
+        DbError,
+    };
+
+    use mentat_db::TxReport;
+
+    use mentat_db::ErrorKind::{
+        UnrecognizedEntid,
+    };
+
+    use ::{
+        Conn,
+        Queryable,
+    };
+
+    use super::*;
+
+    // In reality we expect the store to hand these out safely.
+    fn fake_known_entid(e: Entid) -> KnownEntid {
+        KnownEntid(e)
+    }
+
+    #[test]
+    fn test_entity_builder_bogus_entids() {
+        let mut builder = TermBuilder::new();
+        let e = builder.named_tempid("x".into());
+        let a1 = fake_known_entid(37);    // :db/doc
+        let a2 = fake_known_entid(999);    // :db/doc
+        let v = TypedValue::typed_string("Some attribute");
+        let ve = fake_known_entid(12345);
+
+        builder.add(e.clone(), a1, v).expect("add succeeded");
+        builder.add(e.clone(), a2, e.clone()).expect("add succeeded, even though it's meaningless");
+        builder.add(e.clone(), a2, ve).expect("add succeeded, even though it's meaningless");
+        let (terms, tempids) = builder.build().expect("build succeeded");
+
+        assert_eq!(tempids.len(), 1);
+        assert_eq!(terms.len(), 3);     // TODO: check the contents?
+
+        // Now try to add them to a real store.
+        let mut sqlite = mentat_db::db::new_connection("").unwrap();
+        let mut conn = Conn::connect(&mut sqlite).unwrap();
+        let mut in_progress = conn.begin_transaction(&mut sqlite).expect("begun successfully");
+
+        // This should fail: unrecognized entid.
+        if let Err(Error(DbError(UnrecognizedEntid(e)), _)) = in_progress.transact_terms(terms, tempids) {
+            assert_eq!(e, 999);
+        } else {
+            panic!("Should have rejected the entid.");
+        }
+    }
+
+    #[test]
+    fn test_entity_builder() {
+        let mut sqlite = mentat_db::db::new_connection("").unwrap();
+        let mut conn = Conn::connect(&mut sqlite).unwrap();
+
+        let foo_one = NamespacedKeyword::new("foo", "one");
+        let foo_many = NamespacedKeyword::new("foo", "many");
+        let foo_ref = NamespacedKeyword::new("foo", "ref");
+        let report: TxReport;
+
+        // Give ourselves a schema to work with!
+        // Scoped borrow of conn.
+        {
+            conn.transact(&mut sqlite, r#"[
+                [:db/add "o" :db/ident :foo/one]
+                [:db/add "o" :db/valueType :db.type/long]
+                [:db/add "o" :db/cardinality :db.cardinality/one]
+                [:db/add "m" :db/ident :foo/many]
+                [:db/add "m" :db/valueType :db.type/string]
+                [:db/add "m" :db/cardinality :db.cardinality/many]
+                [:db/add "r" :db/ident :foo/ref]
+                [:db/add "r" :db/valueType :db.type/ref]
+                [:db/add "r" :db/cardinality :db.cardinality/one]
+            ]"#).unwrap();
+
+            let mut in_progress = conn.begin_transaction(&mut sqlite).expect("begun successfully");
+
+            // Scoped borrow of in_progress.
+            {
+                let mut builder = TermBuilder::new();
+                let e_x = builder.named_tempid("x".into());
+                let e_y = builder.named_tempid("y".into());
+                let a_ref = in_progress.get_entid(&foo_ref).expect(":foo/ref");
+                let a_one = in_progress.get_entid(&foo_one).expect(":foo/one");
+                let a_many = in_progress.get_entid(&foo_many).expect(":foo/many");
+                let v_many_1 = TypedValue::typed_string("Some text");
+                let v_many_2 = TypedValue::typed_string("Other text");
+                let v_long: TypedValue = 123.into();
+
+                builder.add(e_x.clone(), a_many, v_many_1).expect("add succeeded");
+                builder.add(e_x.clone(), a_many, v_many_2).expect("add succeeded");
+                builder.add(e_y.clone(), a_ref, e_x.clone()).expect("add succeeded");
+                builder.add(e_x.clone(), a_one, v_long).expect("add succeeded");
+
+                let (terms, tempids) = builder.build().expect("build succeeded");
+
+                assert_eq!(tempids.len(), 2);
+                assert_eq!(terms.len(), 4);
+
+                report = in_progress.transact_terms(terms, tempids).expect("add succeeded");
+                let x = report.tempids.get("x").expect("our tempid has an ID");
+                let y = report.tempids.get("y").expect("our tempid has an ID");
+                assert_eq!(in_progress.lookup_value_for_attribute(*y, &foo_ref).expect("lookup succeeded"),
+                           Some(TypedValue::Ref(*x)));
+                assert_eq!(in_progress.lookup_value_for_attribute(*x, &foo_one).expect("lookup succeeded"),
+                           Some(TypedValue::Long(123)));
+            }
+
+            in_progress.commit().expect("commit succeeded");
+        }
+
+        // It's all still there after the commit.
+        let x = report.tempids.get("x").expect("our tempid has an ID");
+        let y = report.tempids.get("y").expect("our tempid has an ID");
+        assert_eq!(conn.lookup_value_for_attribute(&mut sqlite, *y, &foo_ref).expect("lookup succeeded"),
+                   Some(TypedValue::Ref(*x)));
+    }
+}

--- a/src/entity_builder.rs
+++ b/src/entity_builder.rs
@@ -360,7 +360,7 @@ mod testing {
         let mut builder = TermBuilder::new();
         let e = builder.named_tempid("x".into());
         let a1 = fake_known_entid(37);    // :db/doc
-        let a2 = fake_known_entid(999);    // :db/doc
+        let a2 = fake_known_entid(999);
         let v = TypedValue::typed_string("Some attribute");
         let ve = fake_known_entid(12345);
 

--- a/src/entity_builder.rs
+++ b/src/entity_builder.rs
@@ -102,6 +102,9 @@ pub trait BuildTerms where Self: Sized {
     fn add<E, V>(&mut self, e: E, a: KnownEntid, v: V) -> Result<()>
     where E: IntoThing<KnownEntidOr<TempIdHandle>>,
           V: IntoThing<TypedValueOr<TempIdHandle>>;
+    fn retract<E, V>(&mut self, e: E, a: KnownEntid, v: V) -> Result<()>
+    where E: IntoThing<KnownEntidOr<TempIdHandle>>,
+          V: IntoThing<TypedValueOr<TempIdHandle>>;
 }
 
 impl BuildTerms for TermBuilder {
@@ -123,6 +126,15 @@ impl BuildTerms for TermBuilder {
         let e = e.into_thing();
         let v = v.into_thing();
         self.terms.push(Term::AddOrRetract(OpType::Add, e, a.into(), v));
+        Ok(())
+    }
+
+    fn retract<E, V>(&mut self, e: E, a: KnownEntid, v: V) -> Result<()>
+    where E: IntoThing<KnownEntidOr<TempIdHandle>>,
+          V: IntoThing<TypedValueOr<TempIdHandle>> {
+        let e = e.into_thing();
+        let v = v.into_thing();
+        self.terms.push(Term::AddOrRetract(OpType::Retract, e, a.into(), v));
         Ok(())
     }
 }
@@ -219,6 +231,12 @@ impl<'a, 'c> BuildTerms for InProgressBuilder<'a, 'c> {
     where E: IntoThing<KnownEntidOr<TempIdHandle>>,
           V: IntoThing<TypedValueOr<TempIdHandle>> {
         self.builder.add(e, a, v)
+    }
+
+    fn retract<E, V>(&mut self, e: E, a: KnownEntid, v: V) -> Result<()>
+    where E: IntoThing<KnownEntidOr<TempIdHandle>>,
+          V: IntoThing<TypedValueOr<TempIdHandle>> {
+        self.builder.retract(e, a, v)
     }
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -72,5 +72,20 @@ error_chain! {
             description("conflicting attribute definitions")
             display("vocabulary {}/{} already has attribute {}, and the requested definition differs", vocabulary, version, attribute)
         }
+
+        ExistingVocabularyTooNew(name: String, existing: ::vocabulary::Version, ours: ::vocabulary::Version) {
+            description("existing vocabulary too new")
+            display("existing vocabulary too new: wanted {}, got {}", ours, existing)
+        }
+
+        UnexpectedCoreSchema(version: Option<::vocabulary::Version>) {
+            description("unexpected core schema version")
+            display("core schema: wanted {}, got {:?}", mentat_db::CORE_SCHEMA_VERSION, version)
+        }
+
+        MissingCoreVocabulary(kw: mentat_query::NamespacedKeyword) {
+            description("missing core vocabulary")
+            display("missing core attribute {}", kw)
+        }
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -15,6 +15,9 @@ use rusqlite;
 use std::collections::BTreeSet;
 
 use edn;
+use mentat_core::{
+    Attribute,
+};
 use mentat_db;
 use mentat_query;
 use mentat_query_algebrizer;
@@ -55,9 +58,19 @@ error_chain! {
             display("invalid argument name: '{}'", name)
         }
 
-        UnknownAttribute(kw: mentat_query::NamespacedKeyword) {
+        UnknownAttribute(name: String) {
             description("unknown attribute")
-            display("unknown attribute: '{}'", kw)
+            display("unknown attribute: '{}'", name)
+        }
+
+        InvalidVocabularyVersion {
+            description("invalid vocabulary version")
+            display("invalid vocabulary version")
+        }
+
+        ConflictingAttributeDefinitions(vocabulary: String, version: ::vocabulary::Version, attribute: String, current: Attribute, requested: Attribute) {
+            description("conflicting attribute definitions")
+            display("vocabulary {}/{} already has attribute {}, and the requested definition differs", vocabulary, version, attribute)
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ use rusqlite::Connection;
 
 pub mod errors;
 pub mod ident;
+pub mod vocabulary;
 pub mod conn;
 pub mod query;
 pub mod entity_builder;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,9 @@
 #[macro_use]
 extern crate error_chain;
 
+#[macro_use]
+extern crate lazy_static;
+
 extern crate rusqlite;
 
 extern crate edn;
@@ -33,6 +36,7 @@ pub mod errors;
 pub mod ident;
 pub mod conn;
 pub mod query;
+pub mod entity_builder;
 
 pub fn get_name() -> String {
     return String::from("mentat");
@@ -44,11 +48,15 @@ pub fn get_connection() -> Connection {
 }
 
 pub use mentat_core::{
+    Attribute,
+    Entid,
     TypedValue,
     ValueType,
 };
 
 pub use mentat_db::{
+    CORE_SCHEMA_VERSION,
+    DB_SCHEMA_CORE,
     new_connection,
 };
 
@@ -64,6 +72,7 @@ pub use query::{
 
 pub use conn::{
     Conn,
+    InProgress,
     Metadata,
     Queryable,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,7 @@ pub use mentat_db::{
 };
 
 pub use query::{
+    IntoResult,
     NamespacedKeyword,
     PlainSymbol,
     QueryInputs,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,7 @@ pub use query::{
 pub use conn::{
     Conn,
     Metadata,
+    Queryable,
 };
 
 #[cfg(test)]

--- a/src/query.rs
+++ b/src/query.rs
@@ -13,6 +13,7 @@ use rusqlite::types::ToSql;
 
 use mentat_core::{
     Entid,
+    HasSchema,
     Schema,
     TypedValue,
 };

--- a/src/query.rs
+++ b/src/query.rs
@@ -14,6 +14,7 @@ use rusqlite::types::ToSql;
 use mentat_core::{
     Entid,
     HasSchema,
+    KnownEntid,
     Schema,
     TypedValue,
 };
@@ -117,49 +118,53 @@ fn fetch_values<'sqlite, 'schema>
     run_algebrized_query(sqlite, algebrized)
 }
 
-fn lookup_attribute(schema: &Schema, attribute: &NamespacedKeyword) -> Result<Entid> {
+fn lookup_attribute(schema: &Schema, attribute: &NamespacedKeyword) -> Result<KnownEntid> {
     schema.get_entid(attribute)
-          .ok_or_else(|| ErrorKind::UnknownAttribute(attribute.clone()).into())
+          .ok_or_else(|| ErrorKind::UnknownAttribute(attribute.name.clone()).into())
 }
 
 /// Return a single value for the provided entity and attribute.
 /// If the attribute is multi-valued, an arbitrary value is returned.
 /// If no value is present for that entity, `None` is returned.
 /// If `attribute` isn't an attribute, `None` is returned.
-pub fn lookup_value<'sqlite, 'schema>
+pub fn lookup_value<'sqlite, 'schema, E, A>
 (sqlite: &'sqlite rusqlite::Connection,
  schema: &'schema Schema,
- entity: Entid,
- attribute: Entid) -> Result<Option<TypedValue>> {
-    fetch_values(sqlite, schema, entity, attribute, true).into_scalar_result()
+ entity: E,
+ attribute: A) -> Result<Option<TypedValue>>
+ where E: Into<Entid>, A: Into<Entid> {
+    fetch_values(sqlite, schema, entity.into(), attribute.into(), true).into_scalar_result()
 }
 
-pub fn lookup_values<'sqlite, 'schema>
+pub fn lookup_values<'sqlite, 'schema, E, A>
 (sqlite: &'sqlite rusqlite::Connection,
  schema: &'schema Schema,
- entity: Entid,
- attribute: Entid) -> Result<Vec<TypedValue>> {
-    fetch_values(sqlite, schema, entity, attribute, false).into_coll_result()
+ entity: E,
+ attribute: A) -> Result<Vec<TypedValue>>
+ where E: Into<Entid>, A: Into<Entid> {
+    fetch_values(sqlite, schema, entity.into(), attribute.into(), false).into_coll_result()
 }
 
 /// Return a single value for the provided entity and attribute.
 /// If the attribute is multi-valued, an arbitrary value is returned.
 /// If no value is present for that entity, `None` is returned.
 /// If `attribute` doesn't name an attribute, an error is returned.
-pub fn lookup_value_for_attribute<'sqlite, 'schema, 'attribute>
+pub fn lookup_value_for_attribute<'sqlite, 'schema, 'attribute, E>
 (sqlite: &'sqlite rusqlite::Connection,
  schema: &'schema Schema,
- entity: Entid,
- attribute: &'attribute NamespacedKeyword) -> Result<Option<TypedValue>> {
-    lookup_value(sqlite, schema, entity, lookup_attribute(schema, attribute)?)
+ entity: E,
+ attribute: &'attribute NamespacedKeyword) -> Result<Option<TypedValue>>
+ where E: Into<Entid> {
+    lookup_value(sqlite, schema, entity.into(), lookup_attribute(schema, attribute)?)
 }
 
-pub fn lookup_values_for_attribute<'sqlite, 'schema, 'attribute>
+pub fn lookup_values_for_attribute<'sqlite, 'schema, 'attribute, E>
 (sqlite: &'sqlite rusqlite::Connection,
  schema: &'schema Schema,
- entity: Entid,
- attribute: &'attribute NamespacedKeyword) -> Result<Vec<TypedValue>> {
-    lookup_values(sqlite, schema, entity, lookup_attribute(schema, attribute)?)
+ entity: E,
+ attribute: &'attribute NamespacedKeyword) -> Result<Vec<TypedValue>>
+ where E: Into<Entid> {
+    lookup_values(sqlite, schema, entity.into(), lookup_attribute(schema, attribute)?)
 }
 
 fn run_algebrized_query<'sqlite>(sqlite: &'sqlite rusqlite::Connection, algebrized: AlgebraicQuery) -> QueryExecutionResult {

--- a/src/vocabulary.rs
+++ b/src/vocabulary.rs
@@ -1,0 +1,519 @@
+// Copyright 2016 Mozilla
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+use std::collections::BTreeMap;
+
+use mentat_core::{
+    Attribute,
+    Entid,
+    HasSchema,
+    KnownEntid,
+    NamespacedKeyword,
+    TypedValue,
+    ValueType,
+};
+
+pub use mentat_core::attribute;
+use mentat_core::attribute::Unique;
+
+use ::{
+    CORE_SCHEMA_VERSION,
+    IntoResult,
+};
+
+use ::conn::{
+    InProgress,
+    Queryable,
+};
+
+use ::errors::{
+    ErrorKind,
+    Result,
+};
+
+use ::entity_builder::{
+    BuildTerms,
+    TermBuilder,
+    Terms,
+};
+
+pub use mentat_db::AttributeBuilder;
+
+pub type Version = u32;
+pub type Datom = (Entid, Entid, TypedValue);
+
+/// `Attribute` instances not only aren't named, but don't even have entids.
+/// We need two kinds of structure here: an abstract definition of a vocabulary in terms of names,
+/// and a concrete instance of a vocabulary in a particular store.
+/// Note that, because it's possible to 'flesh out' a vocabulary with attributes without bumping
+/// its version number, we need to know the attributes that the application cares about -- it's
+/// not enough to know the name and version. Indeed, we even care about the details of each attribute,
+/// because that's how we'll detect errors.
+#[derive(Debug)]
+pub struct Definition {
+    pub name: NamespacedKeyword,
+    pub version: Version,
+    pub attributes: Vec<(NamespacedKeyword, Attribute)>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Vocabulary {
+    pub entity: Entid,
+    pub version: Version,
+    attributes: Vec<(Entid, Attribute)>,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct Vocabularies(pub BTreeMap<NamespacedKeyword, Vocabulary>);   // N.B., this has a copy of the attributes in Schema!
+
+impl Vocabularies {
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn get(&self, name: &NamespacedKeyword) -> Option<&Vocabulary> {
+        self.0.get(name)
+    }
+}
+
+lazy_static! {
+    static ref DB_SCHEMA_CORE: NamespacedKeyword = {
+        NamespacedKeyword::new("db.schema", "core")
+    };
+    static ref DB_SCHEMA_ATTRIBUTE: NamespacedKeyword = {
+        NamespacedKeyword::new("db.schema", "attribute")
+    };
+    static ref DB_SCHEMA_VERSION: NamespacedKeyword = {
+        NamespacedKeyword::new("db.schema", "version")
+    };
+    static ref DB_IDENT: NamespacedKeyword = {
+        NamespacedKeyword::new("db", "ident")
+    };
+    static ref DB_UNIQUE: NamespacedKeyword = {
+        NamespacedKeyword::new("db", "unique")
+    };
+    static ref DB_UNIQUE_VALUE: NamespacedKeyword = {
+        NamespacedKeyword::new("db.unique", "value")
+    };
+    static ref DB_UNIQUE_IDENTITY: NamespacedKeyword = {
+        NamespacedKeyword::new("db.unique", "identity")
+    };
+    static ref DB_IS_COMPONENT: NamespacedKeyword = {
+        NamespacedKeyword::new("db", "isComponent")
+    };
+    static ref DB_VALUE_TYPE: NamespacedKeyword = {
+        NamespacedKeyword::new("db", "valueType")
+    };
+    static ref DB_INDEX: NamespacedKeyword = {
+        NamespacedKeyword::new("db", "index")
+    };
+    static ref DB_FULLTEXT: NamespacedKeyword = {
+        NamespacedKeyword::new("db", "fulltext")
+    };
+    static ref DB_CARDINALITY: NamespacedKeyword = {
+        NamespacedKeyword::new("db", "cardinality")
+    };
+    static ref DB_CARDINALITY_ONE: NamespacedKeyword = {
+        NamespacedKeyword::new("db.cardinality", "one")
+    };
+    static ref DB_CARDINALITY_MANY: NamespacedKeyword = {
+        NamespacedKeyword::new("db.cardinality", "many")
+    };
+
+    // Not yet supported.
+    // static ref DB_NO_HISTORY: NamespacedKeyword = {
+    //     NamespacedKeyword::new("db", "noHistory")
+    // };
+}
+
+trait HasCoreSchema {
+    /// Return the entity ID for a type. On failure, return `MissingCoreVocabulary`.
+    fn core_type(&self, t: ValueType) -> Result<KnownEntid>;
+
+    /// Return the entity ID for an ident. On failure, return `MissingCoreVocabulary`.
+    fn core_entid(&self, ident: &NamespacedKeyword) -> Result<KnownEntid>;
+
+    /// Return the entity ID for an attribute's keyword. On failure, return
+    /// `MissingCoreVocabulary`.
+    fn core_attribute(&self, ident: &NamespacedKeyword) -> Result<KnownEntid>;
+}
+
+impl<T> HasCoreSchema for T where T: HasSchema {
+    fn core_type(&self, t: ValueType) -> Result<KnownEntid> {
+        self.entid_for_type(t)
+            .ok_or_else(|| ErrorKind::MissingCoreVocabulary(DB_SCHEMA_VERSION.clone()).into())
+    }
+
+    fn core_entid(&self, ident: &NamespacedKeyword) -> Result<KnownEntid> {
+        self.get_entid(ident)
+            .ok_or_else(|| ErrorKind::MissingCoreVocabulary(DB_SCHEMA_VERSION.clone()).into())
+    }
+
+    fn core_attribute(&self, ident: &NamespacedKeyword) -> Result<KnownEntid> {
+        self.attribute_for_ident(ident)
+            .ok_or_else(|| ErrorKind::MissingCoreVocabulary(DB_SCHEMA_VERSION.clone()).into())
+            .map(|(_, e)| e)
+    }
+}
+
+impl Definition {
+    fn description_for_attributes<'s, T, R>(&'s self, attributes: &[R], via: &T) -> Result<Terms>
+     where T: HasCoreSchema,
+           R: ::std::borrow::Borrow<(NamespacedKeyword, Attribute)> {
+
+        // The attributes we'll need to describe this vocabulary.
+        let a_version = via.core_attribute(&DB_SCHEMA_VERSION)?;
+        let a_ident = via.core_attribute(&DB_IDENT)?;
+        let a_attr = via.core_attribute(&DB_SCHEMA_ATTRIBUTE)?;
+
+        let a_cardinality = via.core_attribute(&DB_CARDINALITY)?;
+        let a_fulltext = via.core_attribute(&DB_FULLTEXT)?;
+        let a_index = via.core_attribute(&DB_INDEX)?;
+        let a_is_component = via.core_attribute(&DB_IS_COMPONENT)?;
+        let a_value_type = via.core_attribute(&DB_VALUE_TYPE)?;
+        let a_unique = via.core_attribute(&DB_UNIQUE)?;
+
+        // Not yet supported.
+        // let a_no_history = via.core_attribute(&DB_NO_HISTORY)?;
+
+        let v_cardinality_many = via.core_entid(&DB_CARDINALITY_MANY)?;
+        let v_cardinality_one = via.core_entid(&DB_CARDINALITY_ONE)?;
+        let v_unique_identity = via.core_entid(&DB_UNIQUE_IDENTITY)?;
+        let v_unique_value = via.core_entid(&DB_UNIQUE_VALUE)?;
+
+        // The properties of the vocabulary itself.
+        let name: TypedValue = self.name.clone().into();
+        let version: TypedValue = TypedValue::Long(self.version as i64);
+
+        // Describe the vocabulary.
+        let mut entity = TermBuilder::new().describe_tempid("s");
+        entity.add(a_version, version)?;
+        entity.add(a_ident, name)?;
+        let (mut builder, schema) = entity.finish();
+
+        // Describe each of its attributes.
+        // This is a lot like Schema::to_edn_value; at some point we should tidy this up.
+        for ref r in attributes.iter() {
+            let &(ref name, ref attr) = r.borrow();
+
+            // Note that we allow tempid resolution to find an existing entity, if it
+            // exists. We don't yet support upgrades, which will involve producing
+            // alteration statements.
+            let tempid = builder.named_tempid(name.to_string());
+            let name: TypedValue = name.clone().into();
+            builder.add(tempid.clone(), a_ident, name)?;
+            builder.add(schema.clone(), a_attr, tempid.clone())?;
+
+            let value_type = via.core_type(attr.value_type)?;
+            builder.add(tempid.clone(), a_value_type, value_type)?;
+
+            let c = if attr.multival {
+                v_cardinality_many
+            } else {
+                v_cardinality_one
+            };
+            builder.add(tempid.clone(), a_cardinality, c)?;
+
+            if attr.index {
+                builder.add(tempid.clone(), a_index, TypedValue::Boolean(true))?;
+            }
+            if attr.fulltext {
+                builder.add(tempid.clone(), a_fulltext, TypedValue::Boolean(true))?;
+            }
+            if attr.component {
+                builder.add(tempid.clone(), a_is_component, TypedValue::Boolean(true))?;
+            }
+
+            if let Some(u) = attr.unique {
+                let uu = match u {
+                    Unique::Identity => v_unique_identity,
+                    Unique::Value => v_unique_value,
+                };
+                builder.add(tempid.clone(), a_unique, uu)?;
+            }
+        }
+
+        builder.build()
+    }
+
+    /// Return a sequence of terms that describes this vocabulary definition and its attributes.
+    fn description<T>(&self, via: &T) -> Result<Terms> where T: HasSchema {
+        self.description_for_attributes(self.attributes.as_slice(), via)
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum VocabularyCheck<'definition> {
+    NotPresent,
+    Present,
+    PresentButNeedsUpdate { older_version: Vocabulary },
+    PresentButTooNew { newer_version: Vocabulary },
+    PresentButMissing { attributes: Vec<&'definition (NamespacedKeyword, Attribute)> },
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum VocabularyOutcome {
+    /// The vocabulary was absent and has been installed.
+    Installed,
+
+    /// The vocabulary was present with this version, but some attributes were absent.
+    /// They have been installed.
+    InstalledMissing,
+
+    /// The vocabulary was present, at the correct version, and all attributes were present.
+    Existed,
+
+    /// The vocabulary was present, at an older version, and it has been upgraded. Any
+    /// missing attributes were installed.
+    Upgraded,
+}
+
+pub trait HasVocabularies {
+    fn read_vocabularies(&self) -> Result<Vocabularies>;
+    fn read_vocabulary_named(&self, name: &NamespacedKeyword) -> Result<Option<Vocabulary>>;
+}
+
+pub trait VersionedStore {
+    /// Check whether the vocabulary described by the provided metadata is present in the store.
+    fn check_vocabulary<'definition>(&self, definition: &'definition Definition) -> Result<VocabularyCheck<'definition>>;
+
+    /// Check whether the provided vocabulary is present in the store. If it isn't, make it so.
+    fn ensure_vocabulary(&mut self, definition: &Definition) -> Result<VocabularyOutcome>;
+
+    /// Make sure that our expectations of the core vocabulary -- basic types and attributes -- are met.
+    fn verify_core_schema(&self) -> Result<()>;
+}
+
+trait VocabularyMechanics {
+    fn install_vocabulary(&mut self, definition: &Definition) -> Result<VocabularyOutcome>;
+    fn install_attributes_for<'definition>(&mut self, definition: &'definition Definition, attributes: Vec<&'definition (NamespacedKeyword, Attribute)>) -> Result<VocabularyOutcome>;
+    fn upgrade_vocabulary(&mut self, definition: &Definition, from_version: Vocabulary) -> Result<VocabularyOutcome>;
+}
+
+impl Vocabulary {
+    // TODO: don't do linear search!
+    fn find<T>(&self, entid: T) -> Option<&Attribute> where T: Into<Entid> {
+        let to_find = entid.into();
+        self.attributes.iter().find(|&&(e, _)| e == to_find).map(|&(_, ref a)| a)
+    }
+}
+
+impl<'a, 'c> VersionedStore for InProgress<'a, 'c> {
+    fn verify_core_schema(&self) -> Result<()> {
+        if let Some(core) = self.read_vocabulary_named(&DB_SCHEMA_CORE)? {
+            if core.version != CORE_SCHEMA_VERSION {
+                bail!(ErrorKind::UnexpectedCoreSchema(Some(core.version)));
+            }
+
+            // TODO: check things other than the version.
+        } else {
+            // This would be seriously messed up.
+            bail!(ErrorKind::UnexpectedCoreSchema(None));
+        }
+        Ok(())
+    }
+
+    fn check_vocabulary<'definition>(&self, definition: &'definition Definition) -> Result<VocabularyCheck<'definition>> {
+        if let Some(vocabulary) = self.read_vocabulary_named(&definition.name)? {
+            // The name is present.
+            // Check the version.
+            if vocabulary.version == definition.version {
+                // Same version. Check that all of our attributes are present.
+                let mut missing: Vec<&'definition (NamespacedKeyword, Attribute)> = vec![];
+                for pair in definition.attributes.iter() {
+                    if let Some(entid) = self.get_entid(&pair.0) {
+                        if let Some(existing) = vocabulary.find(entid) {
+                            if *existing == pair.1 {
+                                // Same. Phew.
+                                continue;
+                            } else {
+                                // We have two vocabularies with the same name, same version, and
+                                // different definitions for an attribute. That's a coding error.
+                                // We can't accept this vocabulary.
+                                bail!(ErrorKind::ConflictingAttributeDefinitions(
+                                          definition.name.to_string(),
+                                          definition.version,
+                                          pair.0.to_string(),
+                                          existing.clone(),
+                                          pair.1.clone())
+                                );
+                            }
+                        }
+                    }
+                    // It's missing. Collect it.
+                    missing.push(pair);
+                }
+                if missing.is_empty() {
+                    Ok(VocabularyCheck::Present)
+                } else {
+                    Ok(VocabularyCheck::PresentButMissing { attributes: missing })
+                }
+            } else if vocabulary.version < definition.version {
+                // Ours is newer. Upgrade.
+                Ok(VocabularyCheck::PresentButNeedsUpdate { older_version: vocabulary })
+            } else {
+                // The vocabulary in the store is newer. We are outdated.
+                Ok(VocabularyCheck::PresentButTooNew { newer_version: vocabulary })
+            }
+        } else {
+            // The vocabulary isn't present in the store. Install it.
+            Ok(VocabularyCheck::NotPresent)
+        }
+    }
+
+    fn ensure_vocabulary(&mut self, definition: &Definition) -> Result<VocabularyOutcome> {
+        match self.check_vocabulary(definition)? {
+            VocabularyCheck::Present => Ok(VocabularyOutcome::Existed),
+            VocabularyCheck::NotPresent => self.install_vocabulary(definition),
+            VocabularyCheck::PresentButNeedsUpdate { older_version } => self.upgrade_vocabulary(definition, older_version),
+            VocabularyCheck::PresentButMissing { attributes } => self.install_attributes_for(definition, attributes),
+            VocabularyCheck::PresentButTooNew { newer_version } => Err(ErrorKind::ExistingVocabularyTooNew(definition.name.to_string(), newer_version.version, definition.version).into()),
+        }
+    }
+}
+
+impl<'a, 'c> VocabularyMechanics for InProgress<'a, 'c> {
+    /// Turn the vocabulary into datoms, transact them, and on success return the outcome.
+    fn install_vocabulary(&mut self, definition: &Definition) -> Result<VocabularyOutcome> {
+        let (terms, tempids) = definition.description(self)?;
+        self.transact_terms(terms, tempids)?;
+        Ok(VocabularyOutcome::Installed)
+    }
+
+    fn install_attributes_for<'definition>(&mut self, definition: &'definition Definition, attributes: Vec<&'definition (NamespacedKeyword, Attribute)>) -> Result<VocabularyOutcome> {
+        let (terms, tempids) = definition.description_for_attributes(&attributes, self)?;
+        self.transact_terms(terms, tempids)?;
+        Ok(VocabularyOutcome::InstalledMissing)
+    }
+
+    /// Turn the declarative parts of the vocabulary into alterations. Run the 'pre' steps.
+    /// Transact the changes. Run the 'post' steps. Return the result and the new `InProgress`!
+    fn upgrade_vocabulary(&mut self, _definition: &Definition, _from_version: Vocabulary) -> Result<VocabularyOutcome> {
+        unimplemented!();
+        // TODO
+        // Ok(VocabularyOutcome::Installed)
+    }
+}
+
+impl<T> HasVocabularies for T where T: HasSchema + Queryable {
+    fn read_vocabulary_named(&self, name: &NamespacedKeyword) -> Result<Option<Vocabulary>> {
+        if let Some(entid) = self.get_entid(name) {
+            match self.lookup_value_for_attribute(entid, &DB_SCHEMA_VERSION)? {
+                None => Ok(None),
+                Some(TypedValue::Long(version))
+                    if version > 0 && (version < u32::max_value() as i64) => {
+                        let version = version as u32;
+                        let attributes = self.lookup_values_for_attribute(entid, &DB_SCHEMA_ATTRIBUTE)?
+                                             .into_iter()
+                                             .filter_map(|a| {
+                                                 if let TypedValue::Ref(a) = a {
+                                                     self.attribute_for_entid(a)
+                                                         .cloned()
+                                                         .map(|attr| (a, attr))
+                                                 } else {
+                                                     None
+                                                 }
+                                             })
+                                             .collect();
+                        Ok(Some(Vocabulary {
+                            entity: entid.into(),
+                            version: version,
+                            attributes: attributes,
+                        }))
+                    },
+                Some(_) => bail!(ErrorKind::InvalidVocabularyVersion),
+            }
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn read_vocabularies(&self) -> Result<Vocabularies> {
+        // This would be way easier with pull.
+        let versions: BTreeMap<Entid, u32> =
+            self.q_once(r#"[:find ?vocab ?version
+                            :where [?vocab :db.schema/version ?version]]"#, None)
+                .into_rel_result()?
+                .into_iter()
+                .filter_map(|v|
+                    match (&v[0], &v[1]) {
+                        (&TypedValue::Ref(vocab), &TypedValue::Long(version))
+                        if version > 0 && (version < u32::max_value() as i64) => Some((vocab, version as u32)),
+                        (_, _) => None,
+                    })
+                .collect();
+
+        let mut attributes = BTreeMap::<Entid, Vec<(Entid, Attribute)>>::new();
+        let pairs =
+            self.q_once("[:find ?vocab ?attr :where [?vocab :db.schema/attribute ?attr]]", None)
+                .into_rel_result()?
+                .into_iter()
+                .filter_map(|v| {
+                    match (&v[0], &v[1]) {
+                        (&TypedValue::Ref(vocab), &TypedValue::Ref(attr)) => Some((vocab, attr)),
+                        (_, _) => None,
+                    }
+                    });
+
+        // TODO: validate that attributes.keys is a subset of versions.keys.
+        for (vocab, attr) in pairs {
+            if let Some(attribute) = self.attribute_for_entid(attr).cloned() {
+                attributes.entry(vocab).or_insert(Vec::new()).push((attr, attribute));
+            }
+        }
+
+        // TODO: return more errors?
+
+        // We walk versions first in order to support vocabularies with no attributes.
+        Ok(Vocabularies(versions.into_iter().filter_map(|(vocab, version)| {
+            // Get the name.
+            self.get_ident(vocab).cloned()
+                .map(|name| {
+                    let attrs = attributes.remove(&vocab).unwrap_or(vec![]);
+                    (name.clone(), Vocabulary {
+                        entity: vocab,
+                        version: version,
+                        attributes: attrs,
+                    })
+                })
+        }).collect()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ::{
+        NamespacedKeyword,
+        Conn,
+        new_connection,
+    };
+
+    use super::HasVocabularies;
+
+    #[test]
+    fn test_read_vocabularies() {
+        let mut sqlite = new_connection("").expect("could open conn");
+        let mut conn = Conn::connect(&mut sqlite).expect("could open store");
+        let vocabularies = conn.queryable(&mut sqlite).expect("queryable").read_vocabularies().expect("OK");
+        assert_eq!(vocabularies.len(), 1);
+        let core = vocabularies.get(&NamespacedKeyword::new("db.schema", "core")).expect("exists");
+        assert_eq!(core.version, 1);
+    }
+
+    #[test]
+    fn test_core_schema() {
+        let mut c = new_connection("").expect("could open conn");
+        let mut conn = Conn::connect(&mut c).expect("could open store");
+        let in_progress = conn.begin_transaction(&mut c).expect("in progress");
+        let vocab = in_progress.read_vocabularies().expect("vocabulary");
+        assert_eq!(1, vocab.len());
+        assert_eq!(1, vocab.get(&NamespacedKeyword::new("db.schema", "core")).expect("core vocab").version);
+    }
+}

--- a/src/vocabulary.rs
+++ b/src/vocabulary.rs
@@ -501,7 +501,8 @@ mod tests {
     fn test_read_vocabularies() {
         let mut sqlite = new_connection("").expect("could open conn");
         let mut conn = Conn::connect(&mut sqlite).expect("could open store");
-        let vocabularies = conn.queryable(&mut sqlite).expect("queryable").read_vocabularies().expect("OK");
+        let vocabularies = conn.begin_read(&mut sqlite).expect("in progress")
+                               .read_vocabularies().expect("OK");
         assert_eq!(vocabularies.len(), 1);
         let core = vocabularies.get(&NamespacedKeyword::new("db.schema", "core")).expect("exists");
         assert_eq!(core.version, 1);

--- a/tests/query.rs
+++ b/tests/query.rs
@@ -23,6 +23,7 @@ use chrono::FixedOffset;
 use mentat_core::{
     DateTime,
     HasSchema,
+    KnownEntid,
     TypedValue,
     ValueType,
     Utc,
@@ -115,7 +116,7 @@ fn test_scalar() {
     if let QueryResults::Scalar(Some(TypedValue::Keyword(ref rc))) = results {
         // Should be '24'.
         assert_eq!(&NamespacedKeyword::new("db.type", "keyword"), rc.as_ref());
-        assert_eq!(24,
+        assert_eq!(KnownEntid(24),
                    db.schema.get_entid(rc).unwrap());
     } else {
         panic!("Expected scalar.");
@@ -146,7 +147,7 @@ fn test_tuple() {
         let cardinality_one = NamespacedKeyword::new("db.cardinality", "one");
         assert_eq!(tuple.len(), 2);
         assert_eq!(tuple[0], TypedValue::Boolean(true));
-        assert_eq!(tuple[1], TypedValue::Ref(db.schema.get_entid(&cardinality_one).unwrap()));
+        assert_eq!(tuple[1], db.schema.get_entid(&cardinality_one).expect("c1").into());
     } else {
         panic!("Expected tuple.");
     }

--- a/tests/query.rs
+++ b/tests/query.rs
@@ -60,7 +60,7 @@ fn test_rel() {
     let end = time::PreciseTime::now();
 
     // This will need to change each time we add a default ident.
-    assert_eq!(39, results.len());
+    assert_eq!(40, results.len());
 
     // Every row is a pair of a Ref and a Keyword.
     if let QueryResults::Rel(ref rel) = results {
@@ -168,7 +168,7 @@ fn test_coll() {
         .expect("Query failed");
     let end = time::PreciseTime::now();
 
-    assert_eq!(39, results.len());
+    assert_eq!(40, results.len());
 
     if let QueryResults::Coll(ref coll) = results {
         assert!(coll.iter().all(|item| item.matches_type(ValueType::Ref)));
@@ -247,7 +247,7 @@ fn test_instants_and_uuids() {
                  Some(TypedValue::Uuid(u)),
                  Some(TypedValue::Instant(t)),
                  None) => {
-                     assert!(e > 39);       // There are at least this many entities in the store.
+                     assert!(e > 40);       // There are at least this many entities in the store.
                      assert_eq!(Ok(u), Uuid::from_str("cf62d552-6569-4d1b-b667-04703041dfc4"));
                      assert!(t > start);
                  },

--- a/tests/query.rs
+++ b/tests/query.rs
@@ -22,6 +22,7 @@ use chrono::FixedOffset;
 
 use mentat_core::{
     DateTime,
+    HasSchema,
     TypedValue,
     ValueType,
     Utc,

--- a/tests/vocabulary.rs
+++ b/tests/vocabulary.rs
@@ -1,0 +1,269 @@
+// Copyright 2016 Mozilla
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#[macro_use]
+extern crate lazy_static;
+
+extern crate mentat;
+extern crate mentat_core;
+extern crate mentat_db;
+extern crate rusqlite;
+
+use mentat::vocabulary;
+
+use mentat::vocabulary::{
+    VersionedStore,
+    VocabularyCheck,
+    VocabularyOutcome,
+};
+
+use mentat::query::IntoResult;
+
+use mentat_core::{
+    HasSchema,
+};
+
+use mentat::{
+    Conn,
+    NamespacedKeyword,
+    Queryable,
+    TypedValue,
+    ValueType,
+};
+
+use mentat::entity_builder::BuildTerms;
+
+use mentat::errors::{
+    Error,
+    ErrorKind,
+};
+
+lazy_static! {
+    static ref FOO_NAME: NamespacedKeyword = {
+        NamespacedKeyword::new("foo", "name")
+    };
+
+    static ref FOO_MOMENT: NamespacedKeyword = {
+        NamespacedKeyword::new("foo", "moment")
+    };
+
+    static ref FOO_VOCAB: vocabulary::Definition = {
+        vocabulary::Definition {
+            name: NamespacedKeyword::new("org.mozilla", "foo"),
+            version: 1,
+            attributes: vec![
+                (FOO_NAME.clone(),
+                vocabulary::AttributeBuilder::default()
+                    .value_type(ValueType::String)
+                    .multival(false)
+                    .unique(vocabulary::attribute::Unique::Identity)
+                    .build()),
+                (FOO_MOMENT.clone(),
+                vocabulary::AttributeBuilder::default()
+                    .value_type(ValueType::Instant)
+                    .multival(false)
+                    .index(true)
+                    .build()),
+            ]
+        }
+    };
+}
+
+// Do some work with the appropriate level of paranoia for a shared system.
+fn be_paranoid(conn: &mut Conn, sqlite: &mut rusqlite::Connection, name: TypedValue, moment: TypedValue) {
+    let mut in_progress = conn.begin_transaction(sqlite).expect("begun successfully");
+    assert!(in_progress.verify_core_schema().is_ok());
+    assert!(in_progress.ensure_vocabulary(&FOO_VOCAB).is_ok());
+
+    let a_moment = in_progress.attribute_for_ident(&FOO_MOMENT).expect("exists").1;
+    let a_name = in_progress.attribute_for_ident(&FOO_NAME).expect("exists").1;
+
+    let builder = in_progress.builder();
+    let mut entity = builder.describe_tempid("s");
+    entity.add(a_name, name).expect("added");
+    entity.add(a_moment, moment).expect("added");
+    assert!(entity.commit().is_ok());      // Discard the TxReport.
+}
+
+#[test]
+fn test_real_world() {
+    let mut sqlite = mentat_db::db::new_connection("").unwrap();
+    let mut conn = Conn::connect(&mut sqlite).unwrap();
+
+    let alice: TypedValue = TypedValue::typed_string("Alice");
+    let barbara: TypedValue = TypedValue::typed_string("Barbara");
+    let now: TypedValue = TypedValue::current_instant();
+
+    be_paranoid(&mut conn, &mut sqlite, alice.clone(), now.clone());
+    be_paranoid(&mut conn, &mut sqlite, barbara.clone(), now.clone());
+
+    let results = conn.q_once(&mut sqlite, r#"[:find ?name ?when
+                                               :order (asc ?name)
+                                               :where [?x :foo/name ?name]
+                                                      [?x :foo/moment ?when]
+                                               ]"#,
+                              None)
+                      .into_rel_result()
+                      .expect("query succeeded");
+    assert_eq!(results,
+               vec![vec![alice, now.clone()], vec![barbara, now.clone()]]);
+}
+
+#[test]
+fn test_add_vocab() {
+    let bar = vocabulary::AttributeBuilder::default()
+                  .value_type(ValueType::Instant)
+                  .multival(false)
+                  .index(true)
+                  .build();
+    let baz = vocabulary::AttributeBuilder::default()
+                  .value_type(ValueType::String)
+                  .multival(true)
+                  .fulltext(true)
+                  .build();
+    let bar_only = vec![
+        (NamespacedKeyword::new("foo", "bar"), bar.clone()),
+    ];
+    let baz_only = vec![
+        (NamespacedKeyword::new("foo", "baz"), baz.clone()),
+    ];
+    let bar_and_baz = vec![
+        (NamespacedKeyword::new("foo", "bar"), bar.clone()),
+        (NamespacedKeyword::new("foo", "baz"), baz.clone()),
+    ];
+
+    let foo_v1_a = vocabulary::Definition {
+        name: NamespacedKeyword::new("org.mozilla", "foo"),
+        version: 1,
+        attributes: bar_only.clone(),
+    };
+
+    let foo_v1_b = vocabulary::Definition {
+        name: NamespacedKeyword::new("org.mozilla", "foo"),
+        version: 1,
+        attributes: bar_and_baz.clone(),
+    };
+
+    let mut sqlite = mentat_db::db::new_connection("").unwrap();
+    let mut conn = Conn::connect(&mut sqlite).unwrap();
+
+    let foo_version_query = r#"[:find [?version ?aa]
+                                :where
+                                [:org.mozilla/foo :db.schema/version ?version]
+                                [:org.mozilla/foo :db.schema/attribute ?a]
+                                [?a :db/ident ?aa]]"#;
+    let foo_attributes_query = r#"[:find [?aa ...]
+                                   :where
+                                   [:org.mozilla/foo :db.schema/attribute ?a]
+                                   [?a :db/ident ?aa]]"#;
+
+    // Scoped borrow of `conn`.
+    {
+        let mut in_progress = conn.begin_transaction(&mut sqlite).expect("begun successfully");
+
+        assert!(in_progress.verify_core_schema().is_ok());
+        assert_eq!(VocabularyCheck::NotPresent, in_progress.check_vocabulary(&foo_v1_a).expect("check completed"));
+        assert_eq!(VocabularyCheck::NotPresent, in_progress.check_vocabulary(&foo_v1_b).expect("check completed"));
+
+        // If we install v1.a, then it will succeed.
+        assert_eq!(VocabularyOutcome::Installed, in_progress.ensure_vocabulary(&foo_v1_a).expect("ensure succeeded"));
+
+        // Now we can query to get the vocab.
+        let ver_attr =
+            in_progress.q_once(foo_version_query, None)
+                       .into_tuple_result()
+                       .expect("query returns")
+                       .expect("a result");
+        assert_eq!(ver_attr[0], TypedValue::Long(1));
+        assert_eq!(ver_attr[1], TypedValue::typed_ns_keyword("foo", "bar"));
+
+        // If we commit, it'll stick around.
+        in_progress.commit().expect("commit succeeded");
+    }
+
+    // It's still there.
+    let ver_attr =
+        conn.q_once(&mut sqlite,
+                    foo_version_query,
+                    None)
+            .into_tuple_result()
+            .expect("query returns")
+            .expect("a result");
+    assert_eq!(ver_attr[0], TypedValue::Long(1));
+    assert_eq!(ver_attr[1], TypedValue::typed_ns_keyword("foo", "bar"));
+
+    // Scoped borrow of `conn`.
+    {
+        let mut in_progress = conn.begin_transaction(&mut sqlite).expect("begun successfully");
+
+        // Subsequently ensuring v1.a again will succeed with no work done.
+        assert_eq!(VocabularyCheck::Present, in_progress.check_vocabulary(&foo_v1_a).expect("check completed"));
+
+        // Checking for v1.b will say that we have work to do.
+        assert_eq!(VocabularyCheck::PresentButMissing {
+            attributes: vec![&baz_only[0]],
+        }, in_progress.check_vocabulary(&foo_v1_b).expect("check completed"));
+
+        // Ensuring v1.b will succeed.
+        assert_eq!(VocabularyOutcome::InstalledMissing, in_progress.ensure_vocabulary(&foo_v1_b).expect("ensure succeeded"));
+
+        // Checking v1.a or v1.b again will still succeed with no work done.
+        assert_eq!(VocabularyCheck::Present, in_progress.check_vocabulary(&foo_v1_a).expect("check completed"));
+        assert_eq!(VocabularyCheck::Present, in_progress.check_vocabulary(&foo_v1_b).expect("check completed"));
+
+        // Ensuring again does nothing.
+        assert_eq!(VocabularyOutcome::Existed, in_progress.ensure_vocabulary(&foo_v1_b).expect("ensure succeeded"));
+        in_progress.commit().expect("commit succeeded");
+    }
+
+    // We have both attributes.
+    let actual_attributes =
+        conn.q_once(&mut sqlite,
+                    foo_attributes_query,
+                    None)
+            .into_coll_result()
+            .expect("query returns");
+    assert_eq!(actual_attributes,
+               vec![
+                   TypedValue::typed_ns_keyword("foo", "bar"),
+                   TypedValue::typed_ns_keyword("foo", "baz"),
+               ]);
+
+    // Now let's modify our vocabulary without bumping the version. This is invalid and will result
+    // in an error.
+    let malformed_baz = vocabulary::AttributeBuilder::default()
+                            .value_type(ValueType::Instant)
+                            .multival(true)
+                            .build();
+    let bar_and_malformed_baz = vec![
+        (NamespacedKeyword::new("foo", "bar"), bar),
+        (NamespacedKeyword::new("foo", "baz"), malformed_baz.clone()),
+    ];
+    let foo_v1_malformed = vocabulary::Definition {
+        name: NamespacedKeyword::new("org.mozilla", "foo"),
+        version: 1,
+        attributes: bar_and_malformed_baz.clone(),
+    };
+
+    // Scoped borrow of `conn`.
+    {
+        let mut in_progress = conn.begin_transaction(&mut sqlite).expect("begun successfully");
+        match in_progress.ensure_vocabulary(&foo_v1_malformed) {
+            Result::Err(Error(ErrorKind::ConflictingAttributeDefinitions(vocab, version, attr, theirs, ours), _)) => {
+                assert_eq!(vocab.as_str(), ":org.mozilla/foo");
+                assert_eq!(attr.as_str(), ":foo/baz");
+                assert_eq!(version, 1);
+                assert_eq!(&theirs, &baz);
+                assert_eq!(&ours, &malformed_baz);
+            },
+            _ => panic!(),
+        }
+    }
+}

--- a/tests/vocabulary.rs
+++ b/tests/vocabulary.rs
@@ -207,12 +207,13 @@ fn test_add_vocab() {
         assert_eq!(VocabularyCheck::Present, in_progress.check_vocabulary(&foo_v1_a).expect("check completed"));
 
         // Checking for v1.b will say that we have work to do.
-        assert_eq!(VocabularyCheck::PresentButMissing {
+        assert_eq!(VocabularyCheck::PresentButMissingAttributes {
             attributes: vec![&baz_only[0]],
         }, in_progress.check_vocabulary(&foo_v1_b).expect("check completed"));
 
         // Ensuring v1.b will succeed.
-        assert_eq!(VocabularyOutcome::InstalledMissing, in_progress.ensure_vocabulary(&foo_v1_b).expect("ensure succeeded"));
+        assert_eq!(VocabularyOutcome::InstalledMissingAttributes,
+                   in_progress.ensure_vocabulary(&foo_v1_b).expect("ensure succeeded"));
 
         // Checking v1.a or v1.b again will still succeed with no work done.
         assert_eq!(VocabularyCheck::Present, in_progress.check_vocabulary(&foo_v1_a).expect("check completed"));

--- a/tx/src/entities.rs
+++ b/tx/src/entities.rs
@@ -8,7 +8,7 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
-///! This module defines core types that support the transaction processor.
+//! This module defines core types that support the transaction processor.
 
 extern crate edn;
 


### PR DESCRIPTION
I might flatten this out a little tomorrow, but this lets us transact without writing EDN:

```rust
    let mut in_progress = conn.begin_transaction(sqlite)?;
    let a_moment = in_progress.attribute_for_ident(&FOO_MOMENT)?.1;
    let a_name = in_progress.attribute_for_ident(&FOO_NAME)?.1;

    let builder = in_progress.builder();
    let mut entity = builder.describe_tempid("s");
    entity.add(a_name, name)?;
    entity.add(a_moment, moment)?;
    entity.commit()?;
```

and manage schemas without transacting:

```rust
    in_progress.verify_core_schema()?;
    in_progress.ensure_vocabulary(&FOO_VOCAB)?;
```

This implements all of the Rust side of schema management (that is, no JSON) apart from upgrades — you can check, add, and compatibly extend vocabulary, but not incompatibly upgrade yet.

There's a test for the violation of that contract: if you try to alter an attribute without changing the version number, you'll get a descriptive error.