### PR TITLE
(tx) Replace :db/tx with (current-tx) transaction function and broade…

### DIFF
--- a/db/src/debug.rs
+++ b/db/src/debug.rs
@@ -172,7 +172,7 @@ pub(crate) fn datoms_after<S: Borrow<Schema>>(conn: &rusqlite::Connection, schem
 /// Return the sequence of transactions in the store with transaction ID strictly greater than the
 /// given `tx`, ordered by (tx, e, a, v).
 ///
-/// Each transaction returned includes the [:db/tx :db/txInstant ...] datom.
+/// Each transaction returned includes the [(transaction-tx) :db/txInstant ...] datom.
 pub(crate) fn transactions_after<S: Borrow<Schema>>(conn: &rusqlite::Connection, schema: &S, tx: i64) -> Result<Transactions> {
     let borrowed_schema = schema.borrow();
 


### PR DESCRIPTION
…n support. (#664)

:db/tx (and Datomic's version, :datomic/tx) suffer from the same
ambiguities that [a v] lookup references do -- determining the type of
the result is context sensitive.  (In this case, is :db/tx a reference
to the current transaction ID, or is it a valid keyword?)  This commit
addresses the ambiguity by introducing a notion of a transaction
functions, and provides a little scaffolding for adding more (should
the need arise).  I left the scaffolding in place rather than handling
just (current-tx) because I started trying to
implement (current-txInstant) as well, which is more difficult -- see
the comments.

It's worth noting that this approach generalizes more or less directly
to ?input variables, since those can be eagerly bound like the
implemented transaction function (current-tx).