### PR TITLE
Create generalized in-memory cache for attributes

### DIFF
--- a/db/src/cache.rs
+++ b/db/src/cache.rs
@@ -22,10 +22,7 @@ use db::{
 };
 use mentat_core::{
     Entid,
-    HasSchema,
     KnownEntid,
-    NamespacedKeyword,
-    Schema,
     TypedValue,
 };
 
@@ -46,6 +43,7 @@ pub trait Cacheable {
     fn get(&self, key: &Self::Key) -> Option<&Self::Value>;
 }
 
+#[derive(Clone)]
 pub struct EagerCache<K, V, VP> where K: Ord, VP: ValueProvider<K, V> {
     pub cache: BTreeMap<K, V>,
     value_provider: VP,
@@ -80,6 +78,7 @@ impl<K, V, VP> Cacheable for EagerCache<K, V, VP> where K: Ord + Clone + Debug, 
     }
 }
 
+#[derive(Clone)]
 pub struct AttributeValueProvider {
     pub attribute: KnownEntid,
 }

--- a/db/src/cache.rs
+++ b/db/src/cache.rs
@@ -1,0 +1,106 @@
+// Copyright 2016 Mozilla
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+use std::collections::BTreeMap;
+use std::cmp::Ord;
+use std::fmt::Debug;
+
+use rusqlite;
+
+use errors::{
+    Result
+};
+use db::{
+    TypedSQLValue,
+};
+use mentat_core::{
+    Entid,
+    HasSchema,
+    KnownEntid,
+    NamespacedKeyword,
+    Schema,
+    TypedValue,
+};
+
+pub trait ValueProvider<K, V>: Sized {
+    fn fetch_values<'sqlite>(&mut self, sqlite: &'sqlite rusqlite::Connection) -> Result<BTreeMap<K, V>>;
+}
+
+pub trait Cacheable {
+    type Key;
+    type Value;
+    type ValueProvider;
+
+    fn new(value_provider: Self::ValueProvider) -> Self;
+    fn cache_values<'sqlite>(&mut self,
+                                      sqlite: &'sqlite rusqlite::Connection) -> Result<()>;
+    fn update_values<'sqlite>(&mut self,
+                                       sqlite: &'sqlite rusqlite::Connection) -> Result<()>;
+    fn get(&self, key: &Self::Key) -> Option<&Self::Value>;
+}
+
+pub struct EagerCache<K, V, VP> where K: Ord, VP: ValueProvider<K, V> {
+    pub cache: BTreeMap<K, V>,
+    value_provider: VP,
+}
+
+impl<K, V, VP> Cacheable for EagerCache<K, V, VP> where K: Ord + Clone + Debug, V: Clone, VP: ValueProvider<K, V> {
+    type Key = K;
+    type Value = V;
+    type ValueProvider = VP;
+
+    fn new(value_provider: Self::ValueProvider) -> Self {
+        EagerCache {
+            cache: BTreeMap::new(),
+            value_provider,
+        }
+    }
+
+    fn cache_values<'sqlite>(&mut self,
+                                      sqlite: &'sqlite rusqlite::Connection) -> Result<()> {
+        // fetch results and add to cache
+        self.cache = self.value_provider.fetch_values(sqlite)?;
+        Ok(())
+    }
+
+    fn update_values<'sqlite>(&mut self,
+                                       sqlite: &'sqlite rusqlite::Connection) -> Result<()> {
+        self.cache_values(sqlite)
+    }
+
+    fn get(&self, key: &Self::Key) -> Option<&Self::Value> {
+        self.cache.get(&key)
+    }
+}
+
+pub struct AttributeValueProvider {
+    pub attribute: KnownEntid,
+}
+
+impl ValueProvider<Entid, Vec<TypedValue>> for AttributeValueProvider {
+    fn fetch_values<'sqlite>(&mut self, sqlite: &'sqlite rusqlite::Connection) -> Result<BTreeMap<Entid, Vec<TypedValue>>> {
+        let sql = "SELECT e, v, value_type_tag FROM datoms WHERE a = ? ORDER BY e ASC";
+        let mut stmt = sqlite.prepare(sql)?;
+        let value_iter = stmt.query_map(&[&self.attribute.0], |row| {
+            let entid: Entid = row.get(0);
+            let value_type_tag: i32 = row.get(2);
+            let value = TypedValue::from_sql_value_pair(row.get(1), value_type_tag).map(|x| x).unwrap();
+            (entid, value)
+        }).map_err(|e| e.into());
+        value_iter.map(|v| {
+            v.fold(BTreeMap::new(), |mut map, row| {
+                let _ = row.map(|r| {
+                    map.entry(r.0).or_insert(vec![]).push(r.1);
+                });
+                map
+            })
+        })
+    }
+}

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -33,18 +33,18 @@ use itertools::Itertools;
 
 pub use errors::{Error, ErrorKind, ResultExt, Result};
 
+mod add_retract_alter_set;
 pub mod db;
 mod bootstrap;
 pub mod debug;
-mod add_retract_alter_set;
 pub mod entids;
 pub mod errors;
+pub mod internal_types;    // pub because we need them for building entities programmatically.
 mod metadata;
 mod schema;
-pub mod types;
-pub mod internal_types;    // pub because we need them for building entities programmatically.
-mod upsert_resolution;
 mod tx;
+pub mod types;
+mod upsert_resolution;
 
 // Export these for reference from tests. cfg(test) should work, but doesn't.
 // #[cfg(test)]
@@ -57,10 +57,11 @@ pub use schema::{
     AttributeBuilder,
     AttributeValidation,
 };
-
 pub use bootstrap::{
     CORE_SCHEMA_VERSION,
 };
