### PR TITLE
Optimize NamespacedKeyword (and NamespacedSymbol)

### DIFF
--- a/edn/Cargo.toml
+++ b/edn/Cargo.toml
@@ -20,6 +20,10 @@ uuid = { version = "0.5", features = ["v4", "serde"] }
 serde = { version = "1.0", optional = true }
 serde_derive = { version = "1.0", optional = true }
 
+[dev-dependencies]
+serde_test = "1.0"
+serde_json = "1.0"
+
 [features]
 serde_support = ["serde", "serde_derive"]
 

--- a/edn/src/lib.rs
+++ b/edn/src/lib.rs
@@ -22,6 +22,8 @@ extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 
+// Intentionally not pub
+mod namespaced_name;
 pub mod symbols;
 pub mod types;
 pub mod pretty_print;

--- a/edn/src/namespaced_name.rs
+++ b/edn/src/namespaced_name.rs
@@ -1,0 +1,220 @@
+// Copyright 2016 Mozilla
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+use std::cmp::{Ord, PartialOrd, Ordering};
+use std::fmt;
+
+#[cfg(feature = "serde_support")]
+use serde::{
+    de::{self, Deserialize, Deserializer},
+    ser::{Serialize, Serializer}
+};
+
+// Data storage for both NamespacedKeyword and NamespacedSymbol. This gets it's own module because
+// modifying it's fields is `unsafe`, and so we'd like to minimize the amount of code that can
+// touch it.
+#[derive(Clone, Eq, Hash, PartialEq)]
+pub struct NamespacedName {
+    // The bytes that make up the namespace followed directly by those
+    // that make up the name.
+    ns_and_name: String,
+
+    // The index (in bytes) into `ns_and_name` where the namespace ends and
+    // name begins.
+    //
+    // Important: The following invariants around `boundary` must be maintained
+    // for memory safety.
+    //
+    // 1. `boundary` must always be less than or equal to `ns_and_name.len()`.
+    // 2. `boundary` must be byte index that points to a character boundary,
+    //     and not point into the middle of a utf8 codepoint. That is,
+    //    `ns_and_name.is_char_boundary(boundary)` must always be true.
+    //
+    // These invariants are enforced by `NamespacedName::new()`, and since
+    // we never mutate `NamespacedName`s, that's the only place we need to
+    // worry about them.
+    boundary: usize,
+}
+
+impl NamespacedName {
+    #[inline]
+    pub fn new<T>(namespace: T, name: T) -> Self where T: AsRef<str> {
+        let n = name.as_ref();
+        let ns = namespace.as_ref();
+
+        // Note: These invariants are not required for safety. That is, if we
+        // decide to allow these we can safely remove them.
+        assert!(!n.is_empty(), "Symbols and keywords cannot be unnamed.");
+        assert!(!ns.is_empty(), "Symbols and keywords cannot have an empty non-null namespace.");
+
+        let mut dest = String::with_capacity(n.len() + ns.len());
+
+        dest.push_str(ns);
+        dest.push_str(n);
+
+        let boundary = ns.len();
+
+        NamespacedName {
+            ns_and_name: dest,
+            boundary: boundary,
+        }
+    }
+
+    #[inline]
+    pub fn namespace(&self) -> &str {
+        unsafe {
+            self.ns_and_name.slice_unchecked(0, self.boundary)
+        }
+    }
+
+    #[inline]
+    pub fn name(&self) -> &str {
+        unsafe {
+            self.ns_and_name.slice_unchecked(self.boundary, self.ns_and_name.len())
+        }
+    }
+
+    #[inline]
+    pub fn components<'a>(&'a self) -> (&'a str, &'a str) {
+        (self.namespace(), self.name())
+    }
+}
+
+// We can't derive these, since the derived version doesn't know how to interepret `ns_and_name`.
+impl PartialOrd for NamespacedName {
+    fn partial_cmp(&self, other: &NamespacedName) -> Option<Ordering> {
+        // Just use a lexicographic ordering.
+        self.components().partial_cmp(&other.components())
+    }
+}
+
+impl Ord for NamespacedName {
+    fn cmp(&self, other: &NamespacedName) -> Ordering {
+        self.components().cmp(&other.components())
+    }
+}
+
+// We could derive this, but it's really hard to make sense of as-is.
+impl fmt::Debug for NamespacedName {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("NamespacedName")
+           .field("namespace", &self.namespace())
+           .field("name", &self.name())
+           .finish()
+    }
+}
+
+// This is convoluted, but the basic idea is that since we don't want to rely on our input being
+// correct, we'll need to implement a custom serializer no matter what (e.g. we can't just
+// `derive(Deserialize)` since `unsafe` code depends on `self.boundary` being a valid index).
+//
+// We'd also like for users consuming our serialized data as e.g. JSON not to have to learn how we
+// store NamespacedName internally, since it's very much an implementation detail.
+//
+// We achieve both of these by implemeting a type that can serialize in way that's both user-
+// friendly and automatic (e.g. `derive`d), and just pass all work off to it in our custom
+// implementation of Serialize and Deserialize.
+#[cfg(feature = "serde_support")]
+#[cfg_attr(feature = "serde_support", serde(rename = "NamespacedName"))]
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
+struct SerializedNamespacedName<'a> {
+    namespace: &'a str,
+    name: &'a str,
+}
+
+#[cfg(feature = "serde_support")]
+impl<'de> Deserialize<'de> for NamespacedName {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: Deserializer<'de> {
+        let separated = SerializedNamespacedName::deserialize(deserializer)?;
+        if separated.name.len() == 0 {
+            return Err(de::Error::custom("Empty name in keyword or symbol"));
+        }
+        if separated.namespace.len() == 0 {
+            return Err(de::Error::custom("Empty namespace in keyword or symbol"));
+        }
+        Ok(NamespacedName::new(separated.namespace, separated.name))
+    }
+}
+
+#[cfg(feature = "serde_support")]
+impl Serialize for NamespacedName {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
+        let ser = SerializedNamespacedName {
+            namespace: self.namespace(),
+            name: self.name(),
+        };
+        ser.serialize(serializer)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::panic;
+
+    #[test]
+    fn test_new_invariants_maintained() {
+        assert!(panic::catch_unwind(|| NamespacedName::new("", "foo")).is_err(),
+                "Empty namespace should panic");
+        assert!(panic::catch_unwind(|| NamespacedName::new("foo", "")).is_err(),
+                "Empty name should panic");
+        assert!(panic::catch_unwind(|| NamespacedName::new("", "")).is_err(),
+                "Should panic if both fields are empty");
+    }
+
+    #[test]
+    fn test_basic() {
+        let s = NamespacedName::new("aaaaa", "b");
+        assert_eq!(s.namespace(), "aaaaa");
+        assert_eq!(s.name(), "b");
+        assert_eq!(s.components(), ("aaaaa", "b"));
+
+        let s = NamespacedName::new("b", "aaaaa");
+        assert_eq!(s.name(), "aaaaa");
+        assert_eq!(s.namespace(), "b");
+        assert_eq!(s.components(), ("b", "aaaaa"));
+    }
+
+    #[test]
+    fn test_order() {
+        let n0 = NamespacedName::new("a", "aa");
+        let n1 = NamespacedName::new("aa", "a");
+
+        let n2 = NamespacedName::new("a", "ab");
+        let n3 = NamespacedName::new("aa", "b");
+
+        let n4 = NamespacedName::new("b", "ab");
+        let n5 = NamespacedName::new("ba", "b");
+
+        let n6 = NamespacedName::new("z", "zz");
+
+        let mut arr = [
+            n5.clone(),
+            n6.clone(),
+            n0.clone(),
+            n3.clone(),
+            n2.clone(),
+            n1.clone(),
+            n4.clone()
+        ];
+
+        arr.sort();
+
+        assert_eq!(arr, [
+            n0.clone(),
+            n2.clone(),
+            n1.clone(),
+            n3.clone(),
+            n4.clone(),
+            n5.clone(),
+            n6.clone(),
+        ]);
+    }
+}

