### PR TITLE
Implement (tx-log ...) function.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ chrono = "0.4"
 error-chain = { git = "https://github.com/rnewman/error-chain", branch = "rnewman/sync" }
 lazy_static = "0.2"
 time = "0.1"
-uuid = "0.5"
+uuid = { version = "0.5", features = ["v4", "serde"] }
 
 [dependencies.rusqlite]
 version = "0.13"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -9,7 +9,7 @@ enum-set = { git = "https://github.com/rnewman/enum-set" }
 lazy_static = "0.2"
 num = "0.1"
 ordered-float = { version = "0.5", features = ["serde"] }
-uuid = "0.5"
+uuid = { version = "0.5", features = ["v4", "serde"] }
 serde = { version = "1.0", features = ["rc"] }
 serde_derive = "1.0"
 

--- a/edn/Cargo.toml
+++ b/edn/Cargo.toml
@@ -16,7 +16,7 @@ itertools = "0.7"
 num = "0.1"
 ordered-float = "0.5"
 pretty = "0.2"
-uuid = "0.5"
+uuid = { version = "0.5", features = ["v4", "serde"] }
 serde = { version = "1.0", optional = true }
 serde_derive = { version = "1.0", optional = true }
 

--- a/query-algebrizer/src/clauses/mod.rs
+++ b/query-algebrizer/src/clauses/mod.rs
@@ -84,6 +84,7 @@ mod resolve;
 
 mod ground;
 mod fulltext;
