### PR TITLE
Implement simple pull expressions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,9 @@ path = "query-parser"
 [dependencies.mentat_query_projector]
 path = "query-projector"
 
+[dependencies.mentat_query_pull]
+path = "query-pull"
+
 [dependencies.mentat_query_sql]
 path = "query-sql"
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -363,6 +363,45 @@ pub mod intern_set;
 pub mod counter;
 pub mod util;
 
+/// A helper macro to sequentially process an iterable sequence,
+/// evaluating a block between each pair of items.
+///
+/// This is used to simply and efficiently produce output like
+///
+/// ```sql
+///   1, 2, 3
+/// ```
+///
+/// or
+///
+/// ```sql
+/// x = 1 AND y = 2
+/// ```
+///
+/// without producing an intermediate string sequence.
+#[macro_export]
+macro_rules! interpose {
+    ( $name: pat, $across: expr, $body: block, $inter: block ) => {
+        interpose_iter!($name, $across.iter(), $body, $inter)
+    }
+}
+
+/// A helper to bind `name` to values in `across`, running `body` for each value,
+/// and running `inter` between each value. See `interpose` for examples.
+#[macro_export]
+macro_rules! interpose_iter {
+    ( $name: pat, $across: expr, $body: block, $inter: block ) => {
+        let mut seq = $across;
+        if let Some($name) = seq.next() {
+            $body;
+            for $name in seq {
+                $inter;
+                $body;
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -55,12 +55,13 @@ mod value_type_set;
 mod sql_types;
 
 pub use types::{
+    Binding,
     Cloned,
     Entid,
     FromRc,
     KnownEntid,
+    StructuredMap,
     TypedValue,
-    Binding,
     ValueType,
     ValueTypeTag,
     ValueRc,

--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -96,11 +96,16 @@ impl<T> FromRc<T> for Box<T> where T: Sized + Clone {
 // We do this a lot for errors.
 pub trait Cloned<T> {
     fn cloned(&self) -> T;
+    fn to_value_rc(&self) -> ValueRc<T>;
 }
 
 impl<T: Clone> Cloned<T> for Rc<T> where T: Sized + Clone {
     fn cloned(&self) -> T {
         (*self.as_ref()).clone()
+    }
+
+    fn to_value_rc(&self) -> ValueRc<T> {
+        ValueRc::from_rc(self.clone())
     }
 }
 
@@ -108,11 +113,19 @@ impl<T: Clone> Cloned<T> for Arc<T> where T: Sized + Clone {
     fn cloned(&self) -> T {
         (*self.as_ref()).clone()
     }
+
+    fn to_value_rc(&self) -> ValueRc<T> {
+        ValueRc::from_arc(self.clone())
+    }
 }
 
 impl<T: Clone> Cloned<T> for Box<T> where T: Sized + Clone {
     fn cloned(&self) -> T {
         self.as_ref().clone()
+    }
+
+    fn to_value_rc(&self) -> ValueRc<T> {
+        ValueRc::new(self.cloned())
     }
 }
 

--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -297,8 +297,14 @@ pub enum Binding {
 }
 
 impl<T> From<T> for Binding where T: Into<TypedValue> {
-    fn from(value: T) -> Binding {
+    fn from(value: T) -> Self {
         Binding::Scalar(value.into())
+    }
+}
+
+impl From<StructuredMap> for Binding {
+    fn from(value: StructuredMap) -> Self {
+        Binding::Map(ValueRc::new(value))
     }
 }
 
@@ -321,8 +327,27 @@ impl Binding {
 ///
 /// We entirely support the former, and partially support the latter -- you can alias
 /// using a different keyword only.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct StructuredMap(IndexMap<ValueRc<NamespacedKeyword>, Binding>);
+
+impl StructuredMap {
+    /// TODO: replace this with a map-like interface.
+    pub fn get_mut_expedient(&mut self) -> &mut IndexMap<ValueRc<NamespacedKeyword>, Binding> {
+        &mut self.0
+    }
+}
+
+impl StructuredMap {
+    pub fn insert<N, B>(&mut self, name: N, value: B) where N: Into<ValueRc<NamespacedKeyword>>, B: Into<Binding> {
+        self.0.insert(name.into(), value.into());
+    }
+}
+
+impl From<IndexMap<ValueRc<NamespacedKeyword>, Binding>> for StructuredMap {
+    fn from(src: IndexMap<ValueRc<NamespacedKeyword>, Binding>) -> Self {
+        StructuredMap(src)
+    }
+}
 
 impl Binding {
     /// Returns true if the provided type is `Some` and matches this value's type, or if the

--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -328,14 +328,7 @@ impl Binding {
 /// We entirely support the former, and partially support the latter -- you can alias
 /// using a different keyword only.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
-pub struct StructuredMap(IndexMap<ValueRc<NamespacedKeyword>, Binding>);
-
-impl StructuredMap {
-    /// TODO: replace this with a map-like interface.
-    pub fn get_mut_expedient(&mut self) -> &mut IndexMap<ValueRc<NamespacedKeyword>, Binding> {
-        &mut self.0
-    }
-}
+pub struct StructuredMap(pub IndexMap<ValueRc<NamespacedKeyword>, Binding>);
 
 impl StructuredMap {
     pub fn insert<N, B>(&mut self, name: N, value: B) where N: Into<ValueRc<NamespacedKeyword>>, B: Into<Binding> {
@@ -346,6 +339,17 @@ impl StructuredMap {
 impl From<IndexMap<ValueRc<NamespacedKeyword>, Binding>> for StructuredMap {
     fn from(src: IndexMap<ValueRc<NamespacedKeyword>, Binding>) -> Self {
         StructuredMap(src)
+    }
+}
+
+// Mostly for testing.
+impl<T> From<Vec<(NamespacedKeyword, T)>> for StructuredMap where T: Into<Binding> {
+    fn from(value: Vec<(NamespacedKeyword, T)>) -> Self {
+        let mut sm = StructuredMap::default();
+        for (k, v) in value.into_iter() {
+            sm.insert(k, v);
+        }
+        sm
     }
 }
 

--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -23,6 +23,9 @@ path = "../edn"
 [dependencies.mentat_core]
 path = "../core"
 
+[dependencies.mentat_sql]
+path = "../sql"
+
 [dependencies.mentat_tx]
 path = "../tx"
 

--- a/db/src/cache.rs
+++ b/db/src/cache.rs
@@ -77,6 +77,7 @@ use num;
 use rusqlite;
 
 use mentat_core::{
+    Binding,
     CachedAttributes,
     Entid,
     HasSchema,
@@ -88,6 +89,12 @@ use mentat_core::{
 
 use mentat_core::util::{
     Either,
+};
+
+use mentat_sql::{
+    QueryBuilder,
+    SQLiteQueryBuilder,
+    SQLQuery,
 };
 
 use mentat_tx::entities::{
@@ -241,6 +248,11 @@ impl<'conn, F> Iterator for AevRows<'conn, F> where F: FnMut(&rusqlite::Row) -> 
 // - cardinality/one doesn't need a vec
 // - unique/* should ideally have a bijective mapping (reverse lookup)
 
+pub trait AttributeCache {
+    fn has_e(&self, e: Entid) -> bool;
+    fn binding_for_e(&self, e: Entid) -> Option<Binding>;
+}
+
 trait RemoveFromCache {
     fn remove(&mut self, e: Entid, v: &TypedValue);
 }
@@ -270,6 +282,16 @@ impl Absorb for SingleValAttributeCache {
     fn absorb(&mut self, other: Self) {
         assert_eq!(self.attr, other.attr);
         self.e_v.absorb(other.e_v);
+    }
+}
+
+impl AttributeCache for SingleValAttributeCache {
+    fn binding_for_e(&self, e: Entid) -> Option<Binding> {
+        self.get(e).map(|v| v.clone().into())
+    }
+
+    fn has_e(&self, e: Entid) -> bool {
+        self.e_v.contains_key(&e)
     }
 }
 
@@ -329,6 +351,19 @@ impl Absorb for MultiValAttributeCache {
                 self.e_vs.insert(e, vs);
             }
         }
+    }
+}
+
+impl AttributeCache for MultiValAttributeCache {
+    fn binding_for_e(&self, e: Entid) -> Option<Binding> {
+        self.e_vs.get(&e).map(|vs| {
+            let bindings = vs.iter().cloned().map(|v| v.into()).collect();
+            Binding::Vec(ValueRc::new(bindings))
+        })
+    }
+
+    fn has_e(&self, e: Entid) -> bool {
+        self.e_vs.contains_key(&e)
     }
 }
 
@@ -861,15 +896,226 @@ impl AttributeCaches {
         let sql = format!("SELECT a, e, v, value_type_tag FROM {} WHERE a = ? ORDER BY a ASC, e ASC", table);
         let args: Vec<&rusqlite::types::ToSql> = vec![&attribute];
         let mut stmt = sqlite.prepare(&sql)?;
+        let replacing = true;
+        self.repopulate_from_aevt(schema, &mut stmt, args, replacing)
+    }
+
+    fn repopulate_from_aevt<'a, 's, 'c, 'v>(&'a mut self,
+                                            schema: &'s Schema,
+                                            statement: &'c mut rusqlite::Statement,
+                                            args: Vec<&'v rusqlite::types::ToSql>,
+                                            replacing: bool) -> Result<()> {
         let mut aev_factory = AevFactory::new();
-        let rows = stmt.query_map(&args, |row| aev_factory.row_to_aev(row))?;
+        let rows = statement.query_map(&args, |row| aev_factory.row_to_aev(row))?;
         let aevs = AevRows {
             rows: rows,
         };
-        self.accumulate_into_cache(None, schema, aevs.peekable(), AccumulationBehavior::Add { replacing: true })?;
+        self.accumulate_into_cache(None, schema, aevs.peekable(), AccumulationBehavior::Add { replacing })?;
         Ok(())
     }
 }
+
+// Borrowed from mentat_query_sql.
+macro_rules! interpose {
+    ( $name: pat, $across: expr, $body: block, $inter: block ) => {
+        interpose_iter!($name, $across.iter(), $body, $inter)
+    }
+}
+
+// Borrowed from mentat_query_sql.
+macro_rules! interpose_iter {
+    ( $name: pat, $across: expr, $body: block, $inter: block ) => {
+        let mut seq = $across;
+        if let Some($name) = seq.next() {
+            $body;
+            for $name in seq {
+                $inter;
+                $body;
+            }
+        }
+    }
+}
+
+#[derive(Clone)]
+pub enum AttributeSpec {
+    All,
+    Specified {
+        // These are assumed to not include duplicates.
+        fts: Vec<Entid>,
+        non_fts: Vec<Entid>,
+    },
+}
+
+impl AttributeSpec {
+    pub fn all() -> AttributeSpec {
+        AttributeSpec::All
+    }
+
+    pub fn specified(attrs: &BTreeSet<Entid>, schema: &Schema) -> AttributeSpec {
+        let mut fts = Vec::with_capacity(attrs.len());
+        let mut non_fts = Vec::with_capacity(attrs.len());
+        for attr in attrs.iter() {
+            if let Some(a) = schema.attribute_for_entid(*attr) {
+                if a.fulltext {
+                    fts.push(*attr);
+                } else {
+                    non_fts.push(*attr);
+                }
+            }
+        }
+
+        AttributeSpec::Specified { fts, non_fts }
+    }
+}
+
+impl AttributeCaches {
+    fn populate_cache_for_entities_and_attributes<'s, 'c>(&mut self,
+                                                          schema: &'s Schema,
+                                                          sqlite: &'c rusqlite::Connection,
+                                                          attrs: AttributeSpec,
+                                                          entities: &Vec<Entid>) -> Result<()> {
+
+        // Mark the attributes as cached as we go. We do this because we're going in through the
+        // back door here, and the usual caching API won't have taken care of this for us.
+        let mut qb = SQLiteQueryBuilder::new();
+        qb.push_sql("SELECT a, e, v, value_type_tag FROM ");
+        match attrs {
+            AttributeSpec::All => {
+                qb.push_sql("all_datoms WHERE e IN (");
+                interpose!(item, entities,
+                           { qb.push_sql(&item.to_string()) },
+                           { qb.push_sql(", ") });
+                qb.push_sql(") ORDER BY a ASC, e ASC");
+
+                self.forward_cached_attributes.extend(schema.attribute_map.keys());
+            },
+            AttributeSpec::Specified { fts, non_fts } => {
+                let has_fts = !fts.is_empty();
+                let has_non_fts = !non_fts.is_empty();
+
+                if !has_fts && !has_non_fts {
+                    // Nothing to do.
+                    return Ok(());
+                }
+
+                if has_non_fts {
+                    qb.push_sql("datoms WHERE e IN (");
+                    interpose!(item, entities,
+                               { qb.push_sql(&item.to_string()) },
+                               { qb.push_sql(", ") });
+                    qb.push_sql(") AND a IN (");
+                    interpose!(item, non_fts,
+                               { qb.push_sql(&item.to_string()) },
+                               { qb.push_sql(", ") });
+                    qb.push_sql(")");
+
+                    self.forward_cached_attributes.extend(non_fts.iter());
+                }
+
+                if has_fts && has_non_fts {
+                    // Both.
+                    qb.push_sql(" UNION ALL SELECT a, e, v, value_type_tag FROM ");
+                }
+
+                if has_fts {
+                    qb.push_sql("fulltext_datoms WHERE e IN (");
+                    interpose!(item, entities,
+                               { qb.push_sql(&item.to_string()) },
+                               { qb.push_sql(", ") });
+                    qb.push_sql(") AND a IN (");
+                    interpose!(item, fts,
+                               { qb.push_sql(&item.to_string()) },
+                               { qb.push_sql(", ") });
+                    qb.push_sql(")");
+
+                    self.forward_cached_attributes.extend(fts.iter());
+                }
+                qb.push_sql(" ORDER BY a ASC, e ASC");
+            },
+        };
+
+        let SQLQuery { sql, args } = qb.finish();
+        assert!(args.is_empty());                       // TODO: we know there are never args, but we'd like to run this query 'properly'.
+        let mut stmt = sqlite.prepare(sql.as_str())?;
+        let replacing = false;
+        self.repopulate_from_aevt(schema, &mut stmt, vec![], replacing)
+    }
+
+    pub fn forward_attribute_cache_for_attribute<'a, 's>(&'a self, schema: &'s Schema, a: Entid) -> Option<&'a AttributeCache> {
+        if !self.forward_cached_attributes.contains(&a) {
+            return None;
+        }
+        schema.attribute_for_entid(a)
+              .and_then(|attr|
+                if attr.multival {
+                    self.multi_vals.get(&a).map(|v| v as &AttributeCache)
+                } else {
+                    self.single_vals.get(&a).map(|v| v as &AttributeCache)
+                })
+    }
+
+    // Ensure that `entities` is unique.
+    pub fn extend_cache_for_entities_and_attributes<'s, 'c>(&mut self,
+                                                            schema: &'s Schema,
+                                                            sqlite: &'c rusqlite::Connection,
+                                                            mut attrs: AttributeSpec,
+                                                            entities: &Vec<Entid>) -> Result<()> {
+        // TODO: Exclude any entities for which every attribute is known.
+        // TODO: initialize from an existing (complete) AttributeCache.
+
+        // Exclude any attributes for which every entity's value is already known.
+        match &mut attrs {
+            &mut AttributeSpec::All => {
+                // If we're caching all attributes, there's nothing we can exclude.
+            },
+            &mut AttributeSpec::Specified { ref mut non_fts, ref mut fts } => {
+                // Remove any attributes for which all entities are present in the cache (even
+                // as a 'miss').
+                let exclude_missing = |vec: &mut Vec<Entid>| {
+                    vec.retain(|a| {
+                        if let Some(attr) = schema.attribute_for_entid(*a) {
+                            if !self.forward_cached_attributes.contains(a) {
+                                // The attribute isn't cached at all. Do the work for all entities.
+                                return true;
+                            }
+
+                            // Return true if there are any entities missing for this attribute.
+                            if attr.multival {
+                                self.multi_vals
+                                    .get(&a)
+                                    .map(|cache| entities.iter().any(|e| !cache.has_e(*e)))
+                                    .unwrap_or(true)
+                            } else {
+                                self.single_vals
+                                    .get(&a)
+                                    .map(|cache| entities.iter().any(|e| !cache.has_e(*e)))
+                                    .unwrap_or(true)
+                            }
+                        } else {
+                            // Unknown attribute.
+                            false
+                        }
+                    });
+                };
+                exclude_missing(non_fts);
+                exclude_missing(fts);
+            },
+        }
+
+        self.populate_cache_for_entities_and_attributes(schema, sqlite, attrs, entities)
+    }
+
+    /// Ensure that `entities` is unique.
+    pub fn make_cache_for_entities_and_attributes<'s, 'c>(schema: &'s Schema,
+                                                          sqlite: &'c rusqlite::Connection,
+                                                          attrs: AttributeSpec,
+                                                          entities: &Vec<Entid>) -> Result<AttributeCaches> {
+        let mut cache = AttributeCaches::default();
+        cache.populate_cache_for_entities_and_attributes(schema, sqlite, attrs, entities)?;
+        Ok(cache)
+    }
+}
+
 
 impl CachedAttributes for AttributeCaches {
     fn get_values_for_entid(&self, schema: &Schema, attribute: Entid, entid: Entid) -> Option<&Vec<TypedValue>> {

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -24,6 +24,7 @@ extern crate time;
 
 #[macro_use] extern crate edn;
 extern crate mentat_core;
+extern crate mentat_sql;
 extern crate mentat_tx;
 extern crate mentat_tx_parser;
 

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -23,7 +23,7 @@ extern crate tabwriter;
 extern crate time;
 
 #[macro_use] extern crate edn;
-extern crate mentat_core;
+#[macro_use] extern crate mentat_core;
 extern crate mentat_sql;
 extern crate mentat_tx;
 extern crate mentat_tx_parser;
@@ -61,6 +61,7 @@ pub use schema::{
     AttributeBuilder,
     AttributeValidation,
 };
+
 pub use bootstrap::{
     CORE_SCHEMA_VERSION,
 };

--- a/parser-utils/src/macros.rs
+++ b/parser-utils/src/macros.rs
@@ -116,7 +116,7 @@ macro_rules! assert_parse_failure_contains {
         let input = edn::parse::value($input).expect("to be able to parse input as EDN");
         let par = $parser();
         let stream = input.atom_stream();
-        let result = par.skip(eof()).parse(stream).map(|x| x.0).map_err(|e| -> ::ValueParseError { e.into() });
+        let result = par.skip(eof()).parse(stream).map(|x| x.0).map_err(|e| -> $crate::ValueParseError { e.into() });
         assert!(format!("{:?}", result).contains($expected), "Expected {:?} to contain {:?}", result, $expected);
     }}
 }

--- a/query-algebrizer/src/clauses/mod.rs
+++ b/query-algebrizer/src/clauses/mod.rs
@@ -40,7 +40,10 @@ use mentat_core::{
 use mentat_core::counter::RcCounter;
 
 use mentat_query::{
+    Element,
+    FindSpec,
     NamespacedKeyword,
+    Pull,
     Variable,
     WhereClause,
 };
@@ -330,6 +333,21 @@ impl ConjoiningClauses {
                                .map(|(k, v)| (k.clone(), ValueTypeSet::of_one(*v))));
                 cc
             },
+        }
+    }
+}
+
+/// Early-stage query handling.
+impl ConjoiningClauses {
+    pub(crate) fn derive_types_from_find_spec(&mut self, find_spec: &FindSpec) {
+        for spec in find_spec.columns() {
+            match spec {
+                &Element::Pull(Pull { ref var, patterns: _ }) => {
+                    self.constrain_var_to_type(var.clone(), ValueType::Ref);
+                },
+                _ => {
+                },
+            }
         }
     }
 }

--- a/query-algebrizer/src/lib.rs
+++ b/query-algebrizer/src/lib.rs
@@ -279,6 +279,9 @@ pub fn algebrize_with_inputs(known: Known,
     let alias_counter = RcCounter::with_initial(counter);
     let mut cc = ConjoiningClauses::with_inputs_and_alias_counter(parsed.in_vars, inputs, alias_counter);
 
+    // This is so the rest of the query knows that `?x` is a ref if `(pull ?x …)` appears in `:find`.
+    cc.derive_types_from_find_spec(&parsed.find_spec);
+
     // Do we have a variable limit? If so, tell the CC that the var must be numeric.
     if let &Limit::Variable(ref var) = &parsed.limit {
         cc.constrain_var_to_long(var.clone());

--- a/query-algebrizer/src/lib.rs
+++ b/query-algebrizer/src/lib.rs
@@ -161,6 +161,10 @@ impl AlgebraicQuery {
         self.find_spec
             .columns()
             .all(|e| match e {
+                // Pull expressions are never fully bound.
+                // TODO: but the 'inside' of a pull expression certainly can be.
+                &Element::Pull(_) => false,
+
                 &Element::Variable(ref var) |
                 &Element::Corresponding(ref var) => self.cc.is_value_bound(var),
 

--- a/query-parser/src/parse.rs
+++ b/query-parser/src/parse.rs
@@ -1224,6 +1224,9 @@ mod test {
                                           PullConcreteAttribute::Ident(foo_baz.clone())),
                                   ],
                               }));
+        assert_parse_failure_contains!(Find::elem,
+                              "(pull ?x [* :foo/bar])",
+                              r#"errors: [Unexpected(Borrowed("wildcard with specified attributes"))]"#);
     }
 
     #[test]

--- a/query-projector/Cargo.toml
+++ b/query-projector/Cargo.toml
@@ -26,6 +26,9 @@ path = "../query"
 [dependencies.mentat_query_algebrizer]
 path = "../query-algebrizer"
 
+[dependencies.mentat_query_pull]
+path = "../query-pull"
+
 # Only for tests.
 [dev-dependencies.mentat_query_parser]
 path = "../query-parser"

--- a/query-projector/src/errors.rs
+++ b/query-projector/src/errors.rs
@@ -20,6 +20,8 @@ use mentat_query::{
     PlainSymbol,
 };
 
+use mentat_query_pull;
+
 use aggregates::{
     SimpleAggregationOp,
 };
@@ -72,5 +74,6 @@ error_chain! {
 
     links {
         DbError(mentat_db::Error, mentat_db::ErrorKind);
+        PullError(mentat_query_pull::errors::Error, mentat_query_pull::errors::ErrorKind);
     }
 }

--- a/query-projector/src/projectors/constant.rs
+++ b/query-projector/src/projectors/constant.rs
@@ -1,0 +1,66 @@
+// Copyright 2018 Mozilla
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+use std::rc::Rc;
+
+use ::{
+    Element,
+    FindSpec,
+    QueryOutput,
+    QueryResults,
+    Rows,
+    Schema,
+    rusqlite,
+};
+
+use ::errors::{
+    Result,
+};
+
+use super::{
+    Projector,
+};
+
+/// A projector that produces a `QueryResult` containing fixed data.
+/// Takes a boxed function that should return an empty result set of the desired type.
+pub struct ConstantProjector {
+    spec: Rc<FindSpec>,
+    results_factory: Box<Fn() -> QueryResults>,
+}
+
+impl ConstantProjector {
+    pub fn new(spec: Rc<FindSpec>, results_factory: Box<Fn() -> QueryResults>) -> ConstantProjector {
+        ConstantProjector {
+            spec: spec,
+            results_factory: results_factory,
+        }
+    }
+
+    pub fn project_without_rows<'stmt>(&self) -> Result<QueryOutput> {
+        let results = (self.results_factory)();
+        let spec = self.spec.clone();
+        Ok(QueryOutput {
+            spec: spec,
+            results: results,
+        })
+    }
+}
+
+// TODO: a ConstantProjector with non-constant pull expressions.
+
+impl Projector for ConstantProjector {
+    fn project<'stmt, 's>(&self, _schema: &Schema, _sqlite: &'s rusqlite::Connection, _rows: Rows<'stmt>) -> Result<QueryOutput> {
+        self.project_without_rows()
+    }
+
+    fn columns<'s>(&'s self) -> Box<Iterator<Item=&Element> + 's> {
+        self.spec.columns()
+    }
+}

--- a/query-projector/src/projectors/mod.rs
+++ b/query-projector/src/projectors/mod.rs
@@ -27,6 +27,7 @@ pub trait Projector {
 
 mod constant;
 mod simple;
+mod pull_two_stage;
 
 pub use self::constant::ConstantProjector;
 
@@ -35,4 +36,11 @@ pub(crate) use self::simple::{
     RelProjector,
     ScalarProjector,
     TupleProjector,
+};
+
+pub(crate) use self::pull_two_stage::{
+    CollTwoStagePullProjector,
+    RelTwoStagePullProjector,
+    ScalarTwoStagePullProjector,
+    TupleTwoStagePullProjector,
 };

--- a/query-projector/src/projectors/mod.rs
+++ b/query-projector/src/projectors/mod.rs
@@ -1,0 +1,38 @@
+// Copyright 2018 Mozilla
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+use super::{
+    Element,
+    Schema,
+    QueryOutput,
+    Rows,
+    rusqlite,
+};
+
+use super::errors::{
+    Result,
+};
+
+pub trait Projector {
+    fn project<'stmt, 's>(&self, schema: &Schema, sqlite: &'s rusqlite::Connection, rows: Rows<'stmt>) -> Result<QueryOutput>;
+    fn columns<'s>(&'s self) -> Box<Iterator<Item=&Element> + 's>;
+}
+
+mod constant;
+mod simple;
+
+pub use self::constant::ConstantProjector;
+
+pub(crate) use self::simple::{
+    CollProjector,
+    RelProjector,
+    ScalarProjector,
+    TupleProjector,
+};

--- a/query-projector/src/projectors/pull_two_stage.rs
+++ b/query-projector/src/projectors/pull_two_stage.rs
@@ -1,0 +1,336 @@
+// Copyright 2018 Mozilla
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+use std::rc::Rc;
+
+use std::iter::{
+    once,
+};
+
+use mentat_query_pull::{
+    Puller,
+};
+
+use mentat_core::{
+    Entid,
+};
+
+use ::{
+    Binding,
+    CombinedProjection,
+    Element,
+    FindSpec,
+    ProjectedElements,
+    QueryOutput,
+    QueryResults,
+    RelResult,
+    Row,
+    Rows,
+    Schema,
+    TypedIndex,
+    rusqlite,
+};
+
+use ::pull::{
+    PullConsumer,
+    PullOperation,
+    PullTemplate,
+};
+
+use ::errors::{
+    Result,
+};
+
+use super::{
+    Projector,
+};
+
+pub(crate) struct ScalarTwoStagePullProjector {
+    spec: Rc<FindSpec>,
+    puller: Puller,
+}
+
+// TODO: almost by definition, a scalar result format doesn't need to be run in two stages.
+// The only output is the pull expression, and so we can directly supply the projected entity
+// to the pull SQL.
+impl ScalarTwoStagePullProjector {
+    fn with_template(schema: &Schema, spec: Rc<FindSpec>, pull: PullOperation) -> Result<ScalarTwoStagePullProjector> {
+        Ok(ScalarTwoStagePullProjector {
+            spec: spec,
+            puller: Puller::prepare(schema, pull.0.clone())?,
+        })
+    }
+
+    pub(crate) fn combine(schema: &Schema, spec: Rc<FindSpec>, mut elements: ProjectedElements) -> Result<CombinedProjection> {
+        let pull = elements.pulls.pop().expect("Expected a single pull");
+        let projector = Box::new(ScalarTwoStagePullProjector::with_template(schema, spec, pull.op)?);
+        let distinct = false;
+        elements.combine(projector, distinct)
+    }
+}
+
+impl Projector for ScalarTwoStagePullProjector {
+    fn project<'stmt, 's>(&self, schema: &Schema, sqlite: &'s rusqlite::Connection, mut rows: Rows<'stmt>) -> Result<QueryOutput> {
+        // Scalar is pretty straightforward -- zero or one entity, do the pull directly.
+        let results =
+            if let Some(r) = rows.next() {
+                let row = r?;
+                let entity: Entid = row.get(0);          // This will always be 0 and a ref.
+                let bindings = self.puller.pull(schema, sqlite, once(entity))?;
+                let m = Binding::Map(bindings.get(&entity).cloned().unwrap_or_else(Default::default));
+                QueryResults::Scalar(Some(m))
+            } else {
+                QueryResults::Scalar(None)
+            };
+
+        Ok(QueryOutput {
+            spec: self.spec.clone(),
+            results: results,
+        })
+    }
+
+    fn columns<'s>(&'s self) -> Box<Iterator<Item=&Element> + 's> {
+        self.spec.columns()
+    }
+}
+
+/// A tuple projector produces a single vector. It's the single-result version of rel.
+pub(crate) struct TupleTwoStagePullProjector {
+    spec: Rc<FindSpec>,
+    len: usize,
+    templates: Vec<TypedIndex>,
+    pulls: Vec<PullTemplate>,
+}
+
+impl TupleTwoStagePullProjector {
+    fn with_templates(spec: Rc<FindSpec>, len: usize, templates: Vec<TypedIndex>, pulls: Vec<PullTemplate>) -> TupleTwoStagePullProjector {
+        TupleTwoStagePullProjector {
+            spec: spec,
+            len: len,
+            templates: templates,
+            pulls: pulls,
+        }
+    }
+
+    // This is exactly the same as for rel.
+    fn collect_bindings<'a, 'stmt>(&self, row: Row<'a, 'stmt>) -> Result<Vec<Binding>> {
+        // There will be at least as many SQL columns as Datalog columns.
+        // gte 'cos we might be querying extra columns for ordering.
+        // The templates will take care of ignoring columns.
+        assert!(row.column_count() >= self.len as i32);
+        self.templates
+            .iter()
+            .map(|ti| ti.lookup(&row))
+            .collect::<Result<Vec<Binding>>>()
+    }
+
+    pub(crate) fn combine(spec: Rc<FindSpec>, column_count: usize, mut elements: ProjectedElements) -> Result<CombinedProjection> {
+        let projector = Box::new(TupleTwoStagePullProjector::with_templates(spec, column_count, elements.take_templates(), elements.take_pulls()));
+        let distinct = false;
+        elements.combine(projector, distinct)
+    }
+}
+
+impl Projector for TupleTwoStagePullProjector {
+    fn project<'stmt, 's>(&self, schema: &Schema, sqlite: &'s rusqlite::Connection, mut rows: Rows<'stmt>) -> Result<QueryOutput> {
+        let results =
+            if let Some(r) = rows.next() {
+                let row = r?;
+
+                // Keeping the compiler happy.
+                let pull_consumers: Result<Vec<PullConsumer>> = self.pulls
+                                                                    .iter()
+                                                                    .map(|op| PullConsumer::for_template(schema, op))
+                                                                    .collect();
+                let mut pull_consumers = pull_consumers?;
+
+                // Collect the usual bindings and accumulate entity IDs for pull.
+                for mut p in pull_consumers.iter_mut() {
+                    p.collect_entity(&row);
+                }
+
+                let mut bindings = self.collect_bindings(row)?;
+
+                // Run the pull expressions for the collected IDs.
+                for mut p in pull_consumers.iter_mut() {
+                    p.pull(sqlite)?;
+                }
+
+                // Expand the pull expressions back into the results vector.
+                for p in pull_consumers.iter_mut() {
+                    p.expand(&mut bindings);
+                    p.done();
+                }
+
+                QueryResults::Tuple(Some(bindings))
+            } else {
+                QueryResults::Tuple(None)
+            };
+        Ok(QueryOutput {
+            spec: self.spec.clone(),
+            results: results,
+        })
+    }
+
+    fn columns<'s>(&'s self) -> Box<Iterator<Item=&Element> + 's> {
+        self.spec.columns()
+    }
+}
+
+/// A rel projector produces a RelResult, which is a striding abstraction over a vector.
+/// Each stride across the vector is the same size, and sourced from the same columns.
+/// Each column in each stride is the result of taking one or two columns from
+/// the `Row`: one for the value and optionally one for the type tag.
+pub(crate) struct RelTwoStagePullProjector {
+    spec: Rc<FindSpec>,
+    len: usize,
+    templates: Vec<TypedIndex>,
+    pulls: Vec<PullTemplate>,
+}
+
+impl RelTwoStagePullProjector {
+    fn with_templates(spec: Rc<FindSpec>, len: usize, templates: Vec<TypedIndex>, pulls: Vec<PullTemplate>) -> RelTwoStagePullProjector {
+        RelTwoStagePullProjector {
+            spec: spec,
+            len: len,
+            templates: templates,
+            pulls: pulls,
+        }
+    }
+
+    fn collect_bindings_into<'a, 'stmt, 'out>(&self, row: Row<'a, 'stmt>, out: &mut Vec<Binding>) -> Result<()> {
+        // There will be at least as many SQL columns as Datalog columns.
+        // gte 'cos we might be querying extra columns for ordering.
+        // The templates will take care of ignoring columns.
+        assert!(row.column_count() >= self.len as i32);
+        let mut count = 0;
+        for binding in self.templates
+                           .iter()
+                           .map(|ti| ti.lookup(&row)) {
+            out.push(binding?);
+            count += 1;
+        }
+        assert_eq!(self.len, count);
+        Ok(())
+    }
+
+    pub(crate) fn combine(spec: Rc<FindSpec>, column_count: usize, mut elements: ProjectedElements) -> Result<CombinedProjection> {
+        let projector = Box::new(RelTwoStagePullProjector::with_templates(spec, column_count, elements.take_templates(), elements.take_pulls()));
+
+        // If every column yields only one value, or if this is an aggregate query
+        // (because by definition every column in an aggregate query is either
+        // aggregated or is a variable _upon which we group_), then don't bother
+        // with DISTINCT.
+        let already_distinct = elements.pre_aggregate_projection.is_some() ||
+                               projector.columns().all(|e| e.is_unit());
+
+        elements.combine(projector, !already_distinct)
+    }
+}
+
+impl Projector for RelTwoStagePullProjector {
+    fn project<'stmt, 's>(&self, schema: &Schema, sqlite: &'s rusqlite::Connection, mut rows: Rows<'stmt>) -> Result<QueryOutput> {
+        // Allocate space for five rows to start.
+        // This is better than starting off by doubling the buffer a couple of times, and will
+        // rapidly grow to support larger query results.
+        let width = self.len;
+        let mut values: Vec<_> = Vec::with_capacity(5 * width);
+
+        let pull_consumers: Result<Vec<PullConsumer>> = self.pulls
+                                                            .iter()
+                                                            .map(|op| PullConsumer::for_template(schema, op))
+                                                            .collect();
+        let mut pull_consumers = pull_consumers?;
+
+        // Collect the usual bindings and accumulate entity IDs for pull.
+        while let Some(r) = rows.next() {
+            let row = r?;
+            for mut p in pull_consumers.iter_mut() {
+                p.collect_entity(&row);
+            }
+            self.collect_bindings_into(row, &mut values)?;
+        }
+
+        // Run the pull expressions for the collected IDs.
+        for mut p in pull_consumers.iter_mut() {
+            p.pull(sqlite)?;
+        }
+
+        // Expand the pull expressions back into the results vector.
+        for bindings in values.chunks_mut(width) {
+            for p in pull_consumers.iter() {
+                p.expand(bindings);
+            }
+        };
+
+        Ok(QueryOutput {
+            spec: self.spec.clone(),
+            results: QueryResults::Rel(RelResult { width, values }),
+        })
+    }
+
+    fn columns<'s>(&'s self) -> Box<Iterator<Item=&Element> + 's> {
+        self.spec.columns()
+    }
+}
+
+/// A coll projector produces a vector of values.
+/// Each value is sourced from the same column.
+pub(crate) struct CollTwoStagePullProjector {
+    spec: Rc<FindSpec>,
+    pull: PullOperation,
+}
+
+impl CollTwoStagePullProjector {
+    fn with_pull(spec: Rc<FindSpec>, pull: PullOperation) -> CollTwoStagePullProjector {
+        CollTwoStagePullProjector {
+            spec: spec,
+            pull: pull,
+        }
+    }
+
+    pub(crate) fn combine(spec: Rc<FindSpec>, mut elements: ProjectedElements) -> Result<CombinedProjection> {
+        let pull = elements.pulls.pop().expect("Expected a single pull");
+        let projector = Box::new(CollTwoStagePullProjector::with_pull(spec, pull.op));
+
+        // If every column yields only one value, or we're grouping by the value,
+        // don't bother with DISTINCT. This shouldn't really apply to coll-pull.
+        let already_distinct = elements.pre_aggregate_projection.is_some() ||
+                               projector.columns().all(|e| e.is_unit());
+        elements.combine(projector, !already_distinct)
+    }
+}
+
+impl Projector for CollTwoStagePullProjector {
+    fn project<'stmt, 's>(&self, schema: &Schema, sqlite: &'s rusqlite::Connection, mut rows: Rows<'stmt>) -> Result<QueryOutput> {
+        let mut pull_consumer = PullConsumer::for_operation(schema, &self.pull)?;
+
+        while let Some(r) = rows.next() {
+            let row = r?;
+            pull_consumer.collect_entity(&row);
+        }
+
+        // Run the pull expressions for the collected IDs.
+        pull_consumer.pull(sqlite)?;
+
+        // Expand the pull expressions into a results vector.
+        let out = pull_consumer.to_coll_results();
+
+        Ok(QueryOutput {
+            spec: self.spec.clone(),
+            results: QueryResults::Coll(out),
+        })
+    }
+
+    fn columns<'s>(&'s self) -> Box<Iterator<Item=&Element> + 's> {
+        self.spec.columns()
+    }
+}
+

