### PR TITLE
Add a CLI command to output the SQL we would execute for a query.

### DIFF
--- a/src/conn.rs
+++ b/src/conn.rs
@@ -40,6 +40,8 @@ use errors::*;
 use query::{
     lookup_value_for_attribute,
     q_once,
+    q_explain,
+    QueryExplanation,
     QueryInputs,
     QueryResults,
 };
@@ -212,6 +214,15 @@ impl Conn {
                &*self.current_schema(),
                query,
                inputs)
+    }
+
+    pub fn q_explain<T>(&self,
+                        sqlite: &rusqlite::Connection,
+                        query: &str,
+                        inputs: T) -> Result<QueryExplanation>
+        where T: Into<Option<QueryInputs>>
+    {
+        q_explain(sqlite, &*self.current_schema(), query, inputs)
     }
 
     pub fn lookup_value_for_attribute(&self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,9 @@ pub use mentat_db::{
 pub use query::{
     NamespacedKeyword,
     PlainSymbol,
+    QueryExplanation,
     QueryInputs,
+    QueryPlanStep,
     QueryResults,
     Variable,
     q_once,

--- a/tools/cli/src/mentat_cli/input.rs
+++ b/tools/cli/src/mentat_cli/input.rs
@@ -115,7 +115,8 @@ impl InputReader {
             Ok(cmd) => {
                 match cmd {
                     Command::Query(_) |
-                    Command::Transact(_) if !cmd.is_complete() => {
+                    Command::Transact(_) |
+                    Command::QueryExplain(_) if !cmd.is_complete() => {
                         // A query or transact is complete if it contains a valid EDN.
                         // if the command is not complete, ask for more from the REPL and remember
                         // which type of command we've found here.

--- a/tools/cli/src/mentat_cli/store.rs
+++ b/tools/cli/src/mentat_cli/store.rs
@@ -16,6 +16,7 @@ use errors as cli;
 
 use mentat::{
     new_connection,
+    QueryExplanation,
 };
 
 use mentat::query::QueryResults;
@@ -56,6 +57,10 @@ impl Store {
 
     pub fn query(&self, query: String) -> Result<QueryResults, cli::Error> {
         Ok(self.conn.q_once(&self.handle, &query, None)?)
+    }
+
+    pub fn explain_query(&self, query: String) -> Result<QueryExplanation, cli::Error> {
+        Ok(self.conn.q_explain(&self.handle, &query, None)?)
     }
 
     pub fn transact(&mut self, transaction: String) -> Result<TxReport, cli::Error> {


### PR DESCRIPTION
Not having this has been bugging me while working on #474, and since I was already poking around in the CLI code...

Anyway, I can see arguments against it (it's an implementation detail), but it seems generally useful enough to be worth having, especially while we're working on mentat. 

Usage examples:
```
mentat=> .qsql [:find [?v ...] :where [65543 _ ?v]]
SELECT DISTINCT `all_datoms00`.v AS `?v`, `all_datoms00`.value_type_tag AS `?v_value_type_tag` FROM `all_datoms` AS `all_datoms00` WHERE `all_datoms00`.e = 65543

mentat=> .qsql [:find ?eid :where [?eid :t/name "foo"]]
SELECT DISTINCT `datoms00`.e AS `?eid` FROM `datoms` AS `datoms00` WHERE `datoms00`.a = 65536 AND `datoms00`.v = $v0
Bindings:
  $v0 = Text("foo")
```

Having an equivalent for transact seems useful eventually (maybe? I don't really know, to be honest), hence naming it `.qsql` and not the more natural `.sql`.