### PR TITLE
When an attribute is known-fulltext, don't hit AllDatoms.

### DIFF
--- a/query-algebrizer/src/clauses/mod.rs
+++ b/query-algebrizer/src/clauses/mod.rs
@@ -742,10 +742,10 @@ impl ConjoiningClauses {
 
                 // TODO: an existing non-string binding can cause this pattern to fail.
                 &EvolvedValuePlace::Variable(_) =>
-                    Ok(DatomsTable::AllDatoms),
+                    Ok(DatomsTable::FulltextDatoms),
 
                 &EvolvedValuePlace::Value(TypedValue::String(_)) =>
-                    Ok(DatomsTable::AllDatoms),
+                    Ok(DatomsTable::FulltextDatoms),
 
                 _ => {
                     // We can't succeed if there's a non-string constant value for a fulltext


### PR DESCRIPTION
This is an oversight from long ago.

If we know the attribute, and we know it's fulltext, then we should hit `fulltext_datoms`, not `all_datoms` (which is a `UNION` between `fulltext_datoms` and `datoms`).

Tests pass with this change, and some queries get a fair bit faster!