### PR TITLE
Expose component_attributes on Schema.

### DIFF
--- a/db/src/metadata.rs
+++ b/db/src/metadata.rs
@@ -91,6 +91,13 @@ pub struct MetadataReport {
     pub idents_altered: BTreeMap<Entid, IdentAlteration>,
 }
 
+impl MetadataReport {
+    pub fn attributes_did_change(&self) -> bool {
+        !(self.attributes_installed.is_empty() &&
+          self.attributes_altered.is_empty())
+    }
+}
+
 /// Update a `AttributeMap` in place from the given `[e a typed_value]` triples.
 ///
 /// This is suitable for producing a `AttributeMap` from the `schema` materialized view, which does not
@@ -275,6 +282,10 @@ pub fn update_schema_from_entid_quadruples<U>(schema: &mut Schema, assertions: U
         schema.entid_map.remove(&entid);
         schema.ident_map.remove(&ident);
         idents_altered.insert(entid, IdentAlteration::Ident(ident.clone()));
+    }
+
+    if report.attributes_did_change() {
+        schema.update_component_attributes();
     }
 
     Ok(MetadataReport {

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -336,6 +336,10 @@ impl<'a, 'c> HasSchema for InProgressRead<'a, 'c> {
     fn identifies_attribute(&self, x: &NamespacedKeyword) -> bool {
         self.0.identifies_attribute(x)
     }
+
+    fn component_attributes(&self) -> &[Entid] {
+        self.0.component_attributes()
+    }
 }
 
 impl<'a, 'c> HasSchema for InProgress<'a, 'c> {
@@ -367,6 +371,10 @@ impl<'a, 'c> HasSchema for InProgress<'a, 'c> {
     /// Return true if the provided ident identifies an attribute in this schema.
     fn identifies_attribute(&self, x: &NamespacedKeyword) -> bool {
         self.schema.identifies_attribute(x)
+    }
+
+    fn component_attributes(&self) -> &[Entid] {
+        self.schema.component_attributes()
     }
 }
 


### PR DESCRIPTION
Some parts of the query engine (pull) and transactor (retractEntity) need to know whether an attribute is a component attribute, and sometimes want to do so in a generated SQL query. This is one way to do that.