### PR TITLE
Add specialized tx-before and tx-after predicates.

### DIFF
--- a/query-algebrizer/src/clauses/predicate.rs
+++ b/query-algebrizer/src/clauses/predicate.rs
@@ -33,6 +33,7 @@ use types::{
     ColumnConstraint,
     EmptyBecause,
     Inequality,
+    QueryValue,
 };
 
 use Known;
@@ -150,13 +151,31 @@ impl ConjoiningClauses {
 
         // These arguments must be variables or instant/numeric constants.
         // TODO: static evaluation. #383.
-        let constraint = ColumnConstraint::Inequality {
-            operator: comparison,
-            left: left_v,
-            right: right_v,
-        };
+        let constraint = comparison.to_constraint(left_v, right_v);
         self.wheres.add_intersection(constraint);
         Ok(())
+    }
+}
+
+impl Inequality {
+    fn to_constraint(&self, left: QueryValue, right: QueryValue) -> ColumnConstraint {
+        match *self {
+            Inequality::TxAfter |
+            Inequality::TxBefore => {
+                // TODO: both ends of the range must be inside the tx partition!
+                // If we know the partition map -- and at this point we do, it's just
+                // not passed to this function -- then we can generate two constraints,
+                // or clamp a fixed value.
+            },
+            _ => {
+            },
+        }
+
+        ColumnConstraint::Inequality {
+            operator: *self,
+            left: left,
+            right: right,
+        }
     }
 }
 

--- a/query-algebrizer/src/types.rs
+++ b/query-algebrizer/src/types.rs
@@ -287,6 +287,10 @@ pub enum Inequality {
     // Ref operators.
     Unpermute,
     Differ,
+
+    // Tx operators.
+    TxAfter,
+    TxBefore,
 }
 
 impl Inequality {
@@ -301,6 +305,9 @@ impl Inequality {
 
             Unpermute           => "<",
             Differ              => "<>",
+
+            TxAfter             => ">",
+            TxBefore            => "<",
         }
     }
 
@@ -314,6 +321,9 @@ impl Inequality {
 
             "unpermute" => Some(Inequality::Unpermute),
             "differ" => Some(Inequality::Differ),
+
+            "tx-after" => Some(Inequality::TxAfter),
+            "tx-before" => Some(Inequality::TxBefore),
             _ => None,
         }
     }
@@ -332,7 +342,9 @@ impl Inequality {
                 ts
             },
             &Unpermute |
-            &Differ => {
+            &Differ |
+            &TxAfter |
+            &TxBefore => {
                 ValueTypeSet::of_one(ValueType::Ref)
             },
         }
@@ -351,6 +363,9 @@ impl Debug for Inequality {
 
             &Unpermute => "<",
             &Differ => "<>",
+
+            &TxAfter => ">",
+            &TxBefore => "<",
         })
     }
 }

--- a/query-translator/tests/translate.rs
+++ b/query-translator/tests/translate.rs
@@ -1115,3 +1115,22 @@ fn test_project_aggregates() {
                       WHERE `datoms00`.a = 99)");
     assert_eq!(args, vec![]);
 }
+
+#[test]
+fn test_tx_before_and_after() {
+    let schema = prepopulated_typed_schema(ValueType::Long);
+    let query = r#"[:find ?x :where [?x _ _ ?tx] [(tx-after ?tx 12345)]]"#;
+    let SQLQuery { sql, args } = translate(&schema, query);
+    assert_eq!(sql, "SELECT DISTINCT \
+                     `datoms00`.e AS `?x` \
+                     FROM `datoms` AS `datoms00` \
+                     WHERE `datoms00`.tx > 12345");
+    assert_eq!(args, vec![]);
+    let query = r#"[:find ?x :where [?x _ _ ?tx] [(tx-before ?tx 12345)]]"#;
+    let SQLQuery { sql, args } = translate(&schema, query);
+    assert_eq!(sql, "SELECT DISTINCT \
+                     `datoms00`.e AS `?x` \
+                     FROM `datoms` AS `datoms00` \
+                     WHERE `datoms00`.tx < 12345");
+    assert_eq!(args, vec![]);
+}


### PR DESCRIPTION
This is a pretty trivial addition: this is an inequality predicate that applies only to entities, with a little TODO to additionally constrain to the correct partition range.

Note that this is an opinionated divergence from Datomic: Datomic doesn't distinguish between entities, longs, etc., so you can write

```
[:find ?x :where [?x _ ?v ?tx] [(< ?tx 1234)]]
```

or

```
[:find ?x :where [?x _ ?v ?tx] [(< ?v 1234)]]
```

and not spot your typo until it's too late. Mentat will err in that case: we'll read the first `1234` as a `Long`, and the second as a `Ref`, and we'll detect the comparison across type boundaries.