+
+use edn::symbols;
 
 pub use entids::{
     DB_SCHEMA_CORE,
@@ -81,8 +82,6 @@ pub use types::{
     PartitionMap,
     TxReport,
 };
-
-use edn::symbols;
 
 pub fn to_namespaced_keyword(s: &str) -> Result<symbols::NamespacedKeyword> {
     let splits = [':', '/'];

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -34,6 +34,7 @@ use itertools::Itertools;
 pub use errors::{Error, ErrorKind, ResultExt, Result};
 
 mod add_retract_alter_set;
+pub mod cache;
 pub mod db;
 mod bootstrap;
 pub mod debug;

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -159,7 +159,10 @@ mod tests {
             {  :foo/bar        200
                :foo/baz        true }]"#).expect("transaction expected to succeed");
         let schema = conn.current_schema();
-        conn.attribute_cache().add_to_cache(&sqlite, &schema, NamespacedKeyword::new("foo", "bar"), false ).expect("No errors on add to cache");
+        let kw = NamespacedKeyword::new("foo", "bar");
+        conn.attribute_cache().add_to_cache(&sqlite, &schema, kw.clone(), false ).expect("No errors on add to cache");
+        let entid = schema.get_entid(&kw).expect("expected entid for keyword");
+        assert!(conn.attribute_cache().is_cached(&entid));
     }
 
     #[test]
@@ -205,6 +208,8 @@ mod tests {
         let kw = NamespacedKeyword::new("foo", "bar");
 
         conn.attribute_cache().add_to_cache(&mut sqlite, &schema,kw.clone(), false).expect("No errors on add to cache");
+        let entid = schema.get_entid(&kw).expect("expected entid for keyword");
+        assert!(conn.attribute_cache().is_cached(&entid));
         conn.attribute_cache().add_to_cache(&mut sqlite, &schema,kw.clone(), true).expect("No errors on add to cache");
     }
 
@@ -227,11 +232,16 @@ mod tests {
         let kwr = NamespacedKeyword::new("foo", "bar");
         let kwz = NamespacedKeyword::new("foo", "baz");
 
-        conn.attribute_cache().add_to_cache(&mut sqlite, &schema,kwr, false).expect("No errors on add to cache");
+        conn.attribute_cache().add_to_cache(&mut sqlite, &schema,kwr.clone(), false).expect("No errors on add to cache");
+        let entid = schema.get_entid(&kwr).expect("expected entid for keyword");
+        assert!(conn.attribute_cache().is_cached(&entid));
         conn.attribute_cache().add_to_cache(&mut sqlite, &schema,kwz.clone(), true).expect("No errors on add to cache");
+        let entid = schema.get_entid(&kwz).expect("expected entid for keyword");
+        assert!(conn.attribute_cache().is_cached(&entid));
 
         // test that we can remove an item from cache
         conn.attribute_cache().remove_from_cache(&schema,kwz).expect("No errors on remove from cache");
+        assert!(!conn.attribute_cache().is_cached(&entid));
     }
 
     #[test]

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -174,8 +174,8 @@ mod tests {
                :foo/baz        true }]"#).expect("transaction expected to succeed");
         let schema = conn.current_schema();
         let kw = NamespacedKeyword::new("foo", "bar");
-        conn.attribute_cache().add_to_cache(&sqlite, &schema, kw.clone(), CacheType::Eager ).expect("No errors on add to cache");
-        assert!(conn.attribute_cache().is_cached(&kw));
+        conn.attribute_cache().add_to_cache(&sqlite, &schema, kw.clone() ).expect("No errors on add to cache");
+        assert!(conn.attribute_cache().contains_key(&kw));
     }
 
     #[test]
@@ -195,9 +195,9 @@ mod tests {
         let schema = conn.current_schema();
         let kw = NamespacedKeyword::new("foo", "bat");
 
-        let res = conn.attribute_cache().add_to_cache(&sqlite, &schema,kw.clone(), CacheType::Eager);
+        let res = conn.attribute_cache().add_to_cache(&sqlite, &schema,kw.clone());
         match res.unwrap_err() {
-            Error(ErrorKind::UnknownAttribute(msg), _) => assert_eq!(msg, kw.to_string()),
+            Error(ErrorKind::UnknownAttribute(msg), _) => assert_eq!(msg, format!("{:?}", kw)),
             x => panic!("expected UnknownAttribute error, got {:?}", x),
         }
     }
@@ -220,10 +220,10 @@ mod tests {
 
         let kw = NamespacedKeyword::new("foo", "bar");
 
-        conn.attribute_cache().add_to_cache(&mut sqlite, &schema,kw.clone(), CacheType::Eager).expect("No errors on add to cache");
-        assert!(conn.attribute_cache().is_cached(&kw));
-        conn.attribute_cache().add_to_cache(&mut sqlite, &schema,kw.clone(), CacheType::Lazy).expect("No errors on add to cache");
-        assert!(conn.attribute_cache().is_cached(&kw));
+        conn.attribute_cache().add_to_cache(&mut sqlite, &schema,kw.clone()).expect("No errors on add to cache");
+        assert!(conn.attribute_cache().contains_key(&kw));
+        conn.attribute_cache().add_to_cache(&mut sqlite, &schema,kw.clone()).expect("No errors on add to cache");
+        assert!(conn.attribute_cache().contains_key(&kw));
     }
 
     #[test]
@@ -245,14 +245,14 @@ mod tests {
         let kwr = NamespacedKeyword::new("foo", "bar");
         let kwz = NamespacedKeyword::new("foo", "baz");
 
-        conn.attribute_cache().add_to_cache(&mut sqlite, &schema,kwr.clone(), CacheType::Eager).expect("No errors on add to cache");
-        assert!(conn.attribute_cache().is_cached(&kwr));
-        conn.attribute_cache().add_to_cache(&mut sqlite, &schema,kwz.clone(), CacheType::Lazy).expect("No errors on add to cache");
-        assert!(conn.attribute_cache().is_cached(&kwz));
+        conn.attribute_cache().add_to_cache(&mut sqlite, &schema,kwr.clone()).expect("No errors on add to cache");
+        assert!(conn.attribute_cache().contains_key(&kwr));
+        conn.attribute_cache().add_to_cache(&mut sqlite, &schema,kwz.clone()).expect("No errors on add to cache");
+        assert!(conn.attribute_cache().contains_key(&kwz));
 
         // test that we can remove an item from cache
         conn.attribute_cache().remove_from_cache(&kwz).expect("No errors on remove from cache");
-        assert!(!conn.attribute_cache().is_cached(&kwz));
+        assert!(!conn.attribute_cache().contains_key(&kwz));
     }
 
     #[test]
@@ -274,7 +274,7 @@ mod tests {
         let kw = NamespacedKeyword::new("foo", "baz");
         let res = conn.attribute_cache().remove_from_cache(&kw);
         match res.unwrap_err() {
-            Error(ErrorKind::CacheMiss(msg), _) => assert_eq!(msg, kw.to_string()),
+            Error(ErrorKind::CacheMiss(msg), _) => assert_eq!(msg, format!("{:?}", kw)),
             x => panic!("expected CacheMiss error, got {:?}", x),
         }
     }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -9,25 +9,23 @@
 // specific language governing permissions and limitations under the License.
 
 use std::collections::BTreeMap;
-use std::cmp::Ord;
-use std::fmt::Debug;
 
 use rusqlite;
 
-use errors::*;
 use mentat_core::{
-    HasSchema,
+    Entid,
     KnownEntid,
-    NamespacedKeyword,
-    Schema,
     TypedValue,
 };
 
