### PR TITLE
Ensure that DateTime values are truncated to microsecond precision.

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.1"
 workspace = ".."
 
 [dependencies]
+chrono = "0.4"
 enum-set = { git = "https://github.com/rnewman/enum-set" }
 lazy_static = "0.2"
 num = "0.1"


### PR DESCRIPTION
This is the cause of test failures in #507: when we persist `Instant`s into the database, we lose nanoseconds… but the `TypedValue` we have in memory is _not_ truncated. That's inconvenient and misleading, so let's truncate them at the point of creation.