--- a/edn/src/pretty_print.rs
+++ b/edn/src/pretty_print.rs
@@ -64,9 +64,9 @@ impl Value {
                     .append(pp.text("}"))
                     .group()
             }
-            Value::NamespacedSymbol(ref v) => pp.text(v.namespace.as_ref()).append("/").append(v.name.as_ref()),
+            Value::NamespacedSymbol(ref v) => pp.text(v.namespace()).append("/").append(v.name()),
             Value::PlainSymbol(ref v) => pp.text(v.0.as_ref()),
-            Value::NamespacedKeyword(ref v) => pp.text(":").append(v.namespace.as_ref()).append("/").append(v.name.as_ref()),
+            Value::NamespacedKeyword(ref v) => pp.text(":").append(v.namespace()).append("/").append(v.name()),
             Value::Keyword(ref v) => pp.text(":").append(v.0.as_ref()),
             Value::Text(ref v) => pp.text("\"").append(v.as_ref()).append("\""),
             Value::Uuid(ref u) => pp.text("#uuid \"").append(u.hyphenated().to_string()).append("\""),

--- a/edn/src/symbols.rs
+++ b/edn/src/symbols.rs
@@ -25,8 +25,8 @@ pub struct PlainSymbol(pub String);
 pub struct NamespacedSymbol {
     // We derive PartialOrd, which implements a lexicographic based
     // on the order of members, so put namespace first.
-    pub namespace: String,
-    pub name: String,
+    _namespace: String,
+    _name: String,
 }
 
 /// A keyword is a symbol, optionally with a namespace, that prints with a leading colon.
