### PR TITLE
Compile with Rust 1.25.

### DIFF
--- a/query-pull/src/lib.rs
+++ b/query-pull/src/lib.rs
@@ -167,7 +167,7 @@ impl Puller {
         let mut attrs: BTreeSet<Entid> = Default::default();
         for attr in attributes.iter() {
             match attr {
-                PullAttributeSpec::Wildcard => {
+                &PullAttributeSpec::Wildcard => {
                     let attribute_ids = schema.attribute_map.keys();
                     for id in attribute_ids {
                         names.insert(*id, lookup_name(id));
@@ -175,15 +175,15 @@ impl Puller {
                     }
                     break;
                 },
-                PullAttributeSpec::Attribute(PullConcreteAttribute::Ident(ref i)) => {
+                &PullAttributeSpec::Attribute(PullConcreteAttribute::Ident(ref i)) => {
                     if let Some(entid) = schema.get_entid(i) {
                         names.insert(entid.into(), i.clone());
                         attrs.insert(entid.into());
                     }
                 },
-                PullAttributeSpec::Attribute(PullConcreteAttribute::Entid(id)) => {
-                    names.insert(*id, lookup_name(id));
-                    attrs.insert(*id);
+                &PullAttributeSpec::Attribute(PullConcreteAttribute::Entid(ref entid)) => {
+                    names.insert(*entid, lookup_name(entid));
+                    attrs.insert(*entid);
                 },
             }
         }

--- a/src/query.rs
+++ b/src/query.rs
@@ -388,9 +388,9 @@ pub fn q_uncached<'sqlite, 'schema, 'query, T>
     run_algebrized_query(known, sqlite, algebrized)
 }
 
-pub fn q_prepare<'sqlite, 'schema, 'query, T>
+pub fn q_prepare<'sqlite, 'schema, 'cache, 'query, T>
 (sqlite: &'sqlite rusqlite::Connection,
- known: Known<'schema, '_>,
+ known: Known<'schema, 'cache>,
  query: &'query str,
  inputs: T) -> PreparedResult<'sqlite>
         where T: Into<Option<QueryInputs>>

--- a/tools/cli/src/mentat_cli/repl.rs
+++ b/tools/cli/src/mentat_cli/repl.rs
@@ -519,9 +519,9 @@ impl Repl {
     fn binding_as_string(&self, value: &Binding) -> String {
         use self::Binding::*;
         match value {
-            Scalar(ref v) => self.value_as_string(v),
-            Map(ref v) => self.map_as_string(v),
-            Vec(ref v) => self.vec_as_string(v),
+            &Scalar(ref v) => self.value_as_string(v),
+            &Map(ref v) => self.map_as_string(v),
+            &Vec(ref v) => self.vec_as_string(v),
         }
     }
 
@@ -551,14 +551,14 @@ impl Repl {
     fn value_as_string(&self, value: &TypedValue) -> String {
         use self::TypedValue::*;
         match value {
-            Boolean(b) => if *b { "true".to_string() } else { "false".to_string() },
-            Double(d) => format!("{}", d),
-            Instant(i) => format!("{}", i),
-            Keyword(k) => format!("{}", k),
-            Long(l) => format!("{}", l),
-            Ref(r) => format!("{}", r),
-            String(s) => format!("{:?}", s.to_string()),
-            Uuid(u) => format!("{}", u),
+            &Boolean(b) => if b { "true".to_string() } else { "false".to_string() },
+            &Double(d) => format!("{}", d),
+            &Instant(ref i) => format!("{}", i),
+            &Keyword(ref k) => format!("{}", k),
+            &Long(l) => format!("{}", l),
+            &Ref(r) => format!("{}", r),
+            &String(ref s) => format!("{:?}", s.to_string()),
+            &Uuid(ref u) => format!("{}", u),
         }
     }
 }


### PR DESCRIPTION
The only choice involved in this commit is that of replacing the
anonymous lifetime '_ with a named lifetime for the cache; since we're
accepting a Known, which includes the cache in question, I think it's
clear that we expect the function to apply to any given cache
lifetime.