--- a/query-projector/src/projectors/pull_two_stage.rs
+++ b/query-projector/src/projectors/pull_two_stage.rs
@@ -164,9 +164,8 @@ impl Projector for TupleTwoStagePullProjector {
                 }
 
                 // Expand the pull expressions back into the results vector.
-                for p in pull_consumers.iter_mut() {
+                for p in pull_consumers.into_iter() {
                     p.expand(&mut bindings);
-                    p.done();
                 }
 
                 QueryResults::Tuple(Some(bindings))
@@ -321,7 +320,7 @@ impl Projector for CollTwoStagePullProjector {
         pull_consumer.pull(sqlite)?;
 
         // Expand the pull expressions into a results vector.
-        let out = pull_consumer.to_coll_results();
+        let out = pull_consumer.into_coll_results();
 
         Ok(QueryOutput {
             spec: self.spec.clone(),

--- a/query-projector/src/projectors/simple.rs
+++ b/query-projector/src/projectors/simple.rs
@@ -1,0 +1,253 @@
+// Copyright 2018 Mozilla
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+use std::rc::Rc;
+
+use ::{
+    Binding,
+    CombinedProjection,
+    Element,
+    FindSpec,
+    ProjectedElements,
+    QueryOutput,
+    QueryResults,
+    RelResult,
+    Row,
+    Rows,
+    Schema,
+    TypedIndex,
+    rusqlite,
+};
+
+use ::errors::{
+    Result,
+};
+
+use super::{
+    Projector,
+};
+
+pub(crate) struct ScalarProjector {
+    spec: Rc<FindSpec>,
+    template: TypedIndex,
+}
+
+impl ScalarProjector {
+    fn with_template(spec: Rc<FindSpec>, template: TypedIndex) -> ScalarProjector {
+        ScalarProjector {
+            spec: spec,
+            template: template,
+        }
+    }
+
+    pub(crate) fn combine(spec: Rc<FindSpec>, mut elements: ProjectedElements) -> Result<CombinedProjection> {
+        let template = elements.templates.pop().expect("Expected a single template");
+        let projector = Box::new(ScalarProjector::with_template(spec, template));
+        let distinct = false;
+        elements.combine(projector, distinct)
+    }
+}
+
+impl Projector for ScalarProjector {
+    fn project<'stmt, 's>(&self, _schema: &Schema, _sqlite: &'s rusqlite::Connection, mut rows: Rows<'stmt>) -> Result<QueryOutput> {
+        let results =
+            if let Some(r) = rows.next() {
+                let row = r?;
+                let binding = self.template.lookup(&row)?;
+                QueryResults::Scalar(Some(binding))
+            } else {
+                QueryResults::Scalar(None)
+            };
+        Ok(QueryOutput {
+            spec: self.spec.clone(),
+            results: results,
+        })
+    }
+
+    fn columns<'s>(&'s self) -> Box<Iterator<Item=&Element> + 's> {
+        self.spec.columns()
+    }
+}
+
+/// A tuple projector produces a single vector. It's the single-result version of rel.
+pub(crate) struct TupleProjector {
+    spec: Rc<FindSpec>,
+    len: usize,
+    templates: Vec<TypedIndex>,
+}
+
+impl TupleProjector {
+    fn with_templates(spec: Rc<FindSpec>, len: usize, templates: Vec<TypedIndex>) -> TupleProjector {
+        TupleProjector {
+            spec: spec,
+            len: len,
+            templates: templates,
+        }
+    }
+
+    // This is just like we do for `rel`, but into a vec of its own.
+    fn collect_bindings<'a, 'stmt>(&self, row: Row<'a, 'stmt>) -> Result<Vec<Binding>> {
+        // There will be at least as many SQL columns as Datalog columns.
+        // gte 'cos we might be querying extra columns for ordering.
+        // The templates will take care of ignoring columns.
+        assert!(row.column_count() >= self.len as i32);
+        self.templates
+            .iter()
+            .map(|ti| ti.lookup(&row))
+            .collect::<Result<Vec<Binding>>>()
+    }
+
+    pub(crate) fn combine(spec: Rc<FindSpec>, column_count: usize, mut elements: ProjectedElements) -> Result<CombinedProjection> {
+        let projector = Box::new(TupleProjector::with_templates(spec, column_count, elements.take_templates()));
+        let distinct = false;
+        elements.combine(projector, distinct)
+    }
+}
+
+impl Projector for TupleProjector {
+    fn project<'stmt, 's>(&self, _schema: &Schema, _sqlite: &'s rusqlite::Connection, mut rows: Rows<'stmt>) -> Result<QueryOutput> {
+        let results =
+            if let Some(r) = rows.next() {
+                let row = r?;
+                let bindings = self.collect_bindings(row)?;
+                QueryResults::Tuple(Some(bindings))
+            } else {
+                QueryResults::Tuple(None)
+            };
+        Ok(QueryOutput {
+            spec: self.spec.clone(),
+            results: results,
+        })
+    }
+
+    fn columns<'s>(&'s self) -> Box<Iterator<Item=&Element> + 's> {
+        self.spec.columns()
+    }
+}
+
+/// A rel projector produces a RelResult, which is a striding abstraction over a vector.
+/// Each stride across the vector is the same size, and sourced from the same columns.
+/// Each column in each stride is the result of taking one or two columns from
+/// the `Row`: one for the value and optionally one for the type tag.
+pub(crate) struct RelProjector {
+    spec: Rc<FindSpec>,
+    len: usize,
+    templates: Vec<TypedIndex>,
+}
+
+impl RelProjector {
+    fn with_templates(spec: Rc<FindSpec>, len: usize, templates: Vec<TypedIndex>) -> RelProjector {
+        RelProjector {
+            spec: spec,
+            len: len,
+            templates: templates,
+        }
+    }
+
+    fn collect_bindings_into<'a, 'stmt, 'out>(&self, row: Row<'a, 'stmt>, out: &mut Vec<Binding>) -> Result<()> {
+        // There will be at least as many SQL columns as Datalog columns.
+        // gte 'cos we might be querying extra columns for ordering.
+        // The templates will take care of ignoring columns.
+        assert!(row.column_count() >= self.len as i32);
+        let mut count = 0;
+        for binding in self.templates
+                           .iter()
+                           .map(|ti| ti.lookup(&row)) {
+            out.push(binding?);
+            count += 1;
+        }
+        assert_eq!(self.len, count);
+        Ok(())
+    }
+
+    pub(crate) fn combine(spec: Rc<FindSpec>, column_count: usize, mut elements: ProjectedElements) -> Result<CombinedProjection> {
+        let projector = Box::new(RelProjector::with_templates(spec, column_count, elements.take_templates()));
+
+        // If every column yields only one value, or if this is an aggregate query
+        // (because by definition every column in an aggregate query is either
+        // aggregated or is a variable _upon which we group_), then don't bother
+        // with DISTINCT.
+        let already_distinct = elements.pre_aggregate_projection.is_some() ||
+                               projector.columns().all(|e| e.is_unit());
+        elements.combine(projector, !already_distinct)
+    }
+}
+
+impl Projector for RelProjector {
+    fn project<'stmt, 's>(&self, _schema: &Schema, _sqlite: &'s rusqlite::Connection, mut rows: Rows<'stmt>) -> Result<QueryOutput> {
+        // Allocate space for five rows to start.
+        // This is better than starting off by doubling the buffer a couple of times, and will
+        // rapidly grow to support larger query results.
+        let width = self.len;
+        let mut values: Vec<_> = Vec::with_capacity(5 * width);
+
+        while let Some(r) = rows.next() {
+            let row = r?;
+            self.collect_bindings_into(row, &mut values)?;
+        }
+
+        Ok(QueryOutput {
+            spec: self.spec.clone(),
+            results: QueryResults::Rel(RelResult { width, values }),
+        })
+    }
+
+    fn columns<'s>(&'s self) -> Box<Iterator<Item=&Element> + 's> {
+        self.spec.columns()
+    }
+}
+
+/// A coll projector produces a vector of values.
+/// Each value is sourced from the same column.
+pub(crate) struct CollProjector {
+    spec: Rc<FindSpec>,
+    template: TypedIndex,
+}
+
+impl CollProjector {
+    fn with_template(spec: Rc<FindSpec>, template: TypedIndex) -> CollProjector {
+        CollProjector {
+            spec: spec,
+            template: template,
+        }
+    }
+
+    pub(crate) fn combine(spec: Rc<FindSpec>, mut elements: ProjectedElements) -> Result<CombinedProjection> {
+        let template = elements.templates.pop().expect("Expected a single template");
+        let projector = Box::new(CollProjector::with_template(spec, template));
+
+        // If every column yields only one value, or if this is an aggregate query
+        // (because by definition every column in an aggregate query is either
+        // aggregated or is a variable _upon which we group_), then don't bother
+        // with DISTINCT.
+        let already_distinct = elements.pre_aggregate_projection.is_some() ||
+                               projector.columns().all(|e| e.is_unit());
+        elements.combine(projector, !already_distinct)
+    }
+}
+
+impl Projector for CollProjector {
+    fn project<'stmt, 's>(&self, _schema: &Schema, _sqlite: &'s rusqlite::Connection, mut rows: Rows<'stmt>) -> Result<QueryOutput> {
+        let mut out: Vec<_> = vec![];
+        while let Some(r) = rows.next() {
+            let row = r?;
+            let binding = self.template.lookup(&row)?;
+            out.push(binding);
+        }
+        Ok(QueryOutput {
+            spec: self.spec.clone(),
+            results: QueryResults::Coll(out),
+        })
+    }
+
+    fn columns<'s>(&'s self) -> Box<Iterator<Item=&Element> + 's> {
+        self.spec.columns()
+    }
+}