@@ -54,8 +54,8 @@ pub struct NamespacedSymbol {
 /// let bar     = Keyword::new("bar");                         // :bar
 /// let foo_bar = NamespacedKeyword::new("foo", "bar");        // :foo/bar
 /// assert_eq!("bar", bar.0);
-/// assert_eq!("bar", foo_bar.name);
-/// assert_eq!("foo", foo_bar.namespace);
+/// assert_eq!("bar", foo_bar.name());
+/// assert_eq!("foo", foo_bar.namespace());
 /// ```
 ///
 /// If you're not sure whether your input is well-formed, you should use a
@@ -74,8 +74,8 @@ pub struct Keyword(pub String);
 pub struct NamespacedKeyword {
     // We derive PartialOrd, which implements a lexicographic order based
     // on the order of members, so put namespace first.
-    pub namespace: String,
-    pub name: String,
+    _namespace: String,
+    _name: String,
 }
 
 impl PlainSymbol {
@@ -121,7 +121,22 @@ impl NamespacedSymbol {
         assert!(!n.is_empty(), "Symbols cannot be unnamed.");
         assert!(!ns.is_empty(), "Symbols cannot have an empty non-null namespace.");
 
-        NamespacedSymbol { name: n, namespace: ns }
+        NamespacedSymbol { _name: n, _namespace: ns }
+    }
+
+    #[inline]
+    pub fn name(&self) -> &str {
+        &self._name
+    }
+
+    #[inline]
+    pub fn namespace(&self) -> &str {
+        &self._namespace
+    }
+
+    #[inline]
+    pub fn components<'a>(&'a self) -> (&'a str, &'a str) {
+        (&self._namespace, &self._name)
     }
 }
 
@@ -154,9 +169,24 @@ impl NamespacedKeyword {
 
         // TODO: debug asserts to ensure that neither field matches [ :/].
         NamespacedKeyword {
-            name: n,
-            namespace: ns,
+            _name: n,
+            _namespace: ns,
         }
+    }
+
+    #[inline]
+    pub fn name(&self) -> &str {
+        &self._name
+    }
+
+    #[inline]
+    pub fn namespace(&self) -> &str {
+        &self._namespace
+    }
+
+    #[inline]
+    pub fn components<'a>(&'a self) -> (&'a str, &'a str) {
+        (&self._namespace, &self._name)
     }
 
     /// Whether this `NamespacedKeyword` should be interpreted in reverse order. For example,
