### PR TITLE
Expose Uuid from the top level crate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@ pub fn get_connection() -> Connection {
 
 pub use mentat_core::{
     TypedValue,
+    Uuid,
     ValueType,
 };
 


### PR DESCRIPTION
So we don't have to import a subcrate when using mentat elsewhere