### PR TITLE
CLI improvements

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,3 @@
 [alias]
-cli = ["run", "-p", "mentat_cli"]
+cli = ["run", "--release", "-p", "mentat_cli"]
+debugcli = ["run", "-p", "mentat_cli"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,4 +80,4 @@ path = "tx-parser"
 path = "tolstoy"
 
 [profile.release]
-debug = true
+debug = false

--- a/tools/cli/src/mentat_cli/input.rs
+++ b/tools/cli/src/mentat_cli/input.rs
@@ -132,6 +132,9 @@ impl InputReader {
         // Therefore, we add the newly read in line to the existing command args.
         // If there is no in process command, we parse the read in line as a new command.
         let cmd = match &self.in_process_cmd {
+            &Some(Command::QueryPrepared(ref args)) => {
+                Ok(Command::QueryPrepared(args.clone() + " " + &line))
+            },
             &Some(Command::Query(ref args)) => {
                 Ok(Command::Query(args.clone() + " " + &line))
             },
@@ -147,6 +150,7 @@ impl InputReader {
             Ok(cmd) => {
                 match cmd {
                     Command::Query(_) |
+                    Command::QueryPrepared(_) |
                     Command::Transact(_) |
                     Command::QueryExplain(_) if !cmd.is_complete() => {
                         // A query or transact is complete if it contains a valid EDN.

--- a/tools/cli/src/mentat_cli/repl.rs
+++ b/tools/cli/src/mentat_cli/repl.rs
@@ -101,12 +101,25 @@ fn parse_namespaced_keyword(input: &str) -> Option<NamespacedKeyword> {
 }
 
 fn format_time(duration: Duration) {
+    let m_nanos = duration.num_nanoseconds();
+    if let Some(nanos) = m_nanos {
+        if nanos < 1_000 {
+            eprintln!("{bold}{nanos}{reset}ns",
+                      bold = style::Bold,
+                      nanos = nanos,
+                      reset = style::Reset);
+            return;
+        }
+    }
+
     let m_micros = duration.num_microseconds();
     if let Some(micros) = m_micros {
         if micros < 10_000 {
-            eprintln!("{bold}{micros}{reset}µs",
+            let ns = m_nanos.unwrap_or(0) / 1000;
+            eprintln!("{bold}{micros}.{ns}{reset}µs",
                       bold = style::Bold,
                       micros = micros,
+                      ns = ns,
                       reset = style::Reset);
             return;
         }

--- a/tools/cli/src/mentat_cli/repl.rs
+++ b/tools/cli/src/mentat_cli/repl.rs
@@ -383,23 +383,31 @@ impl<'a> Repl<'a> {
     }
 
     fn help_command(&self, args: Vec<String>) {
+        let stdout = ::std::io::stdout();
+        let mut output = TabWriter::new(stdout.lock());
         if args.is_empty() {
             for &(cmd, msg) in HELP_COMMANDS.iter() {
-                println!(".{} - {}", cmd, msg);
+                write!(output, ".{}\t", cmd).unwrap();
+                writeln!(output, "{}", msg).unwrap();
             }
         } else {
             for mut arg in args {
                 if arg.chars().nth(0).unwrap() == '.' {
                     arg.remove(0);
                 }
-                let msg = HELP_COMMANDS.iter().filter(|&&(c, _)| c == arg.as_str()).next().map(|x| x.1);
-                if msg.is_some() {
-                    println!(".{} - {}", arg, msg.unwrap());
+                if let Some(&(cmd, msg)) = HELP_COMMANDS.iter()
+                                                       .filter(|&&(c, _)| c == arg.as_str())
+                                                       .next() {
+                    write!(output, ".{}\t", cmd).unwrap();
+                    writeln!(output, "{}", msg).unwrap();
                 } else {
                     eprintln!("Unrecognised command {}", arg);
+                    return;
                 }
             }
         }
+        writeln!(output, "").unwrap();
+        output.flush().unwrap();
     }
 
     fn print_results(&self, query_output: QueryOutput) -> Result<(), ::errors::Error> {


### PR DESCRIPTION
- Print nanoseconds.
- `cargo cli` is release by default (because it often is used for timing). Use `cargo debugcli` to get a debug version.
- Time query runtime, not including printing results!
- Make our release builds really release: no debug symbols!
- Expose prepared queries in the CLI. We can't hold on to them, but we can separate the execution time and preparation time, and verify that behavior is the same as non-prepared.