@@ -177,9 +207,10 @@ impl NamespacedKeyword {
     /// assert!(!NamespacedKeyword::new("foo", "bar").is_backward());
     /// assert!(NamespacedKeyword::new("foo", "_bar").is_backward());
     /// ```
+
     #[inline]
     pub fn is_backward(&self) -> bool {
-        self.name.starts_with('_')
+        self._name.starts_with('_')
     }
 
     /// Whether this `NamespacedKeyword` should be interpreted in forward order.
@@ -214,14 +245,14 @@ impl NamespacedKeyword {
     /// ```
     pub fn to_reversed(&self) -> NamespacedKeyword {
         let name = if self.is_backward() {
-            self.name[1..].to_string()
+            self._name[1..].to_string()
         } else {
-            format!("{}{}", "_", self.name)
+            format!("{}{}", "_", self._name)
         };
 
         NamespacedKeyword {
-            name: name,
-            namespace: self.namespace.clone(),
+            _name: name,
+            _namespace: self._namespace.clone(),
         }
     }
 
@@ -241,8 +272,8 @@ impl NamespacedKeyword {
     pub fn unreversed(&self) -> Option<NamespacedKeyword> {
         if self.is_backward() {
             Some(NamespacedKeyword {
-                name: self.name[1..].to_string(),
-                namespace: self.namespace.clone(),
+                _name: self._name[1..].to_string(),
+                _namespace: self._namespace.clone(),
             })
         } else {
             None
@@ -278,7 +309,7 @@ impl Display for NamespacedSymbol {
     /// assert_eq!("bar/baz", NamespacedSymbol::new("bar", "baz").to_string());
     /// ```
     fn fmt(&self, f: &mut Formatter) -> ::std::fmt::Result {
-        write!(f, "{}/{}", self.namespace, self.name)
+        write!(f, "{}/{}", self._namespace, self._name)
     }
 }
 
@@ -308,7 +339,7 @@ impl Display for NamespacedKeyword {
     /// assert_eq!(":bar/baz", NamespacedKeyword::new("bar", "baz").to_reversed().to_reversed().to_string());
     /// ```
     fn fmt(&self, f: &mut Formatter) -> ::std::fmt::Result {
-        write!(f, ":{}/{}", self.namespace, self.name)
+        write!(f, ":{}/{}", self._namespace, self._name)
     }
 }
 

--- a/edn/tests/serde_support.rs
+++ b/edn/tests/serde_support.rs
@@ -1,0 +1,45 @@
+
+#![cfg(feature = "serde_support")]
+
+extern crate serde_test;
+extern crate serde_json;
+
+extern crate edn;
+use edn::symbols::NamespacedKeyword;
+use serde_test::{assert_tokens, Token};
+
+#[cfg(feature = "serde_support")]
+#[test]
+fn test_serialize_keyword() {
+    let kw = NamespacedKeyword::new("foo", "bar");
+    assert_tokens(&kw, &[
+        Token::NewtypeStruct { name: "NamespacedKeyword" },
+        Token::Struct { name: "NamespacedName", len: 2 },
+        Token::Str("namespace"),
+        Token::BorrowedStr("foo"),
+        Token::Str("name"),
+        Token::BorrowedStr("bar"),
+        Token::StructEnd,
+    ]);
+}
+
+
+#[cfg(feature = "serde_support")]
+#[test]
+fn test_deserialize_keyword() {
+    let json = r#"{"name": "foo", "namespace": "bar"}"#;
+    let kw = serde_json::from_str::<NamespacedKeyword>(json).unwrap();
+    assert_eq!(kw.name(), "foo");
+    assert_eq!(kw.namespace(), "bar");
+
+    let bad_ns_json = r#"{"name": "foo", "namespace": ""}"#;
+    let not_kw = serde_json::from_str::<NamespacedKeyword>(bad_ns_json);
+    assert!(not_kw.is_err());
+
+    let bad_ns_json = r#"{"name": "", "namespace": "bar"}"#;
+    let not_kw = serde_json::from_str::<NamespacedKeyword>(bad_ns_json);
+    assert!(not_kw.is_err());
+}
+
+
+

--- a/parser-utils/src/value_and_span.rs
+++ b/parser-utils/src/value_and_span.rs
@@ -517,7 +517,7 @@ macro_rules! def_matches_namespaced_keyword {
         def_parser!($parser, $name, &'a edn::ValueAndSpan, {
             satisfy(|v: &'a edn::ValueAndSpan| {
                 match v.inner {
-                    edn::SpannedValue::NamespacedKeyword(ref s) => s.namespace.as_str() == $input_namespace && s.name.as_str() == $input_name,
+                    edn::SpannedValue::NamespacedKeyword(ref s) => s.namespace() == $input_namespace && s.name() == $input_name,
                     _ => false,
                 }
             })

--- a/query-algebrizer/tests/utils/mod.rs
+++ b/query-algebrizer/tests/utils/mod.rs
@@ -74,7 +74,7 @@ impl SchemaBuilder {
                                  keyword_name: T,
                                  value_type: ValueType,
                                  multival: bool) -> Self
-        where T: Into<String>
+        where T: AsRef<str>
     {
         self.define_attr(NamespacedKeyword::new(keyword_ns, keyword_name), Attribute {
             value_type,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,18 +76,18 @@ macro_rules! var {
 macro_rules! kw {
     ( : $ns:ident / $n:ident ) => {
         // We don't need to go through `new` -- `ident` is strict enough.
-        $crate::NamespacedKeyword {
-            namespace: stringify!($ns).into(),
-            name: stringify!($n).into(),
-        }
+        $crate::NamespacedKeyword::new(
+            stringify!($ns),
+            stringify!($n)
+        )
     };
 
     ( : $ns:ident$(. $nss:ident)+ / $n:ident ) => {
         // We don't need to go through `new` -- `ident` is strict enough.
-        $crate::NamespacedKeyword {
-            namespace: concat!(stringify!($ns) $(, ".", stringify!($nss))+).into(),
-            name: stringify!($n).into(),
-        }
+        $crate::NamespacedKeyword::new(
+            concat!(stringify!($ns) $(, ".", stringify!($nss))+),
+            stringify!($n)
+        )
     };
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,6 @@ macro_rules! var {
 #[macro_export]
 macro_rules! kw {
     ( : $ns:ident / $n:ident ) => {
-        // We don't need to go through `new` -- `ident` is strict enough.
         $crate::NamespacedKeyword::new(
             stringify!($ns),
             stringify!($n)
@@ -83,7 +82,6 @@ macro_rules! kw {
     };
 
     ( : $ns:ident$(. $nss:ident)+ / $n:ident ) => {
-        // We don't need to go through `new` -- `ident` is strict enough.
         $crate::NamespacedKeyword::new(
             concat!(stringify!($ns) $(, ".", stringify!($nss))+),
             stringify!($n)

--- a/src/query.rs
+++ b/src/query.rs
@@ -211,7 +211,7 @@ fn fetch_values<'sqlite>
 
 fn lookup_attribute(schema: &Schema, attribute: &NamespacedKeyword) -> Result<KnownEntid> {
     schema.get_entid(attribute)
-          .ok_or_else(|| ErrorKind::UnknownAttribute(attribute.name.clone()).into())
+          .ok_or_else(|| ErrorKind::UnknownAttribute(attribute.name().into()).into())
 }
 
 /// Return a single value for the provided entity and attribute.

--- a/tx-parser/benches/bench.rs
+++ b/tx-parser/benches/bench.rs
@@ -14,7 +14,7 @@ use mentat_tx_parser::Tx;
 fn bench_parse1(b: &mut Bencher) {
     let input = r#"[[:db/add 1 :test/val "a"]]"#;
     let parsed_edn = edn::parse::value(input).expect("to parse test input");
-    b.iter(|| Tx::parse(parsed_edn.clone()));
+    b.iter(|| Tx::parse(&parsed_edn));
 }
 
 #[bench]
@@ -47,5 +47,19 @@ fn bench_parse2(b: &mut Bencher) {
          [:db/add 25 :test/val "y"]
          [:db/add 26 :test/val "z"]]"#;
     let parsed_edn = edn::parse::value(input).expect("to parse test input");
-    b.iter(|| Tx::parse(parsed_edn.clone()));
+    b.iter(|| Tx::parse(&parsed_edn));
+}
+
+#[bench]
+fn bench_parse3(b: &mut Bencher) {
+    let input = include_str!("../../fixtures/cities.schema");
+    let parsed_edn = edn::parse::value(input).expect("to parse test input");
+    b.iter(|| Tx::parse(&parsed_edn));
+}
+
+#[bench]
+fn bench_parse4(b: &mut Bencher) {
+    let input = include_str!("../../fixtures/all_seattle.edn");
+    let parsed_edn = edn::parse::value(input).expect("to parse test input");
+    b.iter(|| Tx::parse(&parsed_edn));
 }


### PR DESCRIPTION
Currently NamespacedKeyword (and NamespacedSymbol) is effectively a tuple of two `String`s. This means that each instance of it will require two allocations, reading the data out of them will typically require two cache misses, etc. There are a number of ways this could be improved.

One way is interning, and the comments indicate in several places that we'd like *should* to doing this, however, the way Mentat is currently structured, I think this is not trivial<sup>[1](#f1)</sup>.

Another is just to store it in a single string, and remember the boundaries. That's what these patches do.

Aside from some additional code complexity (which is localized to the module implementing this optimization), there's no real downside here, and the upside is you'll have better cache locality for code that touches both the name and namespace, fewer allocations for most code, reduced memory usage for objects holding `NamespacedKeywords` (e.g. `std::mem::size_of::<NamespacedKeyword>()` is lower), cheaper creation of these keywords, and etc.

In theory at least, to be sure about that benchmarks are required, so the first patch fixes some issues in the tx-parser benchmark, and makes it parse the transactions with the seattle data from our fixtures. While using the tx-parser to benchmark this is not great representation of mentat as a whole<sup>[2](#f2)</sup>, it is probably reasonably accurate for a benchmark of code that uses keywords heavily, and (most importantly) it was already there.

Anyway, there's a little bit of `unsafe` inside `NamespacedName` now, but the code is still totally safe. There are two variants we need to maintain for safety, and both are maintained by `NamespacedName::new`, and reflected in comments for the `boundary` property.

One note: Do we intend to support the `serde_support` feature (in the `edn` crate)? It's not used on most types, and was certainly the hardest part of this patch to get working properly (note: using `derive(Deserialize)` on a type that requires that its fields maintain certain invariants for the sake of memory safety is a very bad idea). Regardless, this *does* work now, is safe, and has tests...

### Benchmarks

Anyway, the end result of this for me is quite a decent speedup on the tx-parser benchmark:

Before (no optimization -- it does have the first patch which fixes and extends the benchmarks though):
```
test bench_parse1 ... bench:       2,856 ns/iter (+/- 580)
test bench_parse2 ... bench:      51,548 ns/iter (+/- 8,617)
test bench_parse3 ... bench:     109,473 ns/iter (+/- 50,330)
test bench_parse4 ... bench:  11,773,658 ns/iter (+/- 1,575,618)
```

After (with optimization):
```
test bench_parse1 ... bench:       2,392 ns/iter (+/- 901)
test bench_parse2 ... bench:      44,803 ns/iter (+/- 16,559)
test bench_parse3 ... bench:      97,035 ns/iter (+/- 52,726)
test bench_parse4 ... bench:   9,439,930 ns/iter (+/- 1,370,286)
```

This varied across runs but these were relatively representative for me.

It would be nice to know how much that helps in more general cases, but it's actually better than I had expected. Of course, real workloads are going to be dominated by sqlite time, so this somewhat silly to work on (I actually waffled about submitting this PR for this reason, but it seems better to have than not), but it's bugged me for a while, and the kinds of things I work on during the day don't give me many opportunities to micro-optimize any more.

Anyway, you can try yourself with `cargo +nightly bench -p mentat_tx_parser` if you have a nightly build installed in rustup and feel like it. (Sadly, cargo bench is [going away](https://github.com/rust-lang/rfcs/pull/2287) soon, but supposedly something similar will replace it, and not require nightly).

---

<b id="f1">1</b> In particular, mentat treats keywords as value types and creates and extracts them all over the place. In the places we do intern things, we use reference counting, mostly to make the lifetimes bearable (I can think of ways to make this work with references, but none of them are as simple as Rc). Sadly, this is hardly ideal, since `Rc<String>` has a very real cost when compared with `&str`.

Rustc uses both [references](https://github.com/rust-lang/rust/blob/8830a0304327ba8c983555ac5d42cec0569c31bb/src/libsyntax_pos/symbol.rs#L364-L376) and [numeric handles to interned strings](https://github.com/rust-lang/rust/blob/8830a0304327ba8c983555ac5d42cec0569c31bb/src/libsyntax_pos/symbol.rs#L108) depending on the case, but it's worth noting that the lifetime there is a lie, and could result in UAF if used wrong (given that Mentat connections might be long lived, the "leak everything until task cleanup" strategy seems dodgy to me, unless we spawned a task for each query/transaction, which... dunno, might work?). Anyway, nothing prevents us from doing both, and the current representation seemed needlessly expensive to me.

<b id="f2">2</b> In general, it would be really good to get more benchmarks (both ones that use sqlite and ones that don't). There are certainly comments that say things about performance that are [dubious](https://github.com/mozilla/mentat/blob/0c31fc7875294fdf80f4caf253590999a9214e0d/edn/src/types.rs#L45-L47), and not having numbers to back this up doesn't help... Also, things like using `Rc` to avoid copy is not always a win, especially when the type it holds onto is small -- most keywords and symbols are quite short, and they are Rced in several places -- this might be the right choice, but it also could be bad for a lot of reasons. Measuring would remove doubt here.
