### PR TITLE
Transaction Log Observation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default = ["bundled_sqlite3"]
 bundled_sqlite3 = ["rusqlite/bundled"]
 
 [workspace]
-members = ["tools/cli"]
+members = ["tools/cli", "ffi"]
 
 [build-dependencies]
 rustc_version = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ rustc_version = "0.2"
 chrono = "0.4"
 error-chain = { git = "https://github.com/rnewman/error-chain", branch = "rnewman/sync" }
 lazy_static = "0.2"
+smallvec = "0.6"
 time = "0.1"
 uuid = "0.5"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ rustc_version = "0.2"
 chrono = "0.4"
 error-chain = { git = "https://github.com/rnewman/error-chain", branch = "rnewman/sync" }
 lazy_static = "0.2"
-smallvec = "0.6"
 time = "0.1"
 uuid = "0.5"
 

--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -10,7 +10,6 @@ itertools = "0.7"
 lazy_static = "0.2"
 num = "0.1"
 ordered-float = "0.5"
-smallvec = "0.6"
 time = "0.1"
 
 [dependencies.rusqlite]

--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -10,6 +10,7 @@ itertools = "0.7"
 lazy_static = "0.2"
 num = "0.1"
 ordered-float = "0.5"
+smallvec = "0.6"
 time = "0.1"
 
 [dependencies.rusqlite]

--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -5,6 +5,7 @@ workspace = ".."
 
 [dependencies]
 error-chain = { git = "https://github.com/rnewman/error-chain", branch = "rnewman/sync" }
+indexmap = "0.4"
 itertools = "0.7"
 lazy_static = "0.2"
 num = "0.1"

--- a/db/src/cache.rs
+++ b/db/src/cache.rs
@@ -1402,7 +1402,7 @@ impl<'a> TransactWatcher for InProgressCacheTransactWatcher<'a> {
         }
     }
 
