### PR TITLE
publically expose KnownEntid

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ pub use mentat_core::{
     Attribute,
     Entid,
     HasSchema,
+    KnownEntid,
     NamespacedKeyword,
     TypedValue,
     Uuid,


### PR DESCRIPTION
I need this to use the EntityBuilder from outside of Mentat.