### PR TITLE
Provide an API for creating truly empty stores

### DIFF
--- a/src/conn.rs
+++ b/src/conn.rs
@@ -138,7 +138,7 @@ pub struct Store {
 }
 
 impl Store {
-    pub fn create_empty(path: &str) -> Result<Conn> {
+    pub fn open_empty(path: &str) -> Result<Store> {
         if !path.is_empty() {
             if Path::new(path).exists() {
                 bail!(ErrorKind::PathAlreadyExists(path.to_string()));
@@ -146,7 +146,11 @@ impl Store {
         }
 
         let mut connection = ::new_connection(path)?;
-        Conn::empty(&mut connection)
+        let conn = Conn::empty(&mut connection)?;
+        Ok(Store {
+            conn: conn,
+            sqlite: connection,
+        })
     }
 
     pub fn open(path: &str) -> Result<Store> {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -54,6 +54,11 @@ error_chain! {
     }
 
     errors {
+        PathAlreadyExists(path: String) {
+            description("path already exists")
+            display("path {} already exists", path)
+        }
+
         UnboundVariables(names: BTreeSet<String>) {
             description("unbound variables at query execution time")
             display("variables {:?} unbound at query execution time", names)

--- a/tools/cli/src/mentat_cli/repl.rs
+++ b/tools/cli/src/mentat_cli/repl.rs
@@ -189,6 +189,12 @@ impl Repl {
                     Err(e) => eprintln!("{:?}", e)
                 };
             }
+            Command::OpenEmpty(db) => {
+                match self.open_empty(db) {
+                    Ok(_) => println!("Empty database {:?} opened", self.db_name()),
+                    Err(e) => eprintln!("{}", e.to_string()),
+                };
+            },
             Command::Close => self.close(),
             Command::Query(query) => self.execute_query(query),
             Command::QueryExplain(query) => self.explain_query(query),
@@ -221,6 +227,18 @@ impl Repl {
         let path = path.into();
         if self.path.is_empty() || path != self.path {
             let next = Store::open(path.as_str())?;
+            self.path = path;
+            self.store = next;
+        }
+
+        Ok(())
+    }
+
+    fn open_empty<T>(&mut self, path: T) -> ::mentat::errors::Result<()>
+    where T: Into<String> {
+        let path = path.into();
+        if self.path.is_empty() || path != self.path {
+            let next = Store::open_empty(path.as_str())?;
             self.path = path;
             self.store = next;
         }


### PR DESCRIPTION
This is necessary for 'fresh-start' syncing: create an empty vessel into which the entire remote transaction log will be poured.

Use `Store::create_empty` with a path, or `Conn::empty` with a SQLite connection handle.

@grigoryk let me know what you think.