### PR TITLE
Implement `q_prepare` with pre-bound variables

### DIFF
--- a/query-algebrizer/src/clauses/inputs.rs
+++ b/query-algebrizer/src/clauses/inputs.rs
@@ -51,6 +51,13 @@ impl QueryInputs {
         QueryInputs::with_values(values)
     }
 
+    pub fn with_type_sequence(types: Vec<(Variable, ValueType)>) -> QueryInputs {
+        QueryInputs {
+            types: types.into_iter().collect(),
+            values: BTreeMap::default(),
+        }
+    }
+
     pub fn with_values(values: BTreeMap<Variable, TypedValue>) -> QueryInputs {
         QueryInputs {
             types: values.iter().map(|(var, val)| (var.clone(), val.value_type())).collect(),

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -87,5 +87,10 @@ error_chain! {
             description("missing core vocabulary")
             display("missing core attribute {}", kw)
         }
+
+        PreparedQuerySchemaMismatch {
+            description("schema changed since query was prepared")
+            display("schema changed since query was prepared")
+        }
     }
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -51,6 +51,10 @@ use mentat_query_parser::{
     parse_find_string,
 };
 
+use mentat_query_projector::{
+    Projector,
+};
+
 use mentat_sql::{
     SQLQuery,
 };
@@ -74,6 +78,34 @@ use cache::{
 };
 
 pub type QueryExecutionResult = Result<QueryOutput>;
+pub type PreparedResult<'sqlite> = Result<PreparedQuery<'sqlite>>;
+
+pub enum PreparedQuery<'sqlite> {
+    Empty {
+        find_spec: Rc<FindSpec>,
+    },
+    Bound {
+        statement: rusqlite::Statement<'sqlite>,
+        args: Vec<(String, Rc<rusqlite::types::Value>)>,
+        projector: Box<Projector>,
+    },
+}
+
+impl<'sqlite> PreparedQuery<'sqlite> {
+    pub fn run<T>(&mut self, _inputs: T) -> QueryExecutionResult where T: Into<Option<QueryInputs>> {
+        match self {
+            &mut PreparedQuery::Empty { ref find_spec } => {
+                Ok(QueryOutput::empty(find_spec))
+            },
+            &mut PreparedQuery::Bound { ref mut statement, ref args, ref projector } => {
+                let rows = run_statement(statement, args)?;
+                projector
+                      .project(rows)
+                      .map_err(|e| e.into())
+            }
+        }
+    }
+}
 
 pub trait IntoResult {
     fn into_scalar_result(self) -> Result<Option<TypedValue>>;
@@ -307,6 +339,40 @@ pub fn q_once<'sqlite, 'schema, 'query, T>
     let algebrized = algebrize_query_str(schema, query, inputs)?;
 
     run_algebrized_query(sqlite, algebrized)
+}
+
+pub fn q_prepare<'sqlite, 'schema, 'query, T>
+(sqlite: &'sqlite rusqlite::Connection,
+ schema: &'schema Schema,
+ query: &'query str,
+ inputs: T) -> PreparedResult<'sqlite>
+        where T: Into<Option<QueryInputs>>
+{
+    let algebrized = algebrize_query_str(schema, query, inputs)?;
+
+    let unbound = algebrized.unbound_variables();
+    if !unbound.is_empty() {
+        // TODO: Allow binding variables at execution time, not just
+        // preparation time.
+        bail!(ErrorKind::UnboundVariables(unbound.into_iter().map(|v| v.to_string()).collect()));
+    }
+
+    if algebrized.is_known_empty() {
+        // We don't need to do any SQL work at all.
+        return Ok(PreparedQuery::Empty {
+            find_spec: algebrized.find_spec,
+        });
+    }
+
+    let select = query_to_select(algebrized)?;
+    let SQLQuery { sql, args } = select.query.to_sql_query()?;
+    let statement = sqlite.prepare(sql.as_str())?;
+
+    Ok(PreparedQuery::Bound {
+        statement,
+        args,
+        projector: select.projector
+    })
 }
 
 pub fn q_explain<'sqlite, 'schema, 'query, T>


### PR DESCRIPTION
Here's a first cut for feedback, without any algebrizer changes, so we can only bind variables at preparation time, not at execution time.

It's not clear to me if I need the logic to check if the schema is current: it looks like `begin_read` borrows the connection, and, since a `PreparedQuery` can't outlive its `InProgress` (I don't think...), we shouldn't be able to transact changes to the schema. In that case, I can revert the changes to pass around a `Conn` instead of the metadata.