### PR TITLE
Simplify RcCounter

### DIFF
--- a/core/src/counter.rs
+++ b/core/src/counter.rs
@@ -8,26 +8,22 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
+use std::cell::Cell;
 use std::rc::Rc;
-
-use std::sync::atomic::{
-    AtomicUsize,
-    Ordering,
-};
 
 #[derive(Clone)]
 pub struct RcCounter {
-    c: Rc<AtomicUsize>,
+    c: Rc<Cell<usize>>,
 }
 
 /// A simple shared counter.
 impl RcCounter {
     pub fn with_initial(value: usize) -> Self {
-        RcCounter { c: Rc::new(AtomicUsize::new(value)) }
+        RcCounter { c: Rc::new(Cell::new(value)) }
     }
 
     pub fn new() -> Self {
-        RcCounter { c: Rc::new(AtomicUsize::new(0)) }
+        RcCounter { c: Rc::new(Cell::new(0)) }
     }
 
     /// Return the next value in the sequence.
@@ -43,7 +39,8 @@ impl RcCounter {
     /// assert_eq!(c.next(), 6);
     /// ```
     pub fn next(&self) -> usize {
-        self.c.fetch_add(1, Ordering::SeqCst)
+        let current = self.c.get();
+        self.c.replace(current + 1)
     }
 }
 


### PR DESCRIPTION
Previously this used an AtomicUsize with Rc, which isn't consistent, Rc may only be used on a single thread, so there is no need to use atomic instructions for manipulating it. Using Arc makes this consistent.

Additionally, a monotonically increasing counter such as this is one of the canonical examples for when you want to use a relaxed memory ordering. All we care about in this case is that no two threads get the same value, and that subsequent calls to `next()` return increasing values for a given thread. The first is guaranteed by the use of atomic instructions, and the second by the data dependency inherent in fetch_add.

In particular, if you had the following:

```rust
// c0 and c1 are entirely different counters and
// not clones of eachother
let x = c0.next();
let y = c1.next();
```

Previously you had a strong guarantee that no thread would increment `c1` before `c0`, and now we don't (since c0 and c1 are separate, there's no data dependency as there is in the case where they're the same).

That won't matter in the cases we actually use, and seems very unlikely to matter in hypothetical future cases (It's possible we want to revisit this if we add methods to read the current state, but even then, `SeqCst` is a big hammer)