### PR TITLE
CLI quality-of-life fixes

### DIFF
--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -14,7 +14,7 @@ test = false
 [dependencies]
 getopts = "0.2"
 env_logger = "0.3"
-linefeed = "0.1"
+linefeed = "0.4"
 log = "0.3"
 tempfile = "1.1"
 combine = "2.2.2"

--- a/tools/cli/src/mentat_cli/input.rs
+++ b/tools/cli/src/mentat_cli/input.rs
@@ -84,13 +84,15 @@ impl InputReader {
             None => return Ok(Eof),
         };
 
+        if !self.buffer.is_empty() {
+            self.buffer.push('\n');
+        }
+
         self.buffer.push_str(&line);
 
         if self.buffer.is_empty() {
             return Ok(Empty);
         }
-
-        self.add_history(&line);
 
         // if we have a command in process (i.e. an incomplete query or transaction),
         // then we already know which type of command it is and so we don't need to parse the
@@ -121,6 +123,8 @@ impl InputReader {
                         Ok(More)
                     },
                     _ => {
+                        let history = self.buffer.clone();
+                        self.add_history(&history);
                         self.buffer.clear();
                         self.in_process_cmd = None;
                         Ok(InputResult::MetaCommand(cmd))
@@ -128,6 +132,8 @@ impl InputReader {
                 }
             },
             Err(e) => {
+                let history = self.buffer.clone();
+                self.add_history(&history);
                 self.buffer.clear();
                 self.in_process_cmd = None;
                 Err(e)

--- a/tools/cli/src/mentat_cli/input.rs
+++ b/tools/cli/src/mentat_cli/input.rs
@@ -123,18 +123,18 @@ impl InputReader {
                         Ok(More)
                     },
                     _ => {
-                        let history = self.buffer.clone();
-                        self.add_history(&history);
+                        let entry = self.buffer.clone();
                         self.buffer.clear();
+                        self.add_history(entry);
                         self.in_process_cmd = None;
                         Ok(InputResult::MetaCommand(cmd))
                     }
                 }
             },
             Err(e) => {
-                let history = self.buffer.clone();
-                self.add_history(&history);
+                let entry = self.buffer.clone();
                 self.buffer.clear();
+                self.add_history(entry);
                 self.in_process_cmd = None;
                 Err(e)
             },
@@ -165,9 +165,9 @@ impl InputReader {
         }
     }
 
-    fn add_history(&mut self, line: &str) {
+    fn add_history(&mut self, line: String) {
         if let Some(ref mut r) = self.reader {
-            r.add_history(line.to_owned());
+            r.add_history(line);
         }
     }
 }

--- a/tools/cli/src/mentat_cli/input.rs
+++ b/tools/cli/src/mentat_cli/input.rs
@@ -56,7 +56,7 @@ impl InputReader {
     pub fn new() -> InputReader {
         let r = match Reader::new("mentat") {
             Ok(mut r) => {
-                r.set_word_break_chars(" \t\n!\"#$%&'()*+,-./:;<=>?@[\\]^`");
+                r.set_word_break_chars(" \t\n!\"#$%&'(){}*+,-./:;<=>?@[\\]^`");
                 Some(r)
             },
             Err(_) => None,

--- a/tools/cli/src/mentat_cli/input.rs
+++ b/tools/cli/src/mentat_cli/input.rs
@@ -10,8 +10,11 @@
 
 use std::io::stdin;
 
-use linefeed::Reader;
-use linefeed::terminal::DefaultTerminal;
+use linefeed::{
+    DefaultTerminal,
+    Reader,
+    ReadResult,
+};
 
 use self::InputResult::*;
 
@@ -136,7 +139,12 @@ impl InputReader {
         match self.reader {
             Some(ref mut r) => {
                 r.set_prompt(prompt);
-                r.read_line().ok().and_then(|line| line)
+                r.read_line().ok().and_then(|line|
+                    match line {
+                        ReadResult::Input(s) => Some(s),
+                        _ => None
+                    })
+
             },
             None => self.read_stdin()
         }


### PR DESCRIPTION
These have been bugging me while working on type hinting, and are easy to fix so I just did them. None of them should be particularly controversial, hopefully.

Bumping the version fixes a bunch of issues like pasting into the CLI not actually working right until you type a character after the paste, etc (or was I the only one who has that happen to them?). It also makes emacs-style movement keys work.

Arguably, I think `:`, `/`, and `?` should be removed from the the word separators also, but I think it doesn't matter very much, and I can see the argument the other way too.