+mod tx_log_api;
 mod where_fn;
 
 use validate::{
@@ -446,6 +447,10 @@ impl ConjoiningClauses {
                 Column::Variable(_) => {
                     // We don't need to handle expansion of attributes here. The subquery that
                     // produces the variable projection will do so.
+                    self.constrain_column_to_constant(table, column, bound_val);
+                },
+
+                Column::Transactions(_) => {
                     self.constrain_column_to_constant(table, column, bound_val);
                 },
 

--- a/query-algebrizer/src/clauses/resolve.rs
+++ b/query-algebrizer/src/clauses/resolve.rs
@@ -137,6 +137,14 @@ impl ConjoiningClauses {
         }
     }
 
+    /// Take a transaction ID function argument and turn it into a `QueryValue` suitable for use in
+    /// a concrete constraint.
+    pub(crate) fn resolve_tx_argument(&mut self, schema: &Schema, function: &PlainSymbol, position: usize, arg: FnArg) -> Result<QueryValue> {
+        // Under the hood there's nothing special about a transaction ID -- it's just another ref.
+        // In the future, we might handle instants specially.
+        self.resolve_ref_argument(schema, function, position, arg)
+    }
+
     /// Take a function argument and turn it into a `QueryValue` suitable for use in a concrete
     /// constraint.
     #[allow(dead_code)]

--- a/query-algebrizer/src/clauses/tx_log_api.rs
+++ b/query-algebrizer/src/clauses/tx_log_api.rs
@@ -1,0 +1,394 @@
+// Copyright 2018 Mozilla
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+use mentat_core::{
+    ValueType,
+};
+
+use mentat_query::{
+    Binding,
+    FnArg,
+    SrcVar,
+    VariableOrPlaceholder,
+    WhereFn,
+};
+
+use clauses::{
+    ConjoiningClauses,
+};
+
+use errors::{
+    BindingError,
+    ErrorKind,
+    Result,
+};
+
+use types::{
+    Column,
+    ColumnConstraint,
+    DatomsTable,
+    Inequality,
+    QualifiedAlias,
+    QueryValue,
+    SourceAlias,
+    TransactionsColumn,
+};
+
+use Known;
+
+impl ConjoiningClauses {
+    // Log in Query: tx-ids and tx-data
+    //
+    // The log API includes two convenience functions that are available within query. The tx-ids
+    // function takes arguments similar to txRange above, but returns a collection of transaction
+    // entity ids. You will typically use the collection binding form [?tx …] to capture the
+    // results.
+    //
+    // [(tx-ids ?log ?tx1 ?tx2) [?tx ...]]
+    //
+    // TODO: handle tx1 == 0 (more generally, tx1 < bootstrap::TX0) specially (no after constraint).
+    // TODO: allow tx2 to be missing (no before constraint).
+    // TODO: allow txK arguments to be instants.
+    // TODO: allow arbitrary additional attribute arguments that restrict the tx-ids to those
+    // transactions that impact one of the given attributes.
+    pub(crate) fn apply_tx_ids(&mut self, known: Known, where_fn: WhereFn) -> Result<()> {
+        if where_fn.args.len() != 3 {
+            bail!(ErrorKind::InvalidNumberOfArguments(where_fn.operator.clone(), where_fn.args.len(), 3));
+        }
+
+        if where_fn.binding.is_empty() {
+            // The binding must introduce at least one bound variable.
+            bail!(ErrorKind::InvalidBinding(where_fn.operator.clone(), BindingError::NoBoundVariable));
+        }
+
+        if !where_fn.binding.is_valid() {
+            // The binding must not duplicate bound variables.
+            bail!(ErrorKind::InvalidBinding(where_fn.operator.clone(), BindingError::RepeatedBoundVariable));
+        }
+
+        // We should have exactly one binding. Destructure it now.
+        let tx_var = match where_fn.binding {
+            Binding::BindRel(bindings) => {
+                let bindings_count = bindings.len();
+                if bindings_count != 1 {
+                    bail!(ErrorKind::InvalidBinding(where_fn.operator.clone(),
+                                                    BindingError::InvalidNumberOfBindings {
+                                                        number: bindings_count,
+                                                        expected: 1,
+                                                    }));
+                }
+                match bindings.into_iter().next().unwrap() {
+                    VariableOrPlaceholder::Placeholder => unreachable!("binding.is_empty()!"),
+                    VariableOrPlaceholder::Variable(v) => v,
+                }
+            },
+            Binding::BindColl(v) => v,
+            Binding::BindScalar(_) |
+            Binding::BindTuple(_) => {
+                bail!(ErrorKind::InvalidBinding(where_fn.operator.clone(), BindingError::ExpectedBindRelOrBindColl))
+            },
+        };
+
+        let mut args = where_fn.args.into_iter();
+
+        // TODO: process source variables.
+        match args.next().unwrap() {
+            FnArg::SrcVar(SrcVar::DefaultSrc) => {},
+            _ => bail!(ErrorKind::InvalidArgument(where_fn.operator.clone(), "source variable", 0)),
+        }
+
+        let tx1 = self.resolve_tx_argument(&known.schema, &where_fn.operator, 1, args.next().unwrap())?;
+        let tx2 = self.resolve_tx_argument(&known.schema, &where_fn.operator, 2, args.next().unwrap())?;
+
+        let transactions = self.next_alias_for_table(DatomsTable::Transactions);
+
+        self.from.push(SourceAlias(DatomsTable::Transactions, transactions.clone()));
+
+        // Bound variable must be a ref.
+        self.constrain_var_to_type(tx_var.clone(), ValueType::Ref);
+        if self.is_known_empty() {
+            return Ok(());
+        }
+
+        self.bind_column_to_var(known.schema, transactions.clone(), TransactionsColumn::Tx, tx_var.clone());
+
+        let after_constraint = ColumnConstraint::Inequality {
+            operator: Inequality::LessThanOrEquals,
+            left: tx1,
+            right: QueryValue::Column(QualifiedAlias(transactions.clone(), Column::Transactions(TransactionsColumn::Tx))),
+        };
+        self.wheres.add_intersection(after_constraint);
+
+        let before_constraint = ColumnConstraint::Inequality {
+            operator: Inequality::LessThan,
+            left: QueryValue::Column(QualifiedAlias(transactions.clone(), Column::Transactions(TransactionsColumn::Tx))),
+            right: tx2,
+        };
+        self.wheres.add_intersection(before_constraint);
+
+        Ok(())
+    }
+
+    pub(crate) fn apply_tx_data(&mut self, known: Known, where_fn: WhereFn) -> Result<()> {
+        if where_fn.args.len() != 2 {
+            bail!(ErrorKind::InvalidNumberOfArguments(where_fn.operator.clone(), where_fn.args.len(), 2));
+        }
+
+        if where_fn.binding.is_empty() {
+            // The binding must introduce at least one bound variable.
+            bail!(ErrorKind::InvalidBinding(where_fn.operator.clone(), BindingError::NoBoundVariable));
+        }
+
+        if !where_fn.binding.is_valid() {
+            // The binding must not duplicate bound variables.
+            bail!(ErrorKind::InvalidBinding(where_fn.operator.clone(), BindingError::RepeatedBoundVariable));
+        }
+
+        // We should have at most five bindings. Destructure them now.
+        let bindings = match where_fn.binding {
+            Binding::BindRel(bindings) => {
+                let bindings_count = bindings.len();
+                if bindings_count < 1 || bindings_count > 5 {
+                    bail!(ErrorKind::InvalidBinding(where_fn.operator.clone(),
+                                                    BindingError::InvalidNumberOfBindings {
+                                                        number: bindings.len(),
+                                                        expected: 5,
+                                                    }));
+                }
+                bindings
+            },
+            Binding::BindScalar(_) |
+            Binding::BindTuple(_) |
+            Binding::BindColl(_) => bail!(ErrorKind::InvalidBinding(where_fn.operator.clone(), BindingError::ExpectedBindRel)),
+        };
+        let mut bindings = bindings.into_iter();
+        let b_e = bindings.next().unwrap_or(VariableOrPlaceholder::Placeholder);
+        let b_a = bindings.next().unwrap_or(VariableOrPlaceholder::Placeholder);
+        let b_v = bindings.next().unwrap_or(VariableOrPlaceholder::Placeholder);
+        let b_tx = bindings.next().unwrap_or(VariableOrPlaceholder::Placeholder);
+        let b_op = bindings.next().unwrap_or(VariableOrPlaceholder::Placeholder);
+
+        let mut args = where_fn.args.into_iter();
+
+        // TODO: process source variables.
+        match args.next().unwrap() {
+            FnArg::SrcVar(SrcVar::DefaultSrc) => {},
+            _ => bail!(ErrorKind::InvalidArgument(where_fn.operator.clone(), "source variable", 0)),
+        }
+
+        let tx = self.resolve_tx_argument(&known.schema, &where_fn.operator, 1, args.next().unwrap())?;
+
+        let transactions = self.next_alias_for_table(DatomsTable::Transactions);
+
+        self.from.push(SourceAlias(DatomsTable::Transactions, transactions.clone()));
+
+        let tx_constraint = ColumnConstraint::Equals(
+            QualifiedAlias(transactions.clone(), Column::Transactions(TransactionsColumn::Tx)),
+            tx);
+        self.wheres.add_intersection(tx_constraint);
+
+        if let VariableOrPlaceholder::Variable(ref var) = b_e {
+            // It must be a ref.
+            self.constrain_var_to_type(var.clone(), ValueType::Ref);
+            if self.is_known_empty() {
+                return Ok(());
+            }
+
+            self.bind_column_to_var(known.schema, transactions.clone(), TransactionsColumn::Entity, var.clone());
+        }
+
+        if let VariableOrPlaceholder::Variable(ref var) = b_a {
+            // It must be a ref.
+            self.constrain_var_to_type(var.clone(), ValueType::Ref);
+            if self.is_known_empty() {
+                return Ok(());
+            }
+
+            self.bind_column_to_var(known.schema, transactions.clone(), TransactionsColumn::Attribute, var.clone());
+        }
+
+        if let VariableOrPlaceholder::Variable(ref var) = b_v {
+            self.bind_column_to_var(known.schema, transactions.clone(), TransactionsColumn::Value, var.clone());
+        }
+
+        if let VariableOrPlaceholder::Variable(ref var) = b_tx {
+            // It must be a ref.
+            self.constrain_var_to_type(var.clone(), ValueType::Ref);
+            if self.is_known_empty() {
+                return Ok(());
+            }
+
+            // TODO: this might be a programming error if var is our tx argument.  Perhaps we can be
+            // helpful in that case.
+            self.bind_column_to_var(known.schema, transactions.clone(), TransactionsColumn::Tx, var.clone());
+        }
+
+        if let VariableOrPlaceholder::Variable(ref var) = b_op {
+            // It must be a boolean.
+            self.constrain_var_to_type(var.clone(), ValueType::Boolean);
+            if self.is_known_empty() {
+                return Ok(());
+            }
+
+            self.bind_column_to_var(known.schema, transactions.clone(), TransactionsColumn::Added, var.clone());
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod testing {
+    use super::*;
+
+    use mentat_core::{
+        Schema,
+        TypedValue,
+        ValueType,
+    };
+
+    use mentat_query::{
+        Binding,
+        FnArg,
+        PlainSymbol,
+        Variable,
+    };
+
+    #[test]
+    fn test_apply_tx_ids() {
+        let mut cc = ConjoiningClauses::default();
+        let schema = Schema::default();
+
+        let known = Known::for_schema(&schema);
+
+        let op = PlainSymbol::new("tx-ids");
+        cc.apply_tx_ids(known, WhereFn {
+            operator: op,
+            args: vec![
+                FnArg::SrcVar(SrcVar::DefaultSrc),
+                FnArg::EntidOrInteger(1000),
+                FnArg::EntidOrInteger(2000),
+            ],
+            binding: Binding::BindRel(vec![VariableOrPlaceholder::Variable(Variable::from_valid_name("?tx")),
+            ]),
+        }).expect("to be able to apply_tx_ids");
+
+        assert!(!cc.is_known_empty());
+
+        // Finally, expand column bindings.
+        cc.expand_column_bindings();
+        assert!(!cc.is_known_empty());
+
+        let clauses = cc.wheres;
+        assert_eq!(clauses.len(), 2);
+
+        assert_eq!(clauses.0[0],
+                   ColumnConstraint::Inequality {
+                       operator: Inequality::LessThanOrEquals,
+                       left: QueryValue::TypedValue(TypedValue::Ref(1000)),
+                       right: QueryValue::Column(QualifiedAlias("transactions00".to_string(), Column::Transactions(TransactionsColumn::Tx))),
+                   }.into());
+
+        assert_eq!(clauses.0[1],
+                   ColumnConstraint::Inequality {
+                       operator: Inequality::LessThan,
+                       left: QueryValue::Column(QualifiedAlias("transactions00".to_string(), Column::Transactions(TransactionsColumn::Tx))),
+                       right: QueryValue::TypedValue(TypedValue::Ref(2000)),
+                   }.into());
+
+        let bindings = cc.column_bindings;
+        assert_eq!(bindings.len(), 1);
+
+        assert_eq!(bindings.get(&Variable::from_valid_name("?tx")).expect("column binding for ?tx").clone(),
+                   vec![QualifiedAlias("transactions00".to_string(), Column::Transactions(TransactionsColumn::Tx))]);
+
+        let known_types = cc.known_types;
+        assert_eq!(known_types.len(), 1);
+
+        assert_eq!(known_types.get(&Variable::from_valid_name("?tx")).expect("known types for ?tx").clone(),
+                   vec![ValueType::Ref].into_iter().collect());
+    }
+
+    #[test]
+    fn test_apply_tx_data() {
+        let mut cc = ConjoiningClauses::default();
+        let schema = Schema::default();
+
+        let known = Known::for_schema(&schema);
+
+        let op = PlainSymbol::new("tx-data");
+        cc.apply_tx_data(known, WhereFn {
+            operator: op,
+            args: vec![
+                FnArg::SrcVar(SrcVar::DefaultSrc),
+                FnArg::EntidOrInteger(1000),
+            ],
+            binding: Binding::BindRel(vec![
+                VariableOrPlaceholder::Variable(Variable::from_valid_name("?e")),
+                VariableOrPlaceholder::Variable(Variable::from_valid_name("?a")),
+                VariableOrPlaceholder::Variable(Variable::from_valid_name("?v")),
+                VariableOrPlaceholder::Variable(Variable::from_valid_name("?tx")),
+                VariableOrPlaceholder::Variable(Variable::from_valid_name("?added")),
+            ]),
+        }).expect("to be able to apply_tx_data");
+
+        assert!(!cc.is_known_empty());
+
+        // Finally, expand column bindings.
+        cc.expand_column_bindings();
+        assert!(!cc.is_known_empty());
+
+        let clauses = cc.wheres;
+        assert_eq!(clauses.len(), 1);
+
+        assert_eq!(clauses.0[0],
+                   ColumnConstraint::Equals(QualifiedAlias("transactions00".to_string(), Column::Transactions(TransactionsColumn::Tx)),
+                                            QueryValue::TypedValue(TypedValue::Ref(1000))).into());
+
+        let bindings = cc.column_bindings;
+        assert_eq!(bindings.len(), 5);
+
+        assert_eq!(bindings.get(&Variable::from_valid_name("?e")).expect("column binding for ?e").clone(),
+                   vec![QualifiedAlias("transactions00".to_string(), Column::Transactions(TransactionsColumn::Entity))]);
+
+        assert_eq!(bindings.get(&Variable::from_valid_name("?a")).expect("column binding for ?a").clone(),
+                   vec![QualifiedAlias("transactions00".to_string(), Column::Transactions(TransactionsColumn::Attribute))]);
+
+        assert_eq!(bindings.get(&Variable::from_valid_name("?v")).expect("column binding for ?v").clone(),
+                   vec![QualifiedAlias("transactions00".to_string(), Column::Transactions(TransactionsColumn::Value))]);
+
+        assert_eq!(bindings.get(&Variable::from_valid_name("?tx")).expect("column binding for ?tx").clone(),
+                   vec![QualifiedAlias("transactions00".to_string(), Column::Transactions(TransactionsColumn::Tx))]);
+
+        assert_eq!(bindings.get(&Variable::from_valid_name("?added")).expect("column binding for ?added").clone(),
+                   vec![QualifiedAlias("transactions00".to_string(), Column::Transactions(TransactionsColumn::Added))]);
+
+        let known_types = cc.known_types;
+        assert_eq!(known_types.len(), 4);
+
+        assert_eq!(known_types.get(&Variable::from_valid_name("?e")).expect("known types for ?e").clone(),
+                   vec![ValueType::Ref].into_iter().collect());
+
+        assert_eq!(known_types.get(&Variable::from_valid_name("?a")).expect("known types for ?a").clone(),
+                   vec![ValueType::Ref].into_iter().collect());
+
+        assert_eq!(known_types.get(&Variable::from_valid_name("?tx")).expect("known types for ?tx").clone(),
+                   vec![ValueType::Ref].into_iter().collect());
+
+        assert_eq!(known_types.get(&Variable::from_valid_name("?added")).expect("known types for ?added").clone(),
+                   vec![ValueType::Boolean].into_iter().collect());
+
+        let extracted_types = cc.extracted_types;
+        assert_eq!(extracted_types.len(), 1);
+
+        assert_eq!(extracted_types.get(&Variable::from_valid_name("?v")).expect("extracted types for ?v").clone(),
+                   QualifiedAlias("transactions00".to_string(), Column::Transactions(TransactionsColumn::ValueTypeTag)));
+    }
+}

--- a/query-algebrizer/src/clauses/where_fn.rs
+++ b/query-algebrizer/src/clauses/where_fn.rs
@@ -37,6 +37,8 @@ impl ConjoiningClauses {
         match where_fn.operator.0.as_str() {
             "fulltext" => self.apply_fulltext(known, where_fn),
             "ground" => self.apply_ground(known, where_fn),
+            "tx-data" => self.apply_tx_data(known, where_fn),
+            "tx-ids" => self.apply_tx_ids(known, where_fn),
             _ => bail!(ErrorKind::UnknownFunction(where_fn.operator.clone())),
         }
     }

--- a/query-algebrizer/src/errors.rs
+++ b/query-algebrizer/src/errors.rs
@@ -29,6 +29,11 @@ pub enum BindingError {
     /// than Datomic: we won't try to make sense of non-obvious (and potentially erroneous) bindings.
     ExpectedBindRel,
 
+    /// Expected `[[?x ?y]]` or `[?x ...]` but got some other type of binding.  Mentat is
+    /// deliberately more strict than Datomic: we won't try to make sense of non-obvious (and
+    /// potentially erroneous) bindings.
+    ExpectedBindRelOrBindColl,
+
     /// Expected `[?x1 … ?xN]` or `[[?x1 … ?xN]]` but got some other number of bindings.  Mentat is
     /// deliberately more strict than Datomic: we prefer placeholders to omission.
     InvalidNumberOfBindings { number: usize, expected: usize },

--- a/query-algebrizer/src/types.rs
+++ b/query-algebrizer/src/types.rs
@@ -127,6 +127,16 @@ impl DatomsColumn {
             ValueTypeTag => "value_type_tag",
         }
     }
+
+    /// The type of the `v` column is determined by the `value_type_tag` column.  Return the
+    /// associated column determining the type of this column, if there is one.
+    pub fn associated_type_tag_column(&self) -> Option<DatomsColumn> {
+        use self::DatomsColumn::*;
+        match *self {
+            Value => Some(ValueTypeTag),
+            _ => None,
+        }
+    }
 }
 
 impl ColumnName for DatomsColumn {
@@ -220,9 +230,12 @@ impl QualifiedAlias {
         QualifiedAlias(table, column.into())
     }
 
-    pub fn for_type_tag(&self) -> QualifiedAlias {
-        // TODO: this only makes sense for `DatomsColumn` tables.
-        QualifiedAlias(self.0.clone(), Column::Fixed(DatomsColumn::ValueTypeTag))
+    pub fn for_associated_type_tag(&self) -> Option<QualifiedAlias> {
+        match self.1 {
+            Column::Fixed(ref c) => c.associated_type_tag_column().map(Column::Fixed),
+            Column::Fulltext(_) => None,
+            Column::Variable(_) => None,
+        }.map(|d| QualifiedAlias(self.0.clone(), d))
     }
 }
 

--- a/query-sql/src/lib.rs
+++ b/query-sql/src/lib.rs
@@ -243,6 +243,10 @@ fn push_column(qb: &mut QueryBuilder, col: &Column) -> BuildQueryResult {
             Ok(())
         },
         &Column::Variable(ref vc) => push_variable_column(qb, vc),
+        &Column::Transactions(ref d) => {
+            qb.push_sql(d.as_str());
+            Ok(())
+        },
     }
 }
 

--- a/query-translator/src/translate.rs
+++ b/query-translator/src/translate.rs
@@ -170,7 +170,7 @@ impl ToConstraint for ColumnConstraint {
                 Constraint::equal(left.to_column(), right.to_column()),
 
             Equals(qa, QueryValue::PrimitiveLong(value)) => {
-                let tag_column = qa.for_type_tag().to_column();
+                let tag_column = qa.for_associated_type_tag().expect("an associated type tag alias").to_column();
                 let value_column = qa.to_column();
 
                 // A bare long in a query might match a ref, an instant, a long (obviously), or a


### PR DESCRIPTION
`tx-log` allows to query the transaction log efficiently.

@rnewman, can I get early feedback on this?  I haven't added the underlying `transaction_log` table yet; that's next.