--- a/query-projector/src/pull.rs
+++ b/query-projector/src/pull.rs
@@ -44,7 +44,7 @@ pub(crate) struct PullOperation(pub(crate) Vec<PullAttributeSpec>);
 
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct PullIndices {
-    pub(crate) sql_index: Index,                   // SQLite row index.
+    pub(crate) sql_index: Index,                   // SQLite column index.
     pub(crate) output_index: usize,
 }
 
@@ -115,12 +115,7 @@ impl<'schema> PullConsumer<'schema> {
     }
 
     // TODO: do we need to include empty maps for entities that didn't match any pull?
-    pub(crate) fn to_coll_results(self) -> Vec<Binding> {
+    pub(crate) fn into_coll_results(self) -> Vec<Binding> {
         self.results.values().cloned().map(|vrc| Binding::Map(vrc)).collect()
-    }
-
-    pub(crate) fn done(&mut self) {
-        self.results.clear();
-        self.entities.clear();
     }
 }

--- a/query-projector/src/pull.rs
+++ b/query-projector/src/pull.rs
@@ -1,0 +1,126 @@
+// Copyright 2018 Mozilla
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+use std::collections::{
+    BTreeMap,
+    BTreeSet,
+};
+
+use mentat_core::{
+    Binding,
+    Entid,
+    Schema,
+    StructuredMap,
+    TypedValue,
+    ValueRc,
+};
+
+use mentat_query::{
+    PullAttributeSpec,
+};
+
+use mentat_query_pull::{
+    Puller,
+};
+
+use errors::{
+    Result,
+};
+
+use super::{
+    Index,
+    rusqlite,
+};
+
+#[derive(Clone, Debug)]
+pub(crate) struct PullOperation(pub(crate) Vec<PullAttributeSpec>);
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct PullIndices {
+    pub(crate) sql_index: Index,                   // SQLite row index.
+    pub(crate) output_index: usize,
+}
+
+impl PullIndices {
+    fn zero() -> PullIndices {
+        PullIndices {
+            sql_index: 0,
+            output_index: 0,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct PullTemplate {
+    pub(crate) indices: PullIndices,
+    pub(crate) op: PullOperation,
+}
+
+pub(crate) struct PullConsumer<'schema> {
+    indices: PullIndices,
+    schema: &'schema Schema,
+    puller: Puller,
+    entities: BTreeSet<Entid>,
+    results: BTreeMap<Entid, ValueRc<StructuredMap>>,
+}
+
+impl<'schema> PullConsumer<'schema> {
+    pub(crate) fn for_puller(puller: Puller, schema: &'schema Schema, indices: PullIndices) -> PullConsumer<'schema> {
+        PullConsumer {
+            indices: indices,
+            schema: schema,
+            puller: puller,
+            entities: Default::default(),
+            results: Default::default(),
+        }
+    }
+
+    pub(crate) fn for_template(schema: &'schema Schema, template: &PullTemplate) -> Result<PullConsumer<'schema>> {
+        let puller = Puller::prepare(schema, template.op.0.clone())?;
+        Ok(PullConsumer::for_puller(puller, schema, template.indices))
+    }
+
+    pub(crate) fn for_operation(schema: &'schema Schema, operation: &PullOperation) -> Result<PullConsumer<'schema>> {
+        let puller = Puller::prepare(schema, operation.0.clone())?;
+        Ok(PullConsumer::for_puller(puller, schema, PullIndices::zero()))
+    }
+
+    pub(crate) fn collect_entity<'a, 'stmt>(&mut self, row: &rusqlite::Row<'a, 'stmt>) -> Entid {
+        let entity = row.get(self.indices.sql_index);
+        self.entities.insert(entity);
+        entity
+    }
+
+    pub(crate) fn pull(&mut self, sqlite: &rusqlite::Connection) -> Result<()> {
+        let entities: Vec<Entid> = self.entities.iter().cloned().collect();
+        self.results = self.puller.pull(self.schema, sqlite, entities)?;
+        Ok(())
+    }
+
+    pub(crate) fn expand(&self, bindings: &mut [Binding]) {
+        if let Binding::Scalar(TypedValue::Ref(id)) = bindings[self.indices.output_index] {
+            if let Some(pulled) = self.results.get(&id).cloned() {
+                bindings[self.indices.output_index] = Binding::Map(pulled);
+            } else {
+                bindings[self.indices.output_index] = Binding::Map(ValueRc::new(Default::default()));
+            }
+        }
+    }
+
+    // TODO: do we need to include empty maps for entities that didn't match any pull?
+    pub(crate) fn to_coll_results(self) -> Vec<Binding> {
+        self.results.values().cloned().map(|vrc| Binding::Map(vrc)).collect()
+    }
+
+    pub(crate) fn done(&mut self) {
+        self.results.clear();
+        self.entities.clear();
+    }
+}

--- a/query-projector/tests/aggregates.rs
+++ b/query-projector/tests/aggregates.rs
@@ -84,7 +84,7 @@ fn test_aggregate_unsuitable_type() {
     let algebrized = algebrize(Known::for_schema(&schema), parsed).expect("query algebrizes");
 
     // … when we look at the projection list, we cannot reconcile the types.
-    assert!(query_projection(&algebrized).is_err());
+    assert!(query_projection(&schema, &algebrized).is_err());
 }
 
 #[test]
@@ -100,7 +100,7 @@ fn test_the_without_max_or_min() {
     let algebrized = algebrize(Known::for_schema(&schema), parsed).expect("query algebrizes");
 
     // … when we look at the projection list, we cannot reconcile the types.
-    let projection = query_projection(&algebrized);
+    let projection = query_projection(&schema, &algebrized);
     assert!(projection.is_err());
     use ::mentat_query_projector::errors::{
         ErrorKind,

--- a/query-pull/Cargo.toml
+++ b/query-pull/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "mentat_query_pull"
+version = "0.0.1"
+workspace = ".."
+
+[dependencies]
+error-chain = { git = "https://github.com/rnewman/error-chain", branch = "rnewman/sync" }
+
+[dependencies.rusqlite]
+version = "0.13"
+features = ["limits"]
+
+[dependencies.mentat_core]
+path = "../core"
+
+[dependencies.mentat_db]
+path = "../db"
+
+[dependencies.mentat_query]
+path = "../query"
+
+[dependencies.mentat_query_algebrizer]
+path = "../query-algebrizer"
+
+[dependencies.mentat_query_sql]
+path = "../query-sql"
+
+[dependencies.mentat_sql]
+path = "../sql"
+
+# Only for tests.
+[dev-dependencies.mentat_query_parser]
+path = "../query-parser"

--- a/query-pull/src/errors.rs
+++ b/query-pull/src/errors.rs
@@ -8,9 +8,20 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
+use mentat_core::{
+    Entid,
+};
+
 error_chain! {
     types {
         Error, ErrorKind, ResultExt, Result;
+    }
+
+    errors {
+        UnnamedAttribute(id: Entid) {
+            description("unnamed attribute")
+            display("attribute {:?} has no name", id)
+        }
     }
 
     links {

--- a/query-pull/src/errors.rs
+++ b/query-pull/src/errors.rs
@@ -1,0 +1,19 @@
+// Copyright 2018 Mozilla
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+error_chain! {
+    types {
+        Error, ErrorKind, ResultExt, Result;
+    }
+
+    links {
+        DbError(::mentat_db::Error, ::mentat_db::ErrorKind);
+    }
+}

--- a/query-pull/src/lib.rs
+++ b/query-pull/src/lib.rs
@@ -167,7 +167,7 @@ impl Puller {
         let mut attrs: BTreeSet<Entid> = Default::default();
         for attr in attributes.iter() {
             match attr {
-                PullAttributeSpec::Wildcard => {
+                &PullAttributeSpec::Wildcard => {
                     let attribute_ids = schema.attribute_map.keys();
                     for id in attribute_ids {
                         names.insert(*id, lookup_name(id));
@@ -175,15 +175,15 @@ impl Puller {
                     }
                     break;
                 },
-                PullAttributeSpec::Attribute(PullConcreteAttribute::Ident(ref i)) => {
+                &PullAttributeSpec::Attribute(PullConcreteAttribute::Ident(ref i)) => {
                     if let Some(entid) = schema.get_entid(i) {
                         names.insert(entid.into(), i.to_value_rc());
                         attrs.insert(entid.into());
                     }
                 },
-                PullAttributeSpec::Attribute(PullConcreteAttribute::Entid(id)) => {
-                    names.insert(*id, lookup_name(id));
-                    attrs.insert(*id);
+                &PullAttributeSpec::Attribute(PullConcreteAttribute::Entid(ref entid)) => {
+                    names.insert(*entid, lookup_name(entid));
+                    attrs.insert(*entid);
                 },
             }
         }

--- a/query-pull/src/lib.rs
+++ b/query-pull/src/lib.rs
@@ -1,0 +1,244 @@
+// Copyright 2018 Mozilla
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#![allow(dead_code)]
+
+///! A pull expression is a function.
+///!
+///! Its inputs are a store, a schema, and a set of bindings.
+///!
+///! Its output is a map whose keys are the input bindings and whose values are
+///! appropriate structured values to represent the pull expression.
+///!
+///! For example, the pull expression:
+///!
+///! ```edn
+///! (pull ?person [:person/name
+///!                :person/tattoo
+///!                {:person/friend [*]}])`
+///! ```
+///!
+///! will return values shaped like:
+///!
+///! ```edn
+///! {:person/name "Alice"                            ; Single-valued attribute
+///!                                                  ; Absence: Alice has no tattoos.
+///!  :person/friend [                                ; Multi-valued attribute.
+///!    {:person/name "Bob"                           ; Nesting and wildcard.
+///!     :person/pet ["Harrison", "Hoppy"]}]}
+///! ```
+///!
+///! There will be one such value for each input binding.
+///!
+///! We fetch layers of a pull expression iteratively: all attributes at the same
+///! 'level' can be fetched at the same time and accumulated into maps.
+///!
+///! Those maps are wrapped in `Rc` for two reasons:
+///! - They might occur multiple times when projected from a `:find` query.
+///! - They might refer to each other (consider recursion).
+///!
+///! A nested or recursive pull expression consumes values produced by earlier stages
+///! (the recursion with a smaller recursion limit and a growing 'seen' list),
+///! generating another layer of mappings.
+///!
+///! For example, you can imagine the nesting in the earlier pull expression being
+///! decomposed into two chained expressions:
+///!
+///! ```edn
+///! (chain
+///!   (pull ?person [:person/friend])
+///!   (pull ?friend [*]))
+///! ```
+
+#[macro_use]
+extern crate error_chain;
+
+extern crate rusqlite;
+
+extern crate mentat_core;
+extern crate mentat_db;
+extern crate mentat_query;
+extern crate mentat_query_algebrizer;
+extern crate mentat_query_sql;
+extern crate mentat_sql;
+
+use std::collections::{
+    BTreeMap,
+    BTreeSet,
+};
+
+use std::iter::{
+    once,
+};
+
+use mentat_core::{
+    Cloned,
+    Entid,
+    HasSchema,
+    NamespacedKeyword,
+    Schema,
+    StructuredMap,
+    ValueRc,
+};
+
+use mentat_db::cache;
+
+use mentat_query::{
+    PullAttributeSpec,
+    PullConcreteAttribute,
+};
+
+pub mod errors;
+
+use errors::{
+    Result,
+};
+
+type PullResults = BTreeMap<Entid, ValueRc<StructuredMap>>;
+
+pub fn pull_attributes_for_entity<A>(schema: &Schema,
+                                     db: &rusqlite::Connection,
+                                     entity: Entid,
+                                     attributes: A) -> Result<StructuredMap>
+    where A: IntoIterator<Item=Entid> {
+    let attrs = attributes.into_iter()
+                          .map(|e| PullAttributeSpec::Attribute(PullConcreteAttribute::Entid(e)))
+                          .collect();
+    Puller::prepare(schema, attrs)?
+        .pull(schema, db, once(entity))
+        .map(|m| m.into_iter()
+                  .next()
+                  .map(|(k, vs)| {
+                      assert_eq!(k, entity);
+                      vs.cloned()
+                  })
+                  .unwrap_or_else(StructuredMap::default))
+}
+
+pub fn pull_attributes_for_entities<E, A>(schema: &Schema,
+                                          db: &rusqlite::Connection,
+                                          entities: E,
+                                          attributes: A) -> Result<PullResults>
+    where E: IntoIterator<Item=Entid>,
+          A: IntoIterator<Item=Entid> {
+    let attrs = attributes.into_iter()
+                          .map(|e| PullAttributeSpec::Attribute(PullConcreteAttribute::Entid(e)))
+                          .collect();
+    Puller::prepare(schema, attrs)?
+        .pull(schema, db, entities)
+}
+
+/// A `Puller` constructs on demand a map from a provided set of entity IDs to a set of structured maps.
+pub struct Puller {
+    // The domain of this map is the set of attributes to fetch.
+    // The range is the set of aliases to use in the output.
+    attributes: BTreeMap<Entid, ValueRc<NamespacedKeyword>>,
+    attribute_spec: cache::AttributeSpec,
+}
+
+impl Puller {
+    pub fn prepare_simple_attributes(schema: &Schema, attributes: Vec<Entid>) -> Result<Puller> {
+        Puller::prepare(schema,
+                        attributes.into_iter()
+                                  .map(|e| PullAttributeSpec::Attribute(PullConcreteAttribute::Entid(e)))
+                                  .collect())
+    }
+
+    pub fn prepare(schema: &Schema, attributes: Vec<PullAttributeSpec>) -> Result<Puller> {
+        // TODO: eventually this entry point will handle aliasing and that kind of
+        // thing. For now it's just a convenience.
+
+        let lookup_name = |i: &Entid| {
+            // In the unlikely event that we have an attribute with no name, we invent one.
+            ValueRc::new(
+                schema.get_ident(*i)
+                      .cloned()
+                      .unwrap_or(NamespacedKeyword::new("attribute", format!("a{}", i).as_str())))
+        };
+
+        let mut names: BTreeMap<Entid, ValueRc<NamespacedKeyword>> = Default::default();
+        let mut attrs: BTreeSet<Entid> = Default::default();
+        for attr in attributes.iter() {
+            match attr {
+                PullAttributeSpec::Wildcard => {
+                    let attribute_ids = schema.attribute_map.keys();
+                    for id in attribute_ids {
+                        names.insert(*id, lookup_name(id));
+                        attrs.insert(*id);
+                    }
+                    break;
+                },
+                PullAttributeSpec::Attribute(PullConcreteAttribute::Ident(ref i)) => {
+                    if let Some(entid) = schema.get_entid(i) {
+                        names.insert(entid.into(), i.to_value_rc());
+                        attrs.insert(entid.into());
+                    }
+                },
+                PullAttributeSpec::Attribute(PullConcreteAttribute::Entid(id)) => {
+                    names.insert(*id, lookup_name(id));
+                    attrs.insert(*id);
+                },
+            }
+        }
+
+        Ok(Puller {
+            attributes: names,
+            attribute_spec: cache::AttributeSpec::specified(&attrs, schema),
+        })
+    }
+
+    pub fn pull<E>(&self,
+                   schema: &Schema,
+                   db: &rusqlite::Connection,
+                   entities: E) -> Result<PullResults>
+        where E: IntoIterator<Item=Entid> {
+        // We implement pull by:
+        // - Generating `AttributeCaches` for the provided attributes and entities.
+        //   TODO: it would be nice to invert the cache as we build it, rather than have to invert it here.
+        // - Recursing. (TODO: we'll need AttributeCaches to not overwrite in case of recursion! And
+        //   ideally not do excess work when some entity/attribute pairs are known.)
+        // - Building a structure by walking the pull expression with the caches.
+        //   TODO: aliases.
+        // TODO: limits.
+        // TODO: fts.
+
+        // Build a cache for these attributes and entities.
+        // TODO: use the store's existing cache!
+        let entities: Vec<Entid> = entities.into_iter().collect();
+        let cache = cache::AttributeCaches::make_cache_for_entities_and_attributes(
+            schema,
+            db,
+            self.attribute_spec.clone(),
+            &entities)?;
+
+        // Now construct the appropriate result format.
+        let mut maps = BTreeMap::new();
+        for (name, cache) in self.attributes.iter().filter_map(|(a, name)|
+            cache.forward_attribute_cache_for_attribute(schema, *a)
+                 .map(|cache| (name.clone(), cache))) {
+
+            for e in entities.iter() {
+                if let Some(binding) = cache.binding_for_e(*e) {
+                    let mut r = maps.entry(*e)
+                                    .or_insert(ValueRc::new(StructuredMap::default()));
+
+                    // Get into the inner map so we can accumulate a value.
+                    // We can unwrap here because we created all of these maps…
+                    let mut m = ValueRc::get_mut(r).unwrap();
+
+                    m.insert(name.clone(), binding);
+                }
+            }
+        }
+
+        Ok(maps)
+    }
+
+}

--- a/query-sql/src/lib.rs
+++ b/query-sql/src/lib.rs
@@ -9,7 +9,7 @@
 // specific language governing permissions and limitations under the License.
 
 extern crate regex;
-extern crate mentat_core;
+#[macro_use] extern crate mentat_core;
 extern crate mentat_query;
 extern crate mentat_query_algebrizer;
 extern crate mentat_sql;
@@ -252,42 +252,6 @@ fn push_column(qb: &mut QueryBuilder, col: &Column) -> BuildQueryResult {
 
 //---------------------------------------------------------
 // Turn that representation into SQL.
-
-
-/// A helper macro to sequentially process an iterable sequence,
-/// evaluating a block between each pair of items.
-///
-/// This is used to simply and efficiently produce output like
-///
-/// ```sql
-///   1, 2, 3
-/// ```
-///
-/// or
-///
-/// ```sql
-/// x = 1 AND y = 2
-/// ```
-///
-/// without producing an intermediate string sequence.
-macro_rules! interpose {
-    ( $name: pat, $across: expr, $body: block, $inter: block ) => {
-        interpose_iter!($name, $across.iter(), $body, $inter)
-    }
-}
-
-macro_rules! interpose_iter {
-    ( $name: pat, $across: expr, $body: block, $inter: block ) => {
-        let mut seq = $across;
-        if let Some($name) = seq.next() {
-            $body;
-            for $name in seq {
-                $inter;
-                $body;
-            }
-        }
-    }
-}
 
 impl QueryFragment for ColumnOrExpression {
     fn push_sql(&self, out: &mut QueryBuilder) -> BuildQueryResult {

--- a/query-translator/src/translate.rs
+++ b/query-translator/src/translate.rs
@@ -9,6 +9,7 @@
 // specific language governing permissions and limitations under the License.
 
 use mentat_core::{
+    Schema,
     SQLTypeAffinity,
     SQLValueType,
     SQLValueTypeSet,
@@ -439,10 +440,10 @@ fn re_project(mut inner: SelectQuery, projection: Projection) -> SelectQuery {
 
 /// Consume a provided `AlgebraicQuery` to yield a new
 /// `ProjectedSelect`.
-pub fn query_to_select(query: AlgebraicQuery) -> Result<ProjectedSelect> {
+pub fn query_to_select(schema: &Schema, query: AlgebraicQuery) -> Result<ProjectedSelect> {
     // TODO: we can't pass `query.limit` here if we aggregate during projection.
     // SQL-based aggregation -- `SELECT SUM(datoms00.e)` -- is fine.
-    query_projection(&query).map(|e| match e {
+    query_projection(schema, &query).map(|e| match e {
         Either::Left(constant) => ProjectedSelect::Constant(constant),
         Either::Right(CombinedProjection {
             sql_projection,

--- a/query-translator/tests/translate.rs
+++ b/query-translator/tests/translate.rs
@@ -101,7 +101,7 @@ fn inner_translate_with_inputs(schema: &Schema, query: &'static str, inputs: Que
     let known = Known::for_schema(schema);
     let parsed = parse_find_string(query).expect("parse to succeed");
     let algebrized = algebrize_with_inputs(known, parsed, 0, inputs).expect("algebrize to succeed");
-    query_to_select(algebrized).expect("translate to succeed")
+    query_to_select(schema, algebrized).expect("translate to succeed")
 }
 
 fn translate_with_inputs(schema: &Schema, query: &'static str, inputs: QueryInputs) -> SQLQuery {
@@ -249,7 +249,7 @@ fn test_bound_variable_limit_affects_types() {
     assert_eq!(Some(ValueType::Long),
                algebrized.cc.known_type(&Variable::from_valid_name("?limit")));
 
-    let select = query_to_select(algebrized).expect("query to translate");
+    let select = query_to_select(&schema, algebrized).expect("query to translate");
     let SQLQuery { sql, args } = query_to_sql(select);
 
     // TODO: this query isn't actually correct -- we don't yet algebrize for variables that are
@@ -340,7 +340,7 @@ fn test_unknown_ident() {
     assert!(algebrized.is_known_empty());
 
     // If you insist…
-    let select = query_to_select(algebrized).expect("query to translate");
+    let select = query_to_select(&schema, algebrized).expect("query to translate");
     assert_query_is_empty(select, FindSpec::FindRel(vec![var!(?x).into()]));
 }
 

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -573,10 +573,7 @@ pub enum Limit {
 /// Examples:
 ///
 /// ```rust
-/// # extern crate edn;
 /// # extern crate mentat_query;
-/// # use std::rc::Rc;
-/// # use edn::PlainSymbol;
 /// # use mentat_query::{Element, FindSpec, Variable};
 ///
 /// # fn main() {

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -486,18 +486,61 @@ impl PatternValuePlace {
     }
 }
 
-/*
-pub enum PullPattern {
-    Constant(Constant),
-    Variable(Variable),
+// Not yet used.
+// pub enum PullDefaultValue {
+//     EntidOrInteger(i64),
+//     IdentOrKeyword(Rc<NamespacedKeyword>),
+//     Constant(NonIntegerConstant),
+// }
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum PullConcreteAttribute {
+    Ident(Rc<NamespacedKeyword>),
+    Entid(i64),
 }
 
-pub struct Pull {
-    pub src: SrcVar,
-    pub var: Variable,
-    pub pattern: PullPattern,      // Constant, variable, or plain variable.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum PullAttributeSpec {
+    Wildcard,
+    Attribute(PullConcreteAttribute),
+    // PullMapSpec(Vec<…>),
+    // AttributeWithOpts(PullConcreteAttribute, …),
+    // LimitedAttribute(PullConcreteAttribute, u64),  // Limit nil => Attribute instead.
+    // DefaultedAttribute(PullConcreteAttribute, PullDefaultValue),
 }
-*/
+
+impl std::fmt::Display for PullConcreteAttribute {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            &PullConcreteAttribute::Ident(ref k) => {
+                write!(f, "{}", k)
+            },
+            &PullConcreteAttribute::Entid(i) => {
+                write!(f, "{}", i)
+            },
+        }
+    }
+}
+
+impl std::fmt::Display for PullAttributeSpec {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            &PullAttributeSpec::Wildcard => {
+                write!(f, "*")
+            },
+            &PullAttributeSpec::Attribute(ref a) => {
+                write!(f, "{}", a)
+            },
+        }
+    }
+}
+
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct Pull {
+    pub var: Variable,
+    pub patterns: Vec<PullAttributeSpec>,
+}
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct Aggregate {
@@ -516,7 +559,7 @@ pub enum Element {
     /// `max` or `min` cannot yield predictable behavior, and will err during
     /// algebrizing.
     Corresponding(Variable),
-    // Pull(Pull),             // TODO
+    Pull(Pull),
 }
 
 impl Element {
@@ -524,6 +567,7 @@ impl Element {
     pub fn is_unit(&self) -> bool {
         match self {
             &Element::Variable(_) => false,
+            &Element::Pull(_) => false,
             &Element::Aggregate(_) => true,
             &Element::Corresponding(_) => true,
         }
@@ -541,6 +585,13 @@ impl std::fmt::Display for Element {
         match self {
             &Element::Variable(ref var) => {
                 write!(f, "{}", var)
+            },
+            &Element::Pull(Pull { ref var, ref patterns }) => {
+                write!(f, "(pull {} [ ", var)?;
+                for p in patterns.iter() {
+                    write!(f, "{} ", p)?;
+                }
+                write!(f, "])")
             },
             &Element::Aggregate(ref agg) => {
                 match agg.args.len() {

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -161,6 +161,17 @@ pub struct Store {
 }
 
 impl Store {
+    /// Open a store at the supplied path, ensuring that it includes the bootstrap schema.
+    pub fn open(path: &str) -> Result<Store> {
+        let mut connection = ::new_connection(path)?;
+        let conn = Conn::connect(&mut connection)?;
+        Ok(Store {
+            conn: conn,
+            sqlite: connection,
+        })
+    }
+
+    /// Returns a totally blank store with no bootstrap schema. Use `open` instead.
     pub fn open_empty(path: &str) -> Result<Store> {
         if !path.is_empty() {
             if Path::new(path).exists() {
@@ -170,15 +181,6 @@ impl Store {
 
         let mut connection = ::new_connection(path)?;
         let conn = Conn::empty(&mut connection)?;
-        Ok(Store {
-            conn: conn,
-            sqlite: connection,
-        })
-    }
-
-    pub fn open(path: &str) -> Result<Store> {
-        let mut connection = ::new_connection(path)?;
-        let conn = Conn::connect(&mut connection)?;
         Ok(Store {
             conn: conn,
             sqlite: connection,

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -10,6 +10,10 @@
 
 #![allow(dead_code)]
 
+use std::collections::{
+    BTreeMap,
+};
+
 use std::fs::{
     File,
 };
@@ -41,7 +45,9 @@ use mentat_core::{
     KnownEntid,
     NamespacedKeyword,
     Schema,
+    StructuredMap,
     TypedValue,
+    ValueRc,
     ValueType,
 };
 
@@ -66,6 +72,11 @@ use mentat_db::{
 };
 
 use mentat_db::internal_types::TermWithTempIds;
+
+use mentat_query_pull::{
+    pull_attributes_for_entities,
+    pull_attributes_for_entity,
+};
 
 use mentat_tx;
 
@@ -208,6 +219,14 @@ pub trait Queryable {
         where E: Into<Entid>;
 }
 
+pub trait Pullable {
+    fn pull_attributes_for_entities<E, A>(&self, entities: E, attributes: A) -> Result<BTreeMap<Entid, ValueRc<StructuredMap>>>
+    where E: IntoIterator<Item=Entid>,
+          A: IntoIterator<Item=Entid>;
+    fn pull_attributes_for_entity<A>(&self, entity: Entid, attributes: A) -> Result<StructuredMap>
+    where A: IntoIterator<Item=Entid>;
+}
+
 pub trait Syncable {
     fn sync(&mut self, server_uri: &String, user_uuid: &String) -> Result<()>;
 }
@@ -259,6 +278,19 @@ impl<'a, 'c> Queryable for InProgressRead<'a, 'c> {
     }
 }
 
+impl<'a, 'c> Pullable for InProgressRead<'a, 'c> {
+    fn pull_attributes_for_entities<E, A>(&self, entities: E, attributes: A) -> Result<BTreeMap<Entid, ValueRc<StructuredMap>>>
+    where E: IntoIterator<Item=Entid>,
+          A: IntoIterator<Item=Entid> {
+        self.0.pull_attributes_for_entities(entities, attributes)
+    }
+
+    fn pull_attributes_for_entity<A>(&self, entity: Entid, attributes: A) -> Result<StructuredMap>
+    where A: IntoIterator<Item=Entid> {
+        self.0.pull_attributes_for_entity(entity, attributes)
+    }
+}
+
 impl<'a, 'c> Queryable for InProgress<'a, 'c> {
     fn q_once<T>(&self, query: &str, inputs: T) -> Result<QueryOutput>
         where T: Into<Option<QueryInputs>> {
@@ -307,6 +339,21 @@ impl<'a, 'c> Queryable for InProgress<'a, 'c> {
         where E: Into<Entid> {
         let known = Known::new(&self.schema, Some(&self.cache));
         lookup_value_for_attribute(&*(self.transaction), known, entity, attribute)
+    }
+}
+
+impl<'a, 'c> Pullable for InProgress<'a, 'c> {
+    fn pull_attributes_for_entities<E, A>(&self, entities: E, attributes: A) -> Result<BTreeMap<Entid, ValueRc<StructuredMap>>>
+    where E: IntoIterator<Item=Entid>,
+          A: IntoIterator<Item=Entid> {
+        pull_attributes_for_entities(&self.schema, &*(self.transaction), entities, attributes)
+            .map_err(|e| e.into())
+    }
+
+    fn pull_attributes_for_entity<A>(&self, entity: Entid, attributes: A) -> Result<StructuredMap>
+    where A: IntoIterator<Item=Entid> {
+        pull_attributes_for_entity(&self.schema, &*(self.transaction), entity, attributes)
+            .map_err(|e| e.into())
     }
 }
 
@@ -632,6 +679,19 @@ impl Queryable for Store {
     }
 }
 
+impl Pullable for Store {
+    fn pull_attributes_for_entities<E, A>(&self, entities: E, attributes: A) -> Result<BTreeMap<Entid, ValueRc<StructuredMap>>>
+    where E: IntoIterator<Item=Entid>,
+          A: IntoIterator<Item=Entid> {
+        self.conn.pull_attributes_for_entities(&self.sqlite, entities, attributes)
+    }
+
+    fn pull_attributes_for_entity<A>(&self, entity: Entid, attributes: A) -> Result<StructuredMap>
+    where A: IntoIterator<Item=Entid> {
+        self.conn.pull_attributes_for_entity(&self.sqlite, entity, attributes)
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum CacheDirection {
     Forward,
@@ -756,6 +816,29 @@ impl Conn {
                   known,
                   query,
                   inputs)
+    }
+
+    pub fn pull_attributes_for_entities<E, A>(&self,
+                                              sqlite: &rusqlite::Connection,
+                                              entities: E,
+                                              attributes: A) -> Result<BTreeMap<Entid, ValueRc<StructuredMap>>>
+        where E: IntoIterator<Item=Entid>,
+              A: IntoIterator<Item=Entid> {
+        let metadata = self.metadata.lock().unwrap();
+        let schema = &*metadata.schema;
+        pull_attributes_for_entities(schema, sqlite, entities, attributes)
+            .map_err(|e| e.into())
+    }
+
+    pub fn pull_attributes_for_entity<A>(&self,
+                                         sqlite: &rusqlite::Connection,
+                                         entity: Entid,
+                                         attributes: A) -> Result<StructuredMap>
+        where A: IntoIterator<Item=Entid> {
+        let metadata = self.metadata.lock().unwrap();
+        let schema = &*metadata.schema;
+        pull_attributes_for_entity(schema, sqlite, entity, attributes)
+            .map_err(|e| e.into())
     }
 
     pub fn lookup_values_for_attribute(&self,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -26,6 +26,7 @@ use mentat_query;
 use mentat_query_algebrizer;
 use mentat_query_parser;
 use mentat_query_projector;
+use mentat_query_pull;
 use mentat_query_translator;
 use mentat_sql;
 use mentat_tolstoy;
@@ -48,6 +49,7 @@ error_chain! {
         QueryError(mentat_query_algebrizer::Error, mentat_query_algebrizer::ErrorKind);   // Let's not leak the term 'algebrizer'.
         QueryParseError(mentat_query_parser::Error, mentat_query_parser::ErrorKind);
         ProjectorError(mentat_query_projector::errors::Error, mentat_query_projector::errors::ErrorKind);
+        PullError(mentat_query_pull::errors::Error, mentat_query_pull::errors::ErrorKind);
         TranslatorError(mentat_query_translator::Error, mentat_query_translator::ErrorKind);
         SqlError(mentat_sql::Error, mentat_sql::ErrorKind);
         TxParseError(mentat_tx_parser::Error, mentat_tx_parser::ErrorKind);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ extern crate mentat_query;
 extern crate mentat_query_algebrizer;
 extern crate mentat_query_parser;
 extern crate mentat_query_projector;
+extern crate mentat_query_pull;
 extern crate mentat_query_translator;
 extern crate mentat_sql;
 extern crate mentat_tolstoy;
@@ -124,6 +125,7 @@ pub use conn::{
     Conn,
     InProgress,
     Metadata,
+    Pullable,
     Queryable,
     Syncable,
     Store,

--- a/src/query.rs
+++ b/src/query.rs
@@ -388,9 +388,9 @@ pub fn q_uncached<'sqlite, 'schema, 'query, T>
     run_algebrized_query(known, sqlite, algebrized)
 }
 
-pub fn q_prepare<'sqlite, 'schema, 'query, T>
+pub fn q_prepare<'sqlite, 'schema, 'cache, 'query, T>
 (sqlite: &'sqlite rusqlite::Connection,
- known: Known<'schema, '_>,
+ known: Known<'schema, 'cache>,
  query: &'query str,
  inputs: T) -> PreparedResult<'sqlite>
         where T: Into<Option<QueryInputs>>

--- a/tests/pull.rs
+++ b/tests/pull.rs
@@ -1,0 +1,218 @@
+// Copyright 2018 Mozilla
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#[macro_use]
+extern crate mentat;
+extern crate mentat_core;
+extern crate mentat_query_pull;
+
+use std::collections::{
+    BTreeMap,
+    BTreeSet,
+};
+
+use std::path::{
+    Path,
+    PathBuf,
+};
+
+// TODO: re-export from Mentat.
+use mentat_core::{
+    Binding,
+    StructuredMap,
+    ValueRc,
+};
+
+use mentat::{
+    Entid,
+    HasSchema,
+    IntoResult,
+    NamespacedKeyword,
+    Pullable,
+    Queryable,
+    QueryInputs,
+    Store,
+    RelResult,
+    TypedValue,
+};
+
+fn fixture_path(rest: &str) -> PathBuf {
+    let fixtures = Path::new("fixtures/");
+    fixtures.join(Path::new(rest))
+}
+
+#[test]
+fn test_simple_pull() {
+    let beacon;
+    let capitol;
+    let beacon_district;
+    let capitol_district;
+
+    let mut store = Store::open("").expect("opened");
+    {
+        let mut in_progress = store.begin_transaction().expect("began");
+        in_progress.import(fixture_path("cities.schema")).expect("transacted schema");
+        let report = in_progress.import(fixture_path("all_seattle.edn")).expect("transacted data");
+
+        // These tempid strings come out of all_seattle.edn.
+        beacon = *report.tempids.get(&"a17592186045471".to_string()).expect("beacon");
+        beacon_district = *report.tempids.get(&"a17592186045450".to_string()).expect("beacon district");
+
+        capitol = *report.tempids.get(&"a17592186045439".to_string()).expect("capitol");
+        capitol_district = *report.tempids.get(&"a17592186045438".to_string()).expect("capitol district");
+
+        in_progress.commit().expect("committed");
+    }
+
+    let schema = store.conn().current_schema();
+    let district = schema.get_entid(&kw!(:neighborhood/district)).expect("district").0;
+    let name = schema.get_entid(&kw!(:neighborhood/name)).expect("name").0;
+    let attrs: BTreeSet<Entid> = vec![district, name].into_iter().collect();
+
+    // Find Beacon Hill and Capitol Hill via query.
+    let query = r#"[:find [?hood ...]
+                    :where
+                    (or [?hood :neighborhood/name "Beacon Hill"]
+                        [?hood :neighborhood/name "Capitol Hill"])]"#;
+    let hoods: BTreeSet<Entid> = store.q_once(query, None)
+                                      .into_coll_result()
+                                      .expect("hoods")
+                                      .into_iter()
+                                      .map(|b| {
+                                          b.val().and_then(|tv| tv.into_entid()).expect("scalar")
+                                      })
+                                      .collect();
+
+    println!("Hoods: {:?}", hoods);
+
+    // The query and the tempids agree.
+    assert_eq!(hoods, vec![beacon, capitol].into_iter().collect());
+
+    // Pull attributes of those two neighborhoods.
+    let pulled = store.begin_read().expect("read")
+                      .pull_attributes_for_entities(hoods, attrs)
+                      .expect("pulled");
+
+    // Here's what we expect:
+    let c: StructuredMap = vec![
+        (kw!(:neighborhood/name), "Capitol Hill".into()),
+        (kw!(:neighborhood/district), TypedValue::Ref(capitol_district)),
+    ].into();
+    let b: StructuredMap = vec![
+        (kw!(:neighborhood/name), "Beacon Hill".into()),
+        (kw!(:neighborhood/district), TypedValue::Ref(beacon_district)),
+    ].into();
+
+    let expected: BTreeMap<Entid, ValueRc<StructuredMap>>;
+    expected = vec![(capitol, c.into()), (beacon, b.into())].into_iter().collect();
+
+    assert_eq!(pulled, expected);
+
+    // Now test pull inside the query itself.
+    let query = r#"[:find ?hood (pull ?district [:district/name :district/region])
+                    :where
+                    (or [?hood :neighborhood/name "Beacon Hill"]
+                        [?hood :neighborhood/name "Capitol Hill"])
+                    [?hood :neighborhood/district ?district]
+                    :order ?hood]"#;
+    let results: RelResult<Binding> = store.begin_read().expect("read")
+                                           .q_once(query, None)
+                                           .into_rel_result()
+                                           .expect("results");
+
+    let beacon_district: Vec<(NamespacedKeyword, TypedValue)> = vec![
+        (kw!(:district/name), "Greater Duwamish".into()),
+        (kw!(:district/region), schema.get_entid(&NamespacedKeyword::new("region", "se")).unwrap().into())
+    ];
+    let beacon_district: StructuredMap = beacon_district.into();
+    let capitol_district: Vec<(NamespacedKeyword, TypedValue)> = vec![
+        (kw!(:district/name), "East".into()),
+        (kw!(:district/region), schema.get_entid(&NamespacedKeyword::new("region", "e")).unwrap().into())
+    ];
+    let capitol_district: StructuredMap = capitol_district.into();
+
+    let expected = RelResult {
+                       width: 2,
+                       values: vec![
+                           TypedValue::Ref(capitol).into(), capitol_district.into(),
+                           TypedValue::Ref(beacon).into(), beacon_district.into(),
+                       ].into(),
+                   };
+    assert_eq!(results, expected.clone());
+
+    // We can also prepare the query.
+    let reader = store.begin_read().expect("read");
+    let mut prepared = reader.q_prepare(query, None).expect("prepared");
+
+    assert_eq!(prepared.run(None)
+                       .into_rel_result()
+                       .expect("results"),
+               expected);
+
+    // Execute a scalar query where the body is constant.
+    // TODO: we shouldn't require `:where`; that makes this non-constant!
+    let query = r#"[:find (pull ?hood [:neighborhood/name]) . :in ?hood
+                    :where [?hood :neighborhood/district _]]"#;
+    let result = reader.q_once(query, QueryInputs::with_value_sequence(vec![(var!(?hood), TypedValue::Ref(beacon))]))
+                       .into_scalar_result()
+                       .expect("success")
+                       .expect("result");
+
+    let expected: StructuredMap = vec![(kw!(:neighborhood/name), TypedValue::from("Beacon Hill"))].into();
+    assert_eq!(result, expected.into());
+
+    // Collect the names and regions of all districts.
+    let query = r#"[:find [(pull ?district [:district/name :district/region]) ...]
+                    :where [_ :neighborhood/district ?district]]"#;
+    let results = reader.q_once(query, None)
+                        .into_coll_result()
+                        .expect("result");
+
+    let expected: Vec<StructuredMap> = vec![
+        vec![(kw!(:district/name), TypedValue::from("East")),
+            (kw!(:district/region), TypedValue::Ref(65556))].into(),
+        vec![(kw!(:district/name), TypedValue::from("Southwest")),
+            (kw!(:district/region), TypedValue::Ref(65559))].into(),
+        vec![(kw!(:district/name), TypedValue::from("Downtown")),
+            (kw!(:district/region), TypedValue::Ref(65560))].into(),
+        vec![(kw!(:district/name), TypedValue::from("Greater Duwamish")),
+            (kw!(:district/region), TypedValue::Ref(65557))].into(),
+        vec![(kw!(:district/name), TypedValue::from("Ballard")),
+            (kw!(:district/region), TypedValue::Ref(65561))].into(),
+        vec![(kw!(:district/name), TypedValue::from("Northeast")),
+            (kw!(:district/region), TypedValue::Ref(65555))].into(),
+        vec![(kw!(:district/name), TypedValue::from("Southeast")),
+            (kw!(:district/region), TypedValue::Ref(65557))].into(),
+        vec![(kw!(:district/name), TypedValue::from("Northwest")),
+            (kw!(:district/region), TypedValue::Ref(65561))].into(),
+        vec![(kw!(:district/name), TypedValue::from("Central")),
+            (kw!(:district/region), TypedValue::Ref(65556))].into(),
+        vec![(kw!(:district/name), TypedValue::from("Delridge")),
+            (kw!(:district/region), TypedValue::Ref(65559))].into(),
+        vec![(kw!(:district/name), TypedValue::from("Lake Union")),
+            (kw!(:district/region), TypedValue::Ref(65560))].into(),
+        vec![(kw!(:district/name), TypedValue::from("Magnolia/Queen Anne")),
+            (kw!(:district/region), TypedValue::Ref(65560))].into(),
+        vec![(kw!(:district/name), TypedValue::from("North")),
+            (kw!(:district/region), TypedValue::Ref(65555))].into(),
+        ];
+
+    let expected: Vec<Binding> = expected.into_iter().map(|m| m.into()).collect();
+    assert_eq!(results, expected);
+
+}
+
+// TEST:
+// - Constant query bodies in pull.
+// - Values that are present in the cache (=> constant pull, too).
+// - Pull for each kind of find spec.
+// - That the keys in each map are ValueRc::ptr_eq.
+// - Entity presence/absence when the pull expressions don't match anything.
+// - Aliases. (No parser support yet.)

--- a/tools/cli/src/mentat_cli/repl.rs
+++ b/tools/cli/src/mentat_cli/repl.rs
@@ -538,11 +538,15 @@ impl Repl {
 
     fn map_as_string(&self, value: &StructuredMap) -> String {
         let mut out: String = "{".to_string();
+        let mut first = true;
         for (k, v) in value.0.iter() {
+            if !first {
+                out.push_str(", ");
+                first = true;
+            }
             out.push_str(&k.to_string());
-            out.push_str(": ");
+            out.push_str(" ");
             out.push_str(self.binding_as_string(v).as_str());
-            out.push_str(", ");
         }
         out.push_str("}");
         out

--- a/tools/cli/src/mentat_cli/repl.rs
+++ b/tools/cli/src/mentat_cli/repl.rs
@@ -23,6 +23,10 @@ use time::{
     PreciseTime,
 };
 
+use mentat_core::{
+    StructuredMap,
+};
+
 use mentat::{
     CacheDirection,
     NamespacedKeyword,
@@ -423,14 +427,14 @@ impl Repl {
         match query_output.results {
             QueryResults::Scalar(v) => {
                 if let Some(val) = v {
-                    writeln!(output, "| {}\t |", &self.binding_as_string(val))?;
+                    writeln!(output, "| {}\t |", &self.binding_as_string(&val))?;
                 }
             },
 
             QueryResults::Tuple(vv) => {
                 if let Some(vals) = vv {
                     for val in vals {
-                        write!(output, "| {}\t", self.binding_as_string(val))?;
+                        write!(output, "| {}\t", self.binding_as_string(&val))?;
                     }
                     writeln!(output, "|")?;
                 }
@@ -438,14 +442,14 @@ impl Repl {
 
             QueryResults::Coll(vv) => {
                 for val in vv {
-                    writeln!(output, "| {}\t|", self.binding_as_string(val))?;
+                    writeln!(output, "| {}\t|", self.binding_as_string(&val))?;
                 }
             },
 
             QueryResults::Rel(vvv) => {
                 for vv in vvv {
                     for v in vv {
-                        write!(output, "| {}\t", self.binding_as_string(v))?;
+                        write!(output, "| {}\t", self.binding_as_string(&v))?;
                     }
                     writeln!(output, "|")?;
                 }
@@ -512,19 +516,42 @@ impl Repl {
         Ok(report)
     }
 
-    fn binding_as_string(&self, value: Binding) -> String {
+    fn binding_as_string(&self, value: &Binding) -> String {
         use self::Binding::*;
         match value {
-            Scalar(v) => self.value_as_string(v),
-            Map(_) => format!("TODO"),
-            Vec(_) => format!("TODO"),
+            Scalar(ref v) => self.value_as_string(v),
+            Map(ref v) => self.map_as_string(v),
+            Vec(ref v) => self.vec_as_string(v),
         }
     }
 
-    fn value_as_string(&self, value: TypedValue) -> String {
+    fn vec_as_string(&self, value: &Vec<Binding>) -> String {
+        let mut out: String = "[".to_string();
+        let vals: Vec<String> = value.iter()
+                                     .map(|v| self.binding_as_string(v))
+                                     .collect();
+
+        out.push_str(vals.join(", ").as_str());
+        out.push_str("]");
+        out
+    }
+
+    fn map_as_string(&self, value: &StructuredMap) -> String {
+        let mut out: String = "{".to_string();
+        for (k, v) in value.0.iter() {
+            out.push_str(&k.to_string());
+            out.push_str(": ");
+            out.push_str(self.binding_as_string(v).as_str());
+            out.push_str(", ");
+        }
+        out.push_str("}");
+        out
+    }
+
+    fn value_as_string(&self, value: &TypedValue) -> String {
         use self::TypedValue::*;
         match value {
-            Boolean(b) => if b { "true".to_string() } else { "false".to_string() },
+            Boolean(b) => if *b { "true".to_string() } else { "false".to_string() },
             Double(d) => format!("{}", d),
             Instant(i) => format!("{}", i),
             Keyword(k) => format!("{}", k),

--- a/tools/cli/src/mentat_cli/repl.rs
+++ b/tools/cli/src/mentat_cli/repl.rs
@@ -519,9 +519,9 @@ impl Repl {
     fn binding_as_string(&self, value: &Binding) -> String {
         use self::Binding::*;
         match value {
-            Scalar(ref v) => self.value_as_string(v),
-            Map(ref v) => self.map_as_string(v),
-            Vec(ref v) => self.vec_as_string(v),
+            &Scalar(ref v) => self.value_as_string(v),
+            &Map(ref v) => self.map_as_string(v),
+            &Vec(ref v) => self.vec_as_string(v),
         }
     }
 
@@ -551,14 +551,14 @@ impl Repl {
     fn value_as_string(&self, value: &TypedValue) -> String {
         use self::TypedValue::*;
         match value {
-            Boolean(b) => if *b { "true".to_string() } else { "false".to_string() },
-            Double(d) => format!("{}", d),
-            Instant(i) => format!("{}", i),
-            Keyword(k) => format!("{}", k),
-            Long(l) => format!("{}", l),
-            Ref(r) => format!("{}", r),
-            String(s) => format!("{:?}", s.to_string()),
-            Uuid(u) => format!("{}", u),
+            &Boolean(b) => if b { "true".to_string() } else { "false".to_string() },
+            &Double(d) => format!("{}", d),
+            &Instant(ref i) => format!("{}", i),
+            &Keyword(ref k) => format!("{}", k),
+            &Long(l) => format!("{}", l),
+            &Ref(r) => format!("{}", r),
+            &String(ref s) => format!("{:?}", s.to_string()),
+            &Uuid(ref u) => format!("{}", u),
         }
     }
 }


### PR DESCRIPTION
This reworks the projector, adds parsing and projection support for pull, and implements the actual pull mechanism itself on top of the attribute cache. Finally, it adds a rough implementation of display for the CLI.

This supports simple pull: either `(pull ?some-var [:x/y :z/a])` or `(pull ?some-var [*])`. We don't yet support depth, aliasing, limits, or recursion.