-use query::{
-    q_once,
-    IntoResult,
-    QueryInputs,
-    Variable,
+use mentat_db::cache::{
+    AttributeValueProvider,
+    Cacheable,
+    EagerCache,
+};
+
+use errors::{
+    Result,
 };
 
 pub enum CacheAction {
@@ -35,63 +33,8 @@ pub enum CacheAction {
     Deregister,
 }
 
-pub trait ValueProvider<K, V>: Sized {
-    fn fetch_values<'sqlite, 'schema>(&mut self, sqlite: &'sqlite rusqlite::Connection, schema: &'schema Schema) -> Result<BTreeMap<K, V>>;
-}
-
-pub trait Cacheable {
-    type Key;
-    type Value;
-    type ValueProvider;
-
-    fn new(value_provider: Self::ValueProvider) -> Self;
-    fn cache_values<'sqlite, 'schema>(&mut self,
-                             sqlite: &'sqlite rusqlite::Connection,
-                             schema: &'schema Schema) -> Result<()>;
-    fn update_values<'sqlite, 'schema>(&mut self,
-                                       sqlite: &'sqlite rusqlite::Connection,
-                                       schema: &'schema Schema) -> Result<()>;
-    fn get(&self, key: &Self::Key) -> Option<&Self::Value>;
-}
-
-pub struct EagerCache<K, V, VP> where K: Ord, VP: ValueProvider<K, V> {
-    cache: BTreeMap<K, V>,
-    value_provider: VP,
-}
-
-impl<K, V, VP> Cacheable for EagerCache<K, V, VP> where K: Ord + Clone + Debug, V: Clone, VP: ValueProvider<K, V> {
-    type Key = K;
-    type Value = V;
-    type ValueProvider = VP;
-
-    fn new(value_provider: Self::ValueProvider) -> Self {
-        EagerCache {
-            cache: BTreeMap::new(),
-            value_provider,
-        }
-    }
-
-    fn cache_values<'sqlite, 'schema>(&mut self,
-                                            sqlite: &'sqlite rusqlite::Connection,
-                                            schema: &'schema Schema) -> Result<()> {
-        // fetch results and add to cache
-        self.cache = self.value_provider.fetch_values(sqlite, schema)?;
-        Ok(())
-    }
-
-    fn update_values<'sqlite, 'schema>(&mut self,
-                                      sqlite: &'sqlite rusqlite::Connection,
-                                      schema: &'schema Schema) -> Result<()> {
-        self.cache_values(sqlite, schema)
-    }
-
-    fn get(&self, key: &Self::Key) -> Option<&Self::Value> {
-        self.cache.get(&key)
-    }
-}
-
 pub struct AttributeCacher {
-    cache: BTreeMap<NamespacedKeyword, EagerCache<TypedValue, Vec<TypedValue>, AttributeValueProvider>>,   // values keyed by attribute
+    cache: BTreeMap<Entid, EagerCache<Entid, Vec<TypedValue>, AttributeValueProvider>>,   // values keyed by attribute
 }
 
 impl AttributeCacher {
@@ -102,62 +45,37 @@ impl AttributeCacher {
         }
     }
 
-    pub fn register_attribute<'sqlite, 'schema>(&mut self, sqlite: &'sqlite rusqlite::Connection, schema: &'schema Schema, attribute: NamespacedKeyword) -> Result<()> {
-        if schema.identifies_attribute(&attribute) {
-            let value_provider = AttributeValueProvider{ attribute: attribute.clone() };
-            let mut cacher = EagerCache::new(value_provider);
-            cacher.cache_values(sqlite, schema)?;
-            self.cache.insert(attribute, cacher);
-            Ok(())
-        } else {
-            bail!(ErrorKind::UnknownAttribute(attribute.to_string()))
-        }
+    pub fn register_attribute<'sqlite>(&mut self, sqlite: &'sqlite rusqlite::Connection, attribute: KnownEntid) -> Result<()> {
+        let value_provider = AttributeValueProvider{ attribute: attribute.clone() };
+        let mut cacher = EagerCache::new(value_provider);
+        cacher.cache_values(sqlite)?;
+        self.cache.insert(attribute.0, cacher);
+        Ok(())
     }
 
-    pub fn deregister_attribute(&mut self, attribute: &NamespacedKeyword) -> Option<BTreeMap<TypedValue, Vec<TypedValue>>> {
-        self.cache.remove(attribute).map(|m| m.cache )
+    pub fn deregister_attribute(&mut self, attribute: &KnownEntid) -> Option<BTreeMap<Entid, Vec<TypedValue>>> {
+        self.cache.remove(&attribute.0).map(|m| m.cache )
     }
 
-    pub fn get(&mut self, attribute: &NamespacedKeyword) -> Option<&BTreeMap<TypedValue, Vec<TypedValue>>> {
-        self.cache.get( attribute ).map(|m| &m.cache )
+    pub fn get(&mut self, attribute: &KnownEntid) -> Option<&BTreeMap<Entid, Vec<TypedValue>>> {
+        self.cache.get( &attribute.0 ).map(|m| &m.cache )
     }
 
-    pub fn get_for_entid(&mut self, attribute: NamespacedKeyword, entid: KnownEntid) -> Option<&Vec<TypedValue>> {
-        if let Some(c) = self.cache.get(&attribute) {
-            c.get(&entid.into())
+    pub fn get_for_entid(&mut self, attribute: &KnownEntid, entid: &KnownEntid) -> Option<&Vec<TypedValue>> {
+        if let Some(c) = self.cache.get(&attribute.0) {
+            c.get(&entid.0)
         } else { None }
-    }
-}
-
-struct AttributeValueProvider {
-    attribute: NamespacedKeyword,
-}
-
-impl ValueProvider<TypedValue, Vec<TypedValue>> for AttributeValueProvider {
-    fn fetch_values<'sqlite, 'schema>(&mut self, sqlite: &'sqlite rusqlite::Connection, schema: &'schema Schema) -> Result<BTreeMap<TypedValue, Vec<TypedValue>>> {
-        Ok(q_once(sqlite,
-                  schema,
-                  r#"[:find ?entity ?value
-                                          :in ?attribute
-                                          :where [?entity ?a        ?value]
-                                                 [?a      :db/ident ?attribute]]"#,
-                  QueryInputs::with_value_sequence(vec![(Variable::from_valid_name("?attribute"), self.attribute.clone().into())]))
-            .into_rel_result()?
-            .into_iter()
-            .fold(BTreeMap::new(), |mut map, row| {
-                map.entry(row[0].clone()).or_insert(vec![]).push(row[1].clone());
-                map
-            }))
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use mentat_core::HasSchema;
     use mentat_db::db;
     use conn::Conn;
 
-    fn assert_values_present_for_attribute(attribute_cache: &mut AttributeCacher, attribute: &NamespacedKeyword, values: Vec<Vec<TypedValue>>) {
+    fn assert_values_present_for_attribute(attribute_cache: &mut AttributeCacher, attribute: &KnownEntid, values: Vec<Vec<TypedValue>>) {
         let cached_values: Vec<Vec<TypedValue>> = attribute_cache.get(&attribute)
             .expect("Expected cached values")
             .values()
@@ -181,35 +99,11 @@ mod tests {
             {  :foo/bar        200
                :foo/baz        true }]"#).expect("transaction expected to succeed");
         let schema = conn.current_schema();
-        let kw = NamespacedKeyword::new("foo", "bar");
         let mut attribute_cache = AttributeCacher::new();
-        attribute_cache.register_attribute(&sqlite, &schema, kw.clone() ).expect("No errors on add to cache");
-        assert_values_present_for_attribute(&mut attribute_cache, &kw, vec![vec![TypedValue::Long(100)], vec![TypedValue::Long(200)]]);
-    }
-
-    #[test]
-    fn test_add_to_cache_wrong_attribute() {
-        let mut sqlite = db::new_connection("").unwrap();
-        let mut conn = Conn::connect(&mut sqlite).unwrap();
-        let _report = conn.transact(&mut sqlite, r#"[
-            {  :db/ident       :foo/bar
-               :db/valueType   :db.type/long },
-            {  :db/ident       :foo/baz
-               :db/valueType   :db.type/boolean }]"#).expect("transaction expected to succeed");
-        let _report = conn.transact(&mut sqlite, r#"[
-            {  :foo/bar        100
-               :foo/baz        false },
-            {  :foo/bar        200
-               :foo/baz        true }]"#).expect("transaction expected to succeed");
-        let schema = conn.current_schema();
-        let kw = NamespacedKeyword::new("foo", "bat");
-
-        let mut attribute_cache = AttributeCacher::new();
-        let res = attribute_cache.register_attribute(&sqlite, &schema,kw.clone());
-        match res.unwrap_err() {
-            Error(ErrorKind::UnknownAttribute(msg), _) => assert_eq!(msg, kw.to_string()),
-            x => panic!("expected UnknownAttribute error, got {:?}", x),
-        }
+        let kw = kw!(:foo/bar);
+        let entid = schema.get_entid(&kw).expect("Expected entid for attribute");
+        attribute_cache.register_attribute(&sqlite, entid.clone() ).expect("No errors on add to cache");
+        assert_values_present_for_attribute(&mut attribute_cache, &entid, vec![vec![TypedValue::Long(100)], vec![TypedValue::Long(200)]]);
     }
 
     #[test]
@@ -228,13 +122,14 @@ mod tests {
                :foo/baz        true }]"#).expect("transaction expected to succeed");
         let schema = conn.current_schema();
 
-        let kw = NamespacedKeyword::new("foo", "bar");
+        let kw = kw!(:foo/bar);
+        let entid = schema.get_entid(&kw).expect("Expected entid for attribute");
         let mut attribute_cache = AttributeCacher::new();
 
-        attribute_cache.register_attribute(&mut sqlite, &schema,kw.clone()).expect("No errors on add to cache");
-        assert_values_present_for_attribute(&mut attribute_cache, &kw, vec![vec![TypedValue::Long(100)], vec![TypedValue::Long(200)]]);
-        attribute_cache.register_attribute(&mut sqlite, &schema,kw.clone()).expect("No errors on add to cache");
-        assert_values_present_for_attribute(&mut attribute_cache, &kw, vec![vec![TypedValue::Long(100)], vec![TypedValue::Long(200)]]);
+        attribute_cache.register_attribute(&mut sqlite, entid.clone()).expect("No errors on add to cache");
+        assert_values_present_for_attribute(&mut attribute_cache, &entid, vec![vec![TypedValue::Long(100)], vec![TypedValue::Long(200)]]);
+        attribute_cache.register_attribute(&mut sqlite, entid.clone()).expect("No errors on add to cache");
+        assert_values_present_for_attribute(&mut attribute_cache, &entid, vec![vec![TypedValue::Long(100)], vec![TypedValue::Long(200)]]);
     }
 
     #[test]
@@ -253,19 +148,21 @@ mod tests {
                :foo/baz        true }]"#).expect("transaction expected to succeed");
         let schema = conn.current_schema();
 
-        let kwr = NamespacedKeyword::new("foo", "bar");
-        let kwz = NamespacedKeyword::new("foo", "baz");
+        let kwr = kw!(:foo/bar);
+        let entidr = schema.get_entid(&kwr).expect("Expected entid for attribute");
+        let kwz = kw!(:foo/baz);
+        let entidz = schema.get_entid(&kwz).expect("Expected entid for attribute");
 
         let mut attribute_cache = AttributeCacher::new();
 
-        attribute_cache.register_attribute(&mut sqlite, &schema,kwr.clone()).expect("No errors on add to cache");
-        assert_values_present_for_attribute(&mut attribute_cache, &kwr, vec![vec![TypedValue::Long(100)], vec![TypedValue::Long(200)]]);
-        attribute_cache.register_attribute(&mut sqlite, &schema,kwz.clone()).expect("No errors on add to cache");
-        assert_values_present_for_attribute(&mut attribute_cache, &kwz, vec![vec![TypedValue::Boolean(false)], vec![TypedValue::Boolean(true)]]);
+        attribute_cache.register_attribute(&mut sqlite, entidr.clone()).expect("No errors on add to cache");
+        assert_values_present_for_attribute(&mut attribute_cache, &entidr, vec![vec![TypedValue::Long(100)], vec![TypedValue::Long(200)]]);
+        attribute_cache.register_attribute(&mut sqlite, entidz.clone()).expect("No errors on add to cache");
+        assert_values_present_for_attribute(&mut attribute_cache, &entidz, vec![vec![TypedValue::Boolean(false)], vec![TypedValue::Boolean(true)]]);
 
         // test that we can remove an item from cache
-        attribute_cache.deregister_attribute(&kwz).expect("No errors on remove from cache");
-        assert_eq!(attribute_cache.get(&kwz), None);
+        attribute_cache.deregister_attribute(&entidz).expect("No errors on remove from cache");
+        assert_eq!(attribute_cache.get(&entidz), None);
     }
 
     #[test]
@@ -284,8 +181,10 @@ mod tests {
                :foo/baz        true }]"#).expect("transaction expected to succeed");
         let mut attribute_cache = AttributeCacher::new();
 
-        let kw = NamespacedKeyword::new("foo", "baz");
-        assert_eq!(None, attribute_cache.deregister_attribute(&kw));
+        let schema = conn.current_schema();
+        let kw = kw!(:foo/baz);
+        let entid = schema.get_entid(&kw).expect("Expected entid for attribute");
+        assert_eq!(None, attribute_cache.deregister_attribute(&entid));
     }
 }
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -104,7 +104,7 @@ mod tests {
 
     #[test]
     fn test_add_to_cache() {
-        let (conn, mut sqlite) = populate_db();
+        let (conn, sqlite) = populate_db();
         let schema = conn.current_schema();
         let mut attribute_cache = AttributeCacher::new();
         let kw = kw!(:foo/bar);
@@ -152,7 +152,7 @@ mod tests {
 
     #[test]
     fn test_remove_attribute_not_in_cache() {
-        let (conn, mut sqlite) = populate_db();
+        let (conn, _sqlite) = populate_db();
         let mut attribute_cache = AttributeCacher::new();
 
         let schema = conn.current_schema();
@@ -160,8 +160,6 @@ mod tests {
         let entid = schema.get_entid(&kw).expect("Expected entid for attribute");
         assert_eq!(None, attribute_cache.deregister_attribute(&entid));
     }
-
-
 
     #[test]
     fn test_fetch_attribute_value_for_entid() {

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -8,7 +8,7 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use rusqlite;
 
@@ -39,103 +39,101 @@ pub enum CacheAction {
     Remove,
 }
 
-pub struct AttributeCache {
-    eager_cache: HashMap<KnownEntid, HashMap<TypedValue, TypedValue>>,   // values keyed by attribute
-    lazy_cache: HashMap<KnownEntid, HashMap<TypedValue, TypedValue>>,   // values keyed by attribute
-    connection_cache: HashMap<KnownEntid, i64>,         // connections that have requested caching keyed by attribute
+pub trait Cacheable<K, V> {
+    fn new() -> Self;
+    fn is_cached(&self, key: &K) -> bool;
+    fn add_to_cache<'sqlite, 'schema>(&mut self, sqlite: &'sqlite rusqlite::Connection, schema: &'schema Schema, key: K, cache_type: CacheType) -> Result<()>;
+    fn remove_from_cache(&mut self, key: &K) -> Result<()>;
+    fn get<'sqlite, 'schema>(&mut self, sqlite: &'sqlite rusqlite::Connection, schema: &'schema Schema, key: K) -> Result<V>;
 }
 
-impl AttributeCache {
+pub struct AttributeCache {
+    eager_cache: BTreeMap<NamespacedKeyword, BTreeMap<TypedValue, TypedValue>>,   // values keyed by attribute
+    lazy_cache: BTreeMap<NamespacedKeyword, BTreeMap<TypedValue, TypedValue>>,   // values keyed by attribute
+}
 
-    pub fn new() -> AttributeCache {
+impl Cacheable<NamespacedKeyword,BTreeMap<TypedValue, TypedValue>> for AttributeCache {
+    fn new() -> Self {
         AttributeCache {
-            eager_cache: HashMap::new(),
-            lazy_cache: HashMap::new(),
-            connection_cache: HashMap::new(),
+            eager_cache: BTreeMap::new(),
+            lazy_cache: BTreeMap::new(),
         }
     }
-
-    pub fn is_cached(&self, attribute: &KnownEntid) -> bool {
-        self.lazy_cache.contains_key(attribute) || self.eager_cache.contains_key(attribute)
+    fn is_cached(&self, key: &NamespacedKeyword) -> bool {
+        self.lazy_cache.contains_key(key) || self.eager_cache.contains_key(key)
     }
 
-    pub fn add_to_cache<'sqlite, 'schema>(&mut self, sqlite: &'sqlite rusqlite::Connection, schema: &'schema Schema, attribute: NamespacedKeyword, cache_type: CacheType) -> Result<()> {
-        let entid = schema.get_entid(&attribute).ok_or_else(|| ErrorKind::UnknownAttribute(attribute.to_string()))?;
+    fn add_to_cache<'sqlite, 'schema>(&mut self, sqlite: &'sqlite rusqlite::Connection, schema: &'schema Schema, key: NamespacedKeyword, cache_type: CacheType) -> Result<()> {
         // check to see if already in cache, return error if so.
-        if self.is_cached(&entid) {
+        if self.is_cached(&key) {
             return Ok(());
         }
         match cache_type {
-            CacheType::Lazy => self.lazy_cache.insert(entid.clone(), HashMap::new()),
+            CacheType::Lazy => self.lazy_cache.insert(key.clone(), BTreeMap::new()),
             CacheType::Eager => {
                 // fetch results and add to cache
-                let eager_values = self.values_for_attribute(sqlite, schema, &entid)?;
-                self.eager_cache.insert(entid.clone(), eager_values)
+                let eager_values = self.values_for_attribute(sqlite, schema, &key)?;
+                self.eager_cache.insert(key.clone(), eager_values)
             },
         };
-        *self.connection_cache.entry(entid.clone()).or_insert(0) += 1;
         Ok(())
     }
 
-    fn values_for_attribute<'sqlite, 'schema>(&self, sqlite: &'sqlite rusqlite::Connection, schema: &'schema Schema, attribute: &KnownEntid) -> Result<HashMap<TypedValue, TypedValue>> {
+    fn remove_from_cache(&mut self, key: &NamespacedKeyword) -> Result<()> {
+        if !self.is_cached(key) {
+            bail!(ErrorKind::CacheMiss(key.to_string()))
+        }
+        self.eager_cache.remove(key);
+        self.lazy_cache.remove(key);
+        Ok(())
+    }
+
+    fn get<'sqlite, 'schema>(&mut self, sqlite: &'sqlite rusqlite::Connection, schema: &'schema Schema, key: NamespacedKeyword) -> Result<BTreeMap<TypedValue, TypedValue>> {
+        if !self.is_cached(&key) {
+            bail!(ErrorKind::CacheMiss(key.to_string()))
+        }
+        if let Some(res) = self.eager_cache.get(&key) {
+            Ok(res.clone())
+        } else {
+            let res = self.values_for_attribute(sqlite, schema, &key)?;
+            self.lazy_cache.insert(key.clone(), res.clone());
+            Ok(res)
+        }
+    }
+}
+
+impl AttributeCache {
+    fn values_for_attribute<'sqlite, 'schema>(&self, sqlite: &'sqlite rusqlite::Connection, schema: &'schema Schema, attribute: &NamespacedKeyword) -> Result<BTreeMap<TypedValue, TypedValue>> {
+        let entid = schema.get_entid(&attribute).ok_or_else(|| ErrorKind::UnknownAttribute(attribute.to_string()))?;
         Ok(q_once(sqlite,
                schema,
                r#"[:find ?entity ?value
                                           :in ?attribute
                                           :where [?entity ?attribute ?value]]"#,
-               QueryInputs::with_value_sequence(vec![(Variable::from_valid_name("?attribute"), TypedValue::Long(attribute.0))]))
+               QueryInputs::with_value_sequence(vec![(Variable::from_valid_name("?attribute"), TypedValue::Long(entid.0))]))
             .into_rel_result()?
             .iter()
-            .fold(HashMap::new(), |mut map, row| {
+            .fold(BTreeMap::new(), |mut map, row| {
                 map.entry(row[0].clone()).or_insert(row[1].clone());
                 map
             }))
     }
 
-    pub fn remove_from_cache<'schema>(&mut self, schema: &'schema Schema, attribute: NamespacedKeyword) -> Result<()> {
-        let entid = schema.get_entid(&attribute).ok_or_else(|| ErrorKind::UnknownAttribute(attribute.to_string()))?;
-        if !self.is_cached(&entid) {
-            bail!(ErrorKind::CacheMiss(attribute.to_string()))
-        }
-        if let Some(x) = self.connection_cache.get_mut(&entid) {
-            *x -= 1;
-            if *x == 0 {
-                self.eager_cache.remove(&entid);
-                self.lazy_cache.remove(&entid);
-            }
-        }
-        Ok(())
-    }
-
-    pub fn fetch_attribute<'sqlite, 'schema>(&mut self, sqlite: &'sqlite rusqlite::Connection, schema: &'schema Schema, attribute: NamespacedKeyword) -> Result<HashMap<TypedValue, TypedValue>> {
-        let entid = schema.get_entid(&attribute).ok_or_else(|| ErrorKind::UnknownAttribute(attribute.to_string()))?;
-        if !self.is_cached(&entid) {
-            bail!(ErrorKind::CacheMiss(attribute.to_string()))
-        }
-        if let Some(res) = self.eager_cache.get(&entid) {
-            Ok(res.clone())
-        } else {
-            let res = self.values_for_attribute(sqlite, schema, &entid)?;
-            self.lazy_cache.insert(entid.clone(), res.clone());
-            Ok(res)
-        }
-    }
-
-    pub fn fetch_attribute_for_entid<'sqlite, 'schema>(&mut self, sqlite: &'sqlite rusqlite::Connection, schema: &'schema Schema, attribute: NamespacedKeyword, entid: KnownEntid) -> Result<TypedValue> {
-        let attr_entid = schema.get_entid(&attribute).ok_or_else(|| ErrorKind::UnknownAttribute(attribute.to_string()))?;
-        if !self.is_cached(&attr_entid) {
-            bail!(ErrorKind::CacheMiss(attribute.to_string()))
+    pub fn get_for_entid<'sqlite, 'schema>(&mut self, sqlite: &'sqlite rusqlite::Connection, schema: &'schema Schema, key: NamespacedKeyword, entid: KnownEntid) -> Result<TypedValue> {
+        if !self.is_cached(&key) {
+            bail!(ErrorKind::CacheMiss(key.to_string()))
         }
         let entity: TypedValue = entid.into();
-        if let Some(res) = self.eager_cache.get(&attr_entid) {
+        if let Some(res) = self.eager_cache.get(&key) {
             let r = res.get(&entity).ok_or_else(|| ErrorKind::CacheMiss(String::new()))?;
             Ok(r.clone())
         } else {
-            let mut map = self.lazy_cache.entry(attr_entid).or_insert(HashMap::new());
+            let mut map = self.lazy_cache.entry(key.clone()).or_insert(BTreeMap::new());
+            let attr_entid = schema.get_entid(&key).ok_or_else(|| ErrorKind::UnknownAttribute(key.to_string()))?;
             let res = map.entry(entity)
                         .or_insert(lookup_value(sqlite, schema, entid, attr_entid)
-                            .map_err(|_e|ErrorKind::CacheMiss(attribute.to_string()))?
-                            .ok_or_else(||ErrorKind::CacheMiss(attribute.to_string()))?);
+                            .map_err(|_e|ErrorKind::CacheMiss(key.to_string()))?
+                            .ok_or_else(||ErrorKind::CacheMiss(key.to_string()))?);
             Ok(res.clone())
         }
     }
@@ -165,8 +163,7 @@ mod tests {
         let schema = conn.current_schema();
         let kw = NamespacedKeyword::new("foo", "bar");
         conn.attribute_cache().add_to_cache(&sqlite, &schema, kw.clone(), CacheType::Eager ).expect("No errors on add to cache");
-        let entid = schema.get_entid(&kw).expect("expected entid for keyword");
-        assert!(conn.attribute_cache().is_cached(&entid));
+        assert!(conn.attribute_cache().is_cached(&kw));
     }
 
     #[test]
@@ -212,9 +209,9 @@ mod tests {
         let kw = NamespacedKeyword::new("foo", "bar");
 
         conn.attribute_cache().add_to_cache(&mut sqlite, &schema,kw.clone(), CacheType::Eager).expect("No errors on add to cache");
-        let entid = schema.get_entid(&kw).expect("expected entid for keyword");
-        assert!(conn.attribute_cache().is_cached(&entid));
+        assert!(conn.attribute_cache().is_cached(&kw));
         conn.attribute_cache().add_to_cache(&mut sqlite, &schema,kw.clone(), CacheType::Lazy).expect("No errors on add to cache");
+        assert!(conn.attribute_cache().is_cached(&kw));
     }
 
     #[test]
@@ -237,15 +234,13 @@ mod tests {
         let kwz = NamespacedKeyword::new("foo", "baz");
 
         conn.attribute_cache().add_to_cache(&mut sqlite, &schema,kwr.clone(), CacheType::Eager).expect("No errors on add to cache");
-        let entid = schema.get_entid(&kwr).expect("expected entid for keyword");
-        assert!(conn.attribute_cache().is_cached(&entid));
+        assert!(conn.attribute_cache().is_cached(&kwr));
         conn.attribute_cache().add_to_cache(&mut sqlite, &schema,kwz.clone(), CacheType::Lazy).expect("No errors on add to cache");
-        let entid = schema.get_entid(&kwz).expect("expected entid for keyword");
-        assert!(conn.attribute_cache().is_cached(&entid));
+        assert!(conn.attribute_cache().is_cached(&kwz));
 
         // test that we can remove an item from cache
-        conn.attribute_cache().remove_from_cache(&schema,kwz).expect("No errors on remove from cache");
-        assert!(!conn.attribute_cache().is_cached(&entid));
+        conn.attribute_cache().remove_from_cache(&kwz).expect("No errors on remove from cache");
+        assert!(!conn.attribute_cache().is_cached(&kwz));
     }
 
     #[test]
@@ -265,7 +260,7 @@ mod tests {
         let schema = conn.current_schema();
 
         let kw = NamespacedKeyword::new("foo", "baz");
-        let res = conn.attribute_cache().remove_from_cache(&schema, kw.clone());
+        let res = conn.attribute_cache().remove_from_cache(&kw);
         match res.unwrap_err() {
             Error(ErrorKind::CacheMiss(msg), _) => assert_eq!(msg, kw.to_string()),
             x => panic!("expected CacheMiss error, got {:?}", x),

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,0 +1,128 @@
+// Copyright 2016 Mozilla
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+use std::collections::HashMap;
+
+use rusqlite;
+
+use errors::*;
+use mentat_core::{
+    KnownEntid,
+    Schema,
+    TypedValue,
+};
+
+use query::{
+    lookup_value,
+    q_once,
+    IntoResult,
+    QueryInputs,
+    Variable,
+};
+
+
+pub struct AttributeCache {
+    eager_cache: HashMap<KnownEntid, HashMap<TypedValue, TypedValue>>,   // values keyed by attribute
+    lazy_cache: HashMap<KnownEntid, HashMap<TypedValue, TypedValue>>,   // values keyed by attribute
+    connection_cache: HashMap<KnownEntid, i64>,         // connections that have requested caching keyed by attribute
+}
+
+impl AttributeCache {
+
+    pub fn new() -> AttributeCache {
+        AttributeCache {
+            eager_cache: HashMap::new(),
+            lazy_cache: HashMap::new(),
+            connection_cache: HashMap::new(),
+        }
+    }
+
+    pub fn is_cached(&self, attribute: &KnownEntid) -> bool {
+        self.lazy_cache.contains_key(attribute) || self.eager_cache.contains_key(attribute)
+    }
+
+    pub fn add_to_cache<'sqlite, 'schema>(&mut self, sqlite: &'sqlite rusqlite::Connection, schema: &'schema Schema, attribute: KnownEntid, lazy: bool) -> Result<()> {
+        // check to see if already in cache, return error if so.
+        if self.is_cached(&attribute) {
+            return Ok(());
+        }
+        if lazy {
+            self.lazy_cache.insert(attribute.clone(), HashMap::new());
+        } else {
+            // fetch results and add to cache
+            let eager_values = self.values_for_attribute(sqlite, schema, &attribute)?;
+            self.eager_cache.insert(attribute.clone(), eager_values);
+        }
+        *self.connection_cache.entry(attribute.clone()).or_insert(0) += 1;
+        Ok(())
+    }
+
+    fn values_for_attribute<'sqlite, 'schema>(&self, sqlite: &'sqlite rusqlite::Connection, schema: &'schema Schema, attribute: &KnownEntid) -> Result<HashMap<TypedValue, TypedValue>> {
+        Ok(q_once(sqlite,
+               schema,
+               r#"[:find ?entity ?value
+                                          :in ?attribute
+                                          :where [?entity ?attribute ?value]]"#,
+               QueryInputs::with_value_sequence(vec![(Variable::from_valid_name("?attribute"), TypedValue::Long(attribute.0))]))
+            .into_rel_result()?
+            .iter()
+            .fold(HashMap::new(), |mut map, row| {
+                map.entry(row[0].clone()).or_insert(row[1].clone());
+                map
+            }))
+    }
+
+    pub fn remove_from_cache(&mut self, attribute: KnownEntid) -> Result<()> {
+        if !self.is_cached(&attribute) {
+            bail!(ErrorKind::CacheMiss(String::new()))
+        }
+        if let Some(x) = self.connection_cache.get_mut(&attribute) {
+            *x -= 1;
+            if *x == 0 {
+                self.eager_cache.remove(&attribute);
+                self.lazy_cache.remove(&attribute);
+            }
+        }
+        Ok(())
+    }
+
+    pub fn fetch_attribute<'sqlite, 'schema>(&mut self, sqlite: &'sqlite rusqlite::Connection, schema: &'schema Schema, attribute: KnownEntid) -> Result<HashMap<TypedValue, TypedValue>> {
+        if !self.is_cached(&attribute) {
+            bail!(ErrorKind::CacheMiss(String::new()))
+        }
+        if let Some(res) = self.eager_cache.get(&attribute) {
+            Ok(res.clone())
+        } else {
+            let res = self.values_for_attribute(sqlite, schema, &attribute)?;
+            self.lazy_cache.insert(attribute.clone(), res.clone());
+            Ok(res)
+        }
+    }
+
+    pub fn fetch_attribute_for_entid<'sqlite, 'schema>(&mut self, sqlite: &'sqlite rusqlite::Connection, schema: &'schema Schema, attribute: KnownEntid, entid: KnownEntid) -> Result<TypedValue> {
+        if !self.is_cached(&attribute) {
+            bail!(ErrorKind::CacheMiss(String::new()))
+        }
+        let entity: TypedValue = entid.into();
+        if let Some(res) = self.eager_cache.get(&attribute) {
+            let r = res.get(&entity).ok_or_else(|| ErrorKind::CacheMiss(String::new()))?;
+            Ok(r.clone())
+        } else {
+            let mut map = self.lazy_cache.entry(attribute).or_insert(HashMap::new());
+            let res = map.entry(entity)
+                        .or_insert(lookup_value(sqlite, schema, entid, attribute)
+                            .map_err(|_e|ErrorKind::CacheMiss(String::new()))?
+                            .ok_or_else(||ErrorKind::CacheMiss(String::new()))?);
+            Ok(res.clone())
+        }
+    }
+}
+
+

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -34,6 +34,7 @@ use mentat_core::intern_set::InternSet;
 
 use mentat_db::db;
 use mentat_db::{
+    to_namespaced_keyword,
     transact,
     transact_terms,
     PartitionMap,
@@ -48,7 +49,12 @@ use mentat_tx::entities::TempId;
 
 use mentat_tx_parser;
 
+use entity_builder::{
+    InProgressBuilder,
+};
+
 use errors::*;
+
 use query::{
     lookup_value_for_attribute,
     lookup_values_for_attribute,
@@ -57,10 +63,6 @@ use query::{
     QueryExplanation,
     QueryInputs,
     QueryOutput,
-};
-
-use entity_builder::{
-    InProgressBuilder,
 };
 
 /// Connection metadata required to query from, or apply transactions to, a Mentat store.

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -50,12 +50,10 @@ use mentat_tx::entities::TempId;
 use mentat_tx_parser;
 
 use cache::{
-    Cacheable,
     AttributeCache,
 };
 
 pub use cache::{
-    CacheType,
     CacheAction,
 };
 
@@ -540,19 +538,17 @@ impl Conn {
     pub fn cache(&mut self,
                  sqlite: &mut rusqlite::Connection,
                  attribute: &str,
-                 cache_action: CacheAction,
-                 cache_type: CacheType) -> Result<()> {
+                 cache_action: CacheAction) -> Result<()> {
         // fetch the attribute for the given name
         let schema = self.current_schema();
 
         let attr = to_namespaced_keyword(&attribute)?;
         let mut cache = self.attribute_cache.lock().unwrap();
         match cache_action {
-            // add to cache
-            CacheAction::Add => cache.add_to_cache(sqlite, &schema, attr, cache_type),
-            // remove from cache
-            CacheAction::Remove => cache.remove_from_cache(&attr),
+            CacheAction::Add => { cache.add_to_cache(sqlite, &schema, attr)?; },
+            CacheAction::Remove => { cache.remove_from_cache(&attr)?; },
         }
+        Ok(())
     }
 }
 

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -794,7 +794,7 @@ mod tests {
 
         {
             let mut in_progress = conn.begin_transaction(&mut sqlite).expect("transaction");
-            for _ in 1..10000 {
+            for _ in 1..100 {
                 let _report = in_progress.transact(r#"[
             {  :foo/bar        100
                :foo/baz        false },
@@ -828,7 +828,7 @@ mod tests {
 
         conn.cache(&mut sqlite, &kw, CacheAction::Register).expect("expected caching to work");
 
-        for _ in 1..10 {
+        for _ in 1..5 {
             let start = Instant::now();
             let cached_val = conn.lookup_value_for_attribute(&sqlite, entid, &kw).expect("Expected value on lookup");
             let finish = Instant::now();

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -758,7 +758,7 @@ mod tests {
     fn test_add_to_cache_failure_no_attribute() {
         let mut sqlite = db::new_connection("").unwrap();
         let mut conn = Conn::connect(&mut sqlite).unwrap();
-        let report = conn.transact(&mut sqlite, r#"[
+        let _report = conn.transact(&mut sqlite, r#"[
             {  :db/ident       :foo/bar
                :db/valueType   :db.type/long },
             {  :db/ident       :foo/baz

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -764,7 +764,7 @@ mod tests {
             {  :db/ident       :foo/baz
                :db/valueType   :db.type/boolean }]"#).unwrap();
 
-        let res = conn.cache(&mut sqlite,"", CacheAction::Add, CacheType::Lazy);
+        let res = conn.cache(&mut sqlite,"", CacheAction::Add);
         match res.unwrap_err() {
             Error(ErrorKind::DbError(::mentat_db::errors::ErrorKind::NotYetImplemented(msg)), _) => assert_eq!(msg, "InvalidNamespacedKeyword: "),
             x => panic!("expected UnknownAttribute error, got {:?}", x),

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -544,9 +544,10 @@ impl Conn {
 
         let attr = to_namespaced_keyword(&attribute)?;
         let mut cache = self.attribute_cache.lock().unwrap();
+        let attribute_entid = schema.get_entid(&attr).ok_or_else(|| ErrorKind::UnknownAttribute(attribute.to_string()))?;
         match cache_action {
-            CacheAction::Register => { cache.register_attribute(sqlite, &schema, attr)?; },
-            CacheAction::Deregister => { cache.deregister_attribute(&attr); },
+            CacheAction::Register => { cache.register_attribute(sqlite, attribute_entid)?; },
+            CacheAction::Deregister => { cache.deregister_attribute(&attribute_entid); },
         }
         Ok(())
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -87,10 +87,5 @@ error_chain! {
             description("missing core vocabulary")
             display("missing core attribute {}", kw)
         }
-
-        CacheMiss(name: String) {
-            description("Attribute is not to be found in the cache")
-            display("Attribute not present in cache: '{}'", name)
-        }
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -87,5 +87,10 @@ error_chain! {
             description("missing core vocabulary")
             display("missing core attribute {}", kw)
         }
+
+        CacheMiss(name: String) {
+            description("Attribute is not to be found in the cache")
+            display("Attribute not present in cache: '{}'", name)
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,7 @@ macro_rules! kw {
     };
 }
 
+mod cache;
 pub mod errors;
 pub mod ident;
 pub mod vocabulary;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@ macro_rules! kw {
     };
 }
 
-mod cache;
+pub mod cache;
 pub mod errors;
 pub mod ident;
 pub mod vocabulary;

--- a/src/query.rs
+++ b/src/query.rs
@@ -183,12 +183,10 @@ pub fn lookup_value<'sqlite, 'schema, 'cache, E, A>
  where E: Into<Entid>, A: Into<Entid> {
     let entid = entity.into();
     let attrid = attribute.into();
-    let cached = cache.get_value_for_entid(&attrid, &entid).map(|x| x.clone());
+    let cached = cache.get_value_for_entid(&attrid, &entid).cloned();
     if cached.is_some() {
-        println!("returning from cache");
         return Ok(cached);
     }
-    println!("fetching from db");
     fetch_values(sqlite, schema, entid, attrid, true).into_scalar_result()
 }
 
@@ -201,11 +199,9 @@ pub fn lookup_values<'sqlite, 'schema, 'cache, E, A>
  where E: Into<Entid>, A: Into<Entid> {
     let entid = entity.into();
     let attrid = attribute.into();
-    if let Some(cached) = cache.get_values_for_entid(&attrid, &entid).map(|x| x.clone()) {
-        println!("returning from cache");
+    if let Some(cached) = cache.get_values_for_entid(&attrid, &entid).cloned() {
         return Ok(cached);
     }
-    println!("fetching from db");
     fetch_values(sqlite, schema, entid, attrid, false).into_coll_result()
 }
 


### PR DESCRIPTION
https://github.com/mozilla-prototypes/sync-storage-prototype/issues/14

Ok, things I know need to be done:

- Move `EagerCache` and `Cacheable` into a crate further down the stack. Right now they could not be used in querying as they can't be seen below the top level crate.
- Tests for `get` and `get_for_entid`.

Things I think should probably be done:
- Make `cacheable` a trait defining only `add_to_cache` and `new` functions. `AttributeCache` can then effectively go away and we only need to create an instance of `EagerCache` of the right type, provide a `ValueProvider` and store it somewhere.

Things I tried to do but couldn't make work
- Providing `ValueProvider` as a trait object. I know this can be done, but there were problems with `Size` and lifetimes (storing a reference to a trait object) so I went with the solution I did and figured we can come back to it later if we want to.