-    fn done(&mut self, schema: &Schema) -> Result<()> {
+    fn done(&mut self, _t: &Entid, schema: &Schema) -> Result<()> {
         // Oh, I wish we had impl trait. Without it we have a six-line type signature if we
         // try to break this out as a helper function.
         let collected_retractions = mem::replace(&mut self.collected_retractions, Default::default());

--- a/db/src/cache.rs
+++ b/db/src/cache.rs
@@ -1369,6 +1369,9 @@ impl<'a> InProgressCacheTransactWatcher<'a> {
 }
 
 impl<'a> TransactWatcher for InProgressCacheTransactWatcher<'a> {
+    fn start(&mut self, _t: &Entid) {
+    }
+
     fn datom(&mut self, op: OpType, e: Entid, a: Entid, v: &TypedValue) {
         if !self.active {
             return;
@@ -1402,7 +1405,7 @@ impl<'a> TransactWatcher for InProgressCacheTransactWatcher<'a> {
         }
     }
 
-    fn done(&mut self, _t: &Entid, schema: &Schema) -> Result<()> {
+    fn done(&mut self, schema: &Schema) -> Result<()> {
         // Oh, I wish we had impl trait. Without it we have a six-line type signature if we
         // try to break this out as a helper function.
         let collected_retractions = mem::replace(&mut self.collected_retractions, Default::default());

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -13,6 +13,7 @@
 
 #[macro_use]
 extern crate error_chain;
+extern crate indexmap;
 extern crate itertools;
 
 #[macro_use]
@@ -45,6 +46,7 @@ pub mod errors;
 pub mod internal_types;    // pub because we need them for building entities programmatically.
 mod metadata;
 mod schema;
+pub mod tx_observer;
 mod watcher;
 mod tx;
 pub mod types;

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -21,6 +21,7 @@ extern crate lazy_static;
 
 extern crate num;
 extern crate rusqlite;
+extern crate smallvec;
 extern crate tabwriter;
 extern crate time;
 

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -87,7 +87,13 @@ pub use tx::{
     transact_terms,
 };
 
+pub use tx_observer::{
+    TxObservationService,
+    TxObserver,
+};
+
 pub use types::{
+    AttributeSet,
     DB,
     PartitionMap,
     TxReport,

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -21,7 +21,6 @@ extern crate lazy_static;
 
 extern crate num;
 extern crate rusqlite;
-extern crate smallvec;
 extern crate tabwriter;
 extern crate time;
 
@@ -89,6 +88,7 @@ pub use tx::{
 };
 
 pub use tx_observer::{
+    InProgressObserverTransactWatcher,
     TxObservationService,
     TxObserver,
 };

--- a/db/src/tx.rs
+++ b/db/src/tx.rs
@@ -671,6 +671,7 @@ impl<'conn, 'a, W> Tx<'conn, 'a, W> where W: TransactWatcher {
                     }
 
                     self.watcher.datom(op, e, a, &v);
+                    // TODO: Create something like a watcher to do this for us.
                     affected_attrs.insert(a);
 
                     let reduced = (e, a, attribute, v, added);

--- a/db/src/tx.rs
+++ b/db/src/tx.rs
@@ -107,7 +107,6 @@ use schema::{
 };
 use types::{
     Attribute,
-    AttributeSet,
     AVPair,
     AVMap,
     Entid,
@@ -616,8 +615,6 @@ impl<'conn, 'a, W> Tx<'conn, 'a, W> where W: TransactWatcher {
 
 
         let tx_instant;
-        let mut affected_attrs = AttributeSet::new();
-
         { // TODO: Don't use this block to scope borrowing the schema; instead, extract a helper function.
 
         // Assertions that are :db.cardinality/one and not :db.fulltext.
@@ -671,8 +668,6 @@ impl<'conn, 'a, W> Tx<'conn, 'a, W> where W: TransactWatcher {
                     }
 
                     self.watcher.datom(op, e, a, &v);
-                    // TODO: Create something like a watcher to do this for us.
-                    affected_attrs.insert(a);
 
                     let reduced = (e, a, attribute, v, added);
                     match (attribute.fulltext, attribute.multival) {
@@ -714,7 +709,7 @@ impl<'conn, 'a, W> Tx<'conn, 'a, W> where W: TransactWatcher {
         }
 
         db::update_partition_map(self.store, &self.partition_map)?;
-        self.watcher.done(self.schema)?;
+        self.watcher.done(&self.tx_id, self.schema)?;
 
         if tx_might_update_metadata {
             // Extract changes to metadata from the store.
@@ -739,7 +734,6 @@ impl<'conn, 'a, W> Tx<'conn, 'a, W> where W: TransactWatcher {
             tx_id: self.tx_id,
             tx_instant,
             tempids: tempids,
-            changeset: affected_attrs,
         })
     }
 }
@@ -752,7 +746,6 @@ fn start_tx<'conn, 'a, W>(conn: &'conn rusqlite::Connection,
                        watcher: W) -> Result<Tx<'conn, 'a, W>>
     where W: TransactWatcher {
     let tx_id = partition_map.allocate_entid(":db.part/tx");
-
     conn.begin_tx_application()?;
 
     Ok(Tx::new(conn, partition_map, schema_for_mutation, schema, watcher, tx_id))

--- a/db/src/tx.rs
+++ b/db/src/tx.rs
@@ -709,7 +709,7 @@ impl<'conn, 'a, W> Tx<'conn, 'a, W> where W: TransactWatcher {
         }
 
         db::update_partition_map(self.store, &self.partition_map)?;
-        self.watcher.done(&self.tx_id, self.schema)?;
+        self.watcher.done(self.schema)?;
 
         if tx_might_update_metadata {
             // Extract changes to metadata from the store.
@@ -743,11 +743,11 @@ fn start_tx<'conn, 'a, W>(conn: &'conn rusqlite::Connection,
                        mut partition_map: PartitionMap,
                        schema_for_mutation: &'a Schema,
                        schema: &'a Schema,
-                       watcher: W) -> Result<Tx<'conn, 'a, W>>
+                       mut watcher: W) -> Result<Tx<'conn, 'a, W>>
     where W: TransactWatcher {
     let tx_id = partition_map.allocate_entid(":db.part/tx");
     conn.begin_tx_application()?;
-
+    watcher.start(&tx_id);
     Ok(Tx::new(conn, partition_map, schema_for_mutation, schema, watcher, tx_id))
 }
 

--- a/db/src/tx_observer.rs
+++ b/db/src/tx_observer.rs
@@ -1,0 +1,171 @@
+// Copyright 2018 Mozilla
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+use std::sync::{
+    Arc,
+};
+use std::thread;
+
+use indexmap::{
+    IndexMap,
+};
+
+use types::{
+    AttributeSet,
+    TxReport,
+};
+
+pub struct TxObserver {
+    notify_fn: Arc<Option<Box<Fn(String, Vec<TxReport>) + Send + Sync>>>,
+    attributes: AttributeSet,
+}
+
+impl TxObserver {
+    pub fn new<F>(attributes: AttributeSet, notify_fn: F) -> TxObserver where F: Fn(String, Vec<TxReport>) + 'static + Send + Sync {
+        TxObserver {
+            notify_fn: Arc::new(Some(Box::new(notify_fn))),
+            attributes,
+        }
+    }
+
+    pub fn applicable_reports(&self, reports: &Vec<TxReport>) -> Vec<TxReport> {
+        reports.into_iter().filter_map( |report| {
+            if self.attributes.intersection(&report.changeset).next().is_some(){
+                Some(report.clone())
+            } else {
+                None
+            }
+        }).collect()
+    }
+
+    fn notify(&self, key: String, reports: Vec<TxReport>) {
+        if let Some(ref notify_fn) = *self.notify_fn {
+            (notify_fn)(key, reports);
+        } else {
+            eprintln!("no notify function specified for TxObserver");
+        }
+    }
+}
+
+pub trait CommandClone {
+    fn clone_box(&self) -> Box<Command + Send>;
+}
+
+impl<T> CommandClone for T where T: 'static + Command + Clone + Send {
+    fn clone_box(&self) -> Box<Command + Send> {
+        Box::new(self.clone())
+    }
+}
+
+pub trait Command: CommandClone {
+    fn execute(&self);
+}
+
+impl Clone for Box<Command + Send> {
+    fn clone(&self) -> Box<Command + Send> {
+        self.clone_box()
+    }
+}
+
+#[derive(Clone)]
+pub struct NotifyTxObserver {
+    key: String,
+    reports: Vec<TxReport>,
+    observer: Arc<TxObserver>,
+}
+
+impl NotifyTxObserver {
+    pub fn new(key: String, reports: Vec<TxReport>, observer: Arc<TxObserver>) -> Self {
+        NotifyTxObserver {
+            key,
+            reports,
+            observer,
+        }
+    }
+}
+
+impl Command for NotifyTxObserver {
+    fn execute(&self) {
+        self.observer.notify(self.key.clone(), self.reports.clone());
+    }
+}
+
+#[derive(Clone)]
+pub struct AsyncBatchExecutor {
+    commands: Vec<Box<Command + Send>>,
+}
+
+impl Command for AsyncBatchExecutor {
+    fn execute(&self) {
+        let command_queue = self.commands.clone();
+        thread::spawn (move ||{
+            for command in command_queue.iter() {
+                command.execute();
+            }
+        });
+    }
+}
+
+#[derive(Clone)]
+pub struct TxObservationService {
+    observers: IndexMap<String, Arc<TxObserver>>,
+    pub command_queue: Vec<Box<Command + Send>>,
+}
+
+impl TxObservationService {
+    pub fn new() -> Self {
+        TxObservationService {
+            observers: IndexMap::new(),
+            command_queue: Vec::new(),
+        }
+    }
+    // For testing purposes
+    pub fn is_registered(&self, key: &String) -> bool {
+        self.observers.contains_key(key)
+    }
+
+    pub fn register(&mut self, key: String, observer: Arc<TxObserver>) {
+        self.observers.insert(key.clone(), observer);
+    }
+
+    pub fn deregister(&mut self, key: &String) {
+        self.observers.remove(key);
+    }
+
+    pub fn has_observers(&self) -> bool {
+        !self.observers.is_empty()
+    }
+
+    fn command_from_reports(&self, key: &String, reports: &Vec<TxReport>, observer: &Arc<TxObserver>) -> Option<Box<Command + Send>> {
+        let applicable_reports = observer.applicable_reports(reports);
+        if !applicable_reports.is_empty() {
+            Some(Box::new(NotifyTxObserver::new(key.clone(), applicable_reports, Arc::clone(observer))))
+        } else {
+            None
+        }
+    }
+
+    pub fn transaction_did_commit(&mut self, reports: Vec<TxReport>) {
+        // notify all observers about their relevant transactions
+        let commands: Vec<Box<Command + Send>> = self.observers
+                                                .iter()
+                                                .filter_map(|(key, observer)| { self.command_from_reports(&key, &reports, &observer) })
+                                                .collect();
+        self.command_queue.push(Box::new(AsyncBatchExecutor{ commands }));
+    }
+
+    pub fn run(&mut self) {
+        for command in self.command_queue.iter() {
+            command.execute();
+        }
+
+        self.command_queue.clear();
+    }
+}

--- a/db/src/types.rs
+++ b/db/src/types.rs
@@ -103,7 +103,4 @@ pub struct TxReport {
     /// existing entid, or is allocated a new entid.  (It is possible for multiple distinct string
     /// literal tempids to all unify to a single freshly allocated entid.)
     pub tempids: BTreeMap<String, Entid>,
-
-    // A set of entids for attributes that were affected inside this transaction
-    pub changeset: AttributeSet,
 }

--- a/db/src/types.rs
+++ b/db/src/types.rs
@@ -11,19 +11,22 @@
 #![allow(dead_code)]
 
 use std::collections::HashMap;
-use std::collections::BTreeMap;
+use std::collections::{
+    BTreeMap,
+    BTreeSet,
+};
 
 extern crate mentat_core;
 
 pub use self::mentat_core::{
-    DateTime,
-    Entid,
-    ValueType,
-    TypedValue,
     Attribute,
     AttributeBitFlags,
+    DateTime,
+    Entid,
     Schema,
+    TypedValue,
     Utc,
+    ValueType,
 };
 
 /// Represents one partition of the entid space.
@@ -82,6 +85,9 @@ pub type AVPair = (Entid, TypedValue);
 /// Used to resolve lookup-refs and upserts.
 pub type AVMap<'a> = HashMap<&'a AVPair, Entid>;
 
+// represents a set of entids that are correspond to attributes
+pub type AttributeSet = BTreeSet<Entid>;
+
 /// A transaction report summarizes an applied transaction.
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialOrd, PartialEq)]
 pub struct TxReport {
@@ -97,4 +103,7 @@ pub struct TxReport {
     /// existing entid, or is allocated a new entid.  (It is possible for multiple distinct string
     /// literal tempids to all unify to a single freshly allocated entid.)
     pub tempids: BTreeMap<String, Entid>,
+
+    // A set of entids for attributes that were affected inside this transaction
+    pub changeset: AttributeSet,
 }

--- a/db/src/watcher.rs
+++ b/db/src/watcher.rs
@@ -38,7 +38,7 @@ pub trait TransactWatcher {
     /// Called with the schema _prior to_ the transact -- any attributes or
     /// attribute changes transacted during this transact are not reflected in
     /// the schema.
-    fn done(&mut self, schema: &Schema) -> Result<()>;
+    fn done(&mut self, t: &Entid, schema: &Schema) -> Result<()>;
 }
 
 pub struct NullWatcher();
@@ -47,7 +47,7 @@ impl TransactWatcher for NullWatcher {
     fn datom(&mut self, _op: OpType, _e: Entid, _a: Entid, _v: &TypedValue) {
     }
 
-    fn done(&mut self, _schema: &Schema) -> Result<()> {
+    fn done(&mut self, _t: &Entid, _schema: &Schema) -> Result<()> {
         Ok(())
     }
 }

--- a/db/src/watcher.rs
+++ b/db/src/watcher.rs
@@ -32,22 +32,28 @@ use errors::{
 };
 
 pub trait TransactWatcher {
+
+    fn start(&mut self, t: &Entid);
+
     fn datom(&mut self, op: OpType, e: Entid, a: Entid, v: &TypedValue);
 
     /// Only return an error if you want to interrupt the transact!
     /// Called with the schema _prior to_ the transact -- any attributes or
     /// attribute changes transacted during this transact are not reflected in
     /// the schema.
-    fn done(&mut self, t: &Entid, schema: &Schema) -> Result<()>;
+    fn done(&mut self, schema: &Schema) -> Result<()>;
 }
 
 pub struct NullWatcher();
 
 impl TransactWatcher for NullWatcher {
+    fn start(&mut self, _t: &Entid) {
+    }
+
     fn datom(&mut self, _op: OpType, _e: Entid, _a: Entid, _v: &TypedValue) {
     }
 
-    fn done(&mut self, _t: &Entid, _schema: &Schema) -> Result<()> {
+    fn done(&mut self, _schema: &Schema) -> Result<()> {
         Ok(())
     }
 }

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "mentat_ffi"
+version = "0.1.0"
+authors = ["Emily Toop <etoop@mozilla.com>"]
+
+[dependencies.mentat]
+path = ".."

--- a/ffi/src/android.rs
+++ b/ffi/src/android.rs
@@ -1,0 +1,24 @@
+// Copyright 2018 Mozilla
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// TODO just use https://github.com/tomaka/android-rs-glue somehow?
+
+use std::os::raw::c_char;
+use std::os::raw::c_int;
+
+// Logging
+pub enum LogLevel {
+    Debug = 3,
+    Info = 4,
+    Warn = 5,
+    Error = 6,
+}
+
+extern { pub fn __android_log_write(prio: c_int, tag: *const c_char, text: *const c_char) -> c_int; }

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -1,0 +1,180 @@
+// Copyright 2018 Mozilla
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+extern crate mentat;
+
+use std::collections::{
+    BTreeSet,
+};
+use std::os::raw::{
+    c_char,
+    c_int,
+};
+use std::slice;
+use std::sync::{
+    Arc,
+};
+
+pub use mentat::{
+    Entid,
+    HasSchema,
+    NamespacedKeyword,
+    Store,
+    Syncable,
+    TxObserver,
+};
+
+pub use mentat::errors::{
+    Result,
+};
+
+pub mod android;
+pub mod utils;
+
+pub use utils::strings::{
+    c_char_to_string,
+    string_to_c_char,
+    str_to_c_char,
+};
+
+use utils::log;
+
+#[repr(C)]
+#[derive(Debug, Clone)]
+pub struct ExternTxReport {
+    pub txid: Entid,
+    pub changes: Box<[Entid]>,
+    pub changes_len: usize,
+}
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct ExternTxReportList {
+    pub reports: Box<[ExternTxReport]>,
+    pub len: usize,
+}
+
+#[repr(C)]
+pub struct ExternResult {
+    pub error: *const c_char,
+}
+
+impl From<Result<()>> for ExternResult {
+    fn from(result: Result<()>) -> Self {
+        match result {
+            Ok(_) => {
+                ExternResult {
+                    error: std::ptr::null(),
+                }
+            },
+            Err(e) => {
+                ExternResult {
+                    error: string_to_c_char(e.description().into())
+                }
+            }
+        }
+    }
+}
+
+// A store cannot be opened twice to the same location.
+// Once created, the reference to the store is held by the caller and not Rust,
+// therefore the caller is responsible for calling `store_destroy` to release the memory
+// used by the Store in order to avoid a memory leak.
+// TODO: Start returning `ExternResult`s rather than crashing on error.
+#[no_mangle]
+pub extern "C" fn store_open(uri: *const c_char) -> *mut Store {
+    let uri = c_char_to_string(uri);
+    let store = Store::open(&uri).expect("expected a store");
+    Box::into_raw(Box::new(store))
+}
+
+// Reclaim the memory for the provided Store and drop, therefore releasing it.
+#[no_mangle]
+pub unsafe extern "C" fn store_destroy(store: *mut Store) {
+    let _ = Box::from_raw(store);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn store_register_observer(store: *mut Store,
+                                                   key: *const c_char,
+                                            attributes: *const Entid,
+                                        attributes_len: usize,
+                                              callback: extern fn(key: *const c_char, reports: &ExternTxReportList)) {
+    let store = &mut*store;
+    let mut attribute_set = BTreeSet::new();
+    let slice = slice::from_raw_parts(attributes, attributes_len);
+    attribute_set.extend(slice.iter());
+    let key = c_char_to_string(key);
+    let tx_observer = Arc::new(TxObserver::new(attribute_set, move |obs_key, batch| {
+        log::d(&format!("Calling observer registered for {:?}, batch: {:?}", obs_key, batch));
+        let extern_reports: Vec<ExternTxReport> = batch.into_iter().map(|(tx_id, changes)| {
+            let changes: Vec<Entid> = changes.into_iter().map(|i|*i).collect();
+            let len = changes.len();
+            ExternTxReport {
+                txid: *tx_id,
+                changes: changes.into_boxed_slice(),
+                changes_len: len,
+            }
+        }).collect();
+        let len = extern_reports.len();
+        let reports = ExternTxReportList {
+            reports: extern_reports.into_boxed_slice(),
+            len: len,
+        };
+        callback(str_to_c_char(obs_key), &reports);
+    }));
+    store.register_observer(key, tx_observer);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn store_unregister_observer(store: *mut Store, key: *const c_char) {
+    let store = &mut*store;
+    let key = c_char_to_string(key);
+    log::d(&format!("Unregistering observer for key: {:?}", key));
+    store.unregister_observer(&key);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn store_entid_for_attribute(store: *mut Store, attr: *const c_char) -> Entid {
+    let store = &mut*store;
+    let mut keyword_string = c_char_to_string(attr);
+    let attr_name = keyword_string.split_off(1);
+    let parts: Vec<&str> = attr_name.split("/").collect();
+    let kw = NamespacedKeyword::new(parts[0], parts[1]);
+    let conn = store.conn();
+    let current_schema = conn.current_schema();
+    let got_entid = current_schema.get_entid(&kw);
+    let entid = got_entid.unwrap();
+    entid.into()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn tx_report_list_entry_at(tx_report_list: *mut ExternTxReportList, index: c_int) -> *const ExternTxReport {
+    let tx_report_list = &*tx_report_list;
+    let index = index as usize;
+    let report = Box::new(tx_report_list.reports[index].clone());
+    Box::into_raw(report)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn changelist_entry_at(tx_report: *mut ExternTxReport, index: c_int) -> Entid {
+    let tx_report = &*tx_report;
+    let index = index as usize;
+    tx_report.changes[index].clone()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn store_sync(store: *mut Store, user_uuid: *const c_char, server_uri: *const c_char) -> *mut ExternResult {
+    let store = &mut*store;
+    let user_uuid = c_char_to_string(user_uuid);
+    let server_uri = c_char_to_string(server_uri);
+    let res = store.sync(&server_uri, &user_uuid);
+    Box::into_raw(Box::new(res.into()))
+}

--- a/ffi/src/utils.rs
+++ b/ffi/src/utils.rs
@@ -1,0 +1,60 @@
+// Copyright 2018 Mozilla
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+pub mod strings {
+    use std::os::raw::c_char;
+    use std::ffi::{
+        CString,
+        CStr
+    };
+
+    pub fn c_char_to_string(cchar: *const c_char) -> String {
+        let c_str = unsafe { CStr::from_ptr(cchar) };
+        let r_str = match c_str.to_str() {
+            Err(_) => "",
+            Ok(string) => string,
+        };
+        r_str.to_string()
+    }
+
+    pub fn string_to_c_char(r_string: String) -> *mut c_char {
+        CString::new(r_string).unwrap().into_raw()
+    }
+
+    pub fn str_to_c_char(r_string: &str) -> *mut c_char {
+        string_to_c_char(r_string.to_string())
+    }
+}
+
+pub mod log {
+    #[cfg(all(target_os="android", not(test)))]
+    use std::ffi::CString;
+
+    #[cfg(all(target_os="android", not(test)))]
+    use android;
+
+    // TODO far from ideal. And, we might actually want to println in tests.
+    #[cfg(all(not(target_os="android"), not(target_os="ios")))]
+    pub fn d(_: &str) {}
+
+    #[cfg(all(target_os="ios", not(test)))]
+    pub fn d(message: &str) {
+        eprintln!("{}", message);
+    }
+
+    #[cfg(all(target_os="android", not(test)))]
+    pub fn d(message: &str) {
+        let message = CString::new(message).unwrap();
+        let message = message.as_ptr();
+        let tag = CString::new("Mentat").unwrap();
+        let tag = tag.as_ptr();
+        unsafe { android::__android_log_write(android::ANDROID_LOG_DEBUG, tag, message) };
+    }
+}

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -58,6 +58,7 @@ use mentat_db::{
     transact_terms,
     PartitionMap,
     TxObservationService,
+    TxObserver,
     TxReport,
 };
 
@@ -805,6 +806,14 @@ impl Conn {
                 Ok(())
             },
         }
+    }
+
+    pub fn register_observer(&mut self, key: String, observer: Arc<TxObserver>) {
+        self.tx_observer_service.lock().unwrap().register(key, observer);
+    }
+
+    pub fn unregister_observer(&mut self, key: &String) {
+        self.tx_observer_service.lock().unwrap().deregister(key);
     }
 }
 

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -499,7 +499,6 @@ impl<'a, 'c> InProgress<'a, 'c> {
 struct InProgressTransactWatcher<'a, 'o> {
     cache_watcher: InProgressCacheTransactWatcher<'a>,
     observer_watcher: &'o mut InProgressObserverTransactWatcher,
-    tx_id: Option<Entid>,
 }
 
 impl<'a, 'o> InProgressTransactWatcher<'a, 'o> {
@@ -507,21 +506,24 @@ impl<'a, 'o> InProgressTransactWatcher<'a, 'o> {
         InProgressTransactWatcher {
             cache_watcher: cache_watcher,
             observer_watcher: observer_watcher,
-            tx_id: None,
         }
     }
 }
 
 impl<'a, 'o> TransactWatcher for InProgressTransactWatcher<'a, 'o> {
+    fn start(&mut self, t: &Entid) {
+        self.cache_watcher.start(t);
+        self.observer_watcher.start(t);
+    }
+
     fn datom(&mut self, op: OpType, e: Entid, a: Entid, v: &TypedValue) {
         self.cache_watcher.datom(op.clone(), e.clone(), a.clone(), v);
         self.observer_watcher.datom(op.clone(), e.clone(), a.clone(), v);
     }
 
-    fn done(&mut self, t: &Entid, schema: &Schema) -> ::mentat_db::errors::Result<()> {
-        self.cache_watcher.done(t, schema)?;
-        self.observer_watcher.done(t, schema)?;
-        self.tx_id = Some(t.clone());
+    fn done(&mut self, schema: &Schema) -> ::mentat_db::errors::Result<()> {
+        self.cache_watcher.done(schema)?;
+        self.observer_watcher.done(schema)?;
         Ok(())
     }
 }
@@ -530,6 +532,11 @@ impl Store {
     /// Intended for use from tests.
     pub fn sqlite_mut(&mut self) -> &mut rusqlite::Connection {
         &mut self.sqlite
+    }
+
+    #[cfg(test)]
+    pub fn is_registered_as_observer(&self, key: &String) -> bool {
+        self.conn.tx_observer_service.lock().unwrap().is_registered(key)
     }
 }
 
@@ -557,6 +564,14 @@ impl Store {
                         attr,
                         direction,
                         CacheAction::Register)
+    }
+
+    pub fn register_observer(&mut self, key: String, observer: Arc<TxObserver>) {
+        self.conn.register_observer(key, observer);
+    }
+
+    pub fn unregister_observer(&mut self, key: &String) {
+        self.conn.unregister_observer(key);
     }
 }
 
@@ -614,11 +629,6 @@ impl Conn {
             metadata: Mutex::new(Metadata::new(0, partition_map, Arc::new(schema), Default::default())),
             tx_observer_service: Mutex::new(TxObservationService::new()),
         }
-    }
-
-    #[cfg(test)]
-    pub fn is_registered_as_observer(&self, key: &String) -> bool {
-        self.tx_observer_service.lock().unwrap().is_registered(key)
     }
 
     /// Prepare the provided SQLite handle for use as a Mentat store. Creates tables but
@@ -1463,8 +1473,7 @@ mod tests {
     }
 
     fn test_register_observer() {
-        let mut sqlite = db::new_connection("").unwrap();
-        let mut conn = Conn::connect(&mut sqlite).unwrap();
+        let mut conn = Store::open("").unwrap();
 
         let key = "Test Observer".to_string();
         let tx_observer = TxObserver::new(BTreeSet::new(), move |_obs_key, _batch| {});
@@ -1475,8 +1484,7 @@ mod tests {
 
     #[test]
     fn test_deregister_observer() {
-        let mut sqlite = db::new_connection("").unwrap();
-        let mut conn = Conn::connect(&mut sqlite).unwrap();
+        let mut conn = Store::open("").unwrap();
 
         let key = "Test Observer".to_string();
 
@@ -1490,9 +1498,9 @@ mod tests {
         assert!(!conn.is_registered_as_observer(&key));
     }
 
-    fn add_schema(conn: &mut Conn, mut sqlite: &mut rusqlite::Connection) {
+    fn add_schema(conn: &mut Store) {
         // transact some schema
-        let mut in_progress = conn.begin_transaction(&mut sqlite).expect("expected in progress");
+        let mut in_progress = conn.begin_transaction().expect("expected in progress");
         in_progress.ensure_vocabulary(&Definition {
             name: kw!(:todo/items),
             version: 1,
@@ -1542,12 +1550,11 @@ mod tests {
 
     #[test]
     fn test_observer_notified_on_registered_change() {
-        let mut sqlite = db::new_connection("").unwrap();
-        let mut conn = Conn::connect(&mut sqlite).unwrap();
-        add_schema(&mut conn, &mut sqlite);
+        let mut conn = Store::open("").unwrap();
+        add_schema(&mut conn);
 
-        let name_entid: Entid = conn.current_schema().get_entid(&kw!(:todo/name)).expect("entid to exist for name").into();
-        let date_entid: Entid = conn.current_schema().get_entid(&kw!(:todo/completion_date)).expect("entid to exist for completion_date").into();
+        let name_entid: Entid = conn.conn().current_schema().get_entid(&kw!(:todo/name)).expect("entid to exist for name").into();
+        let date_entid: Entid = conn.conn().current_schema().get_entid(&kw!(:todo/completion_date)).expect("entid to exist for completion_date").into();
         let mut registered_attrs = BTreeSet::new();
         registered_attrs.insert(name_entid.clone());
         registered_attrs.insert(date_entid.clone());
@@ -1579,9 +1586,9 @@ mod tests {
 
         let mut tx_ids = Vec::new();
         let mut changesets = Vec::new();
-        let uuid_entid: Entid = conn.current_schema().get_entid(&kw!(:todo/uuid)).expect("entid to exist for name").into();
+        let uuid_entid: Entid = conn.conn().current_schema().get_entid(&kw!(:todo/uuid)).expect("entid to exist for name").into();
         {
-            let mut in_progress = conn.begin_transaction(&mut sqlite).expect("expected transaction");
+            let mut in_progress = conn.begin_transaction().expect("expected transaction");
             for i in 0..3 {
                 let mut changeset = BTreeSet::new();
                 let name = format!("todo{}", i);
@@ -1619,12 +1626,11 @@ mod tests {
 
     #[test]
     fn test_observer_not_notified_on_unregistered_change() {
-        let mut sqlite = db::new_connection("").unwrap();
-        let mut conn = Conn::connect(&mut sqlite).unwrap();
-        add_schema(&mut conn, &mut sqlite);
+        let mut conn = Store::open("").unwrap();
+        add_schema(&mut conn);
 
-        let name_entid: Entid = conn.current_schema().get_entid(&kw!(:todo/name)).expect("entid to exist for name").into();
-        let date_entid: Entid = conn.current_schema().get_entid(&kw!(:todo/completion_date)).expect("entid to exist for completion_date").into();
+        let name_entid: Entid = conn.conn().current_schema().get_entid(&kw!(:todo/name)).expect("entid to exist for name").into();
+        let date_entid: Entid = conn.conn().current_schema().get_entid(&kw!(:todo/completion_date)).expect("entid to exist for completion_date").into();
         let mut registered_attrs = BTreeSet::new();
         registered_attrs.insert(name_entid.clone());
         registered_attrs.insert(date_entid.clone());
@@ -1655,7 +1661,7 @@ mod tests {
         let tx_ids = Vec::<Entid>::new();
         let changesets = Vec::<BTreeSet<Entid>>::new();
         {
-            let mut in_progress = conn.begin_transaction(&mut sqlite).expect("expected transaction");
+            let mut in_progress = conn.begin_transaction().expect("expected transaction");
             for i in 0..3 {
                 let name = format!("label{}", i);
                 let mut builder = in_progress.builder().describe_tempid(&name);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,12 +36,14 @@ extern crate mentat_tx_parser;
 pub use mentat_core::{
     Attribute,
     Entid,
+    DateTime,
     HasSchema,
     KnownEntid,
     NamespacedKeyword,
     Schema,
     TypedValue,
     Uuid,
+    Utc,
     ValueType,
 };
 
@@ -52,6 +54,7 @@ pub use mentat_query::{
 pub use mentat_db::{
     CORE_SCHEMA_VERSION,
     DB_SCHEMA_CORE,
+    TxObserver,
     TxReport,
     new_connection,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,8 +18,6 @@ extern crate lazy_static;
 
 extern crate rusqlite;
 
-extern crate smallvec;
-
 extern crate uuid;
 
 pub extern crate edn;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,8 @@ extern crate lazy_static;
 
 extern crate rusqlite;
 
+extern crate smallvec;
+
 extern crate uuid;
 
 pub extern crate edn;


### PR DESCRIPTION
 Transaction observation

- Creation of `TxObserverService` in `Conn` that takes `TxObserver`s and registers them against keys and for sets of attributes.
- `InProgress` batches up tx's as it goes along so granular notification can be provided.
- `TxObserverService` called when `InProgress` commits and filters `TxObserver`s that are affected by the tx's that occurred and notifies them of what changed.

Things I could still do:
- Remove concept of `TxObserver` entirely and just register functions against keys inside `TxObserverService`.

Things I tried for storing observers:
- Trait Objects
-- Store trait object as reference - caused lifetime issues when attaching `tx_observer_service` to an `InProgress` as the lifetime for the trait object reference couldn't be worked out.
-- Store trait object inside `RefCell` inside an `Rc` - got mutability but required definition of var as `Rc<RefCell<Trait>>` which caused sizing issues - basically you can't specify a trait object as a generic parameter. To resolve this would mean making a concrete type implementing trait and storing that, which kinda defeats the purpose.
-- Store trait object inside `Box` - this works but means that the observer service owns the observer which kinda defeats the point.

- Functions
-- Pretty much everything written above but using functions rather than trait objects

- Futures
-- Experimented with returning a Future on observer registration, but I had problems in 2 ways:
--- Difficulty telling the future that it has completed without turning the entire observer service into a Future.
--- Once the future has completed, consumers needed to reregister in order to get another future, which was clumsy.
--- It's possible I didn't understand the `Futures` or `Streams` documentation properly and there is still a way to do this.
  