### PR TITLE
Flip ValueRc to Arc in order to allow TypedValue in errors. (#677)

### DIFF
--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -121,7 +121,7 @@ impl<T: Clone> Cloned<T> for Box<T> where T: Sized + Clone {
 /// This type must implement `FromRc` and `Cloned`, and a `From` implementation must exist for
 /// `TypedValue`.
 ///
-pub type ValueRc<T> = Rc<T>;
+pub type ValueRc<T> = Arc<T>;
 
 /// Represents one entid in the entid space.
 ///


### PR DESCRIPTION
@mmacedoeu did a good deal of work to show that Arc instead of Rc
wasn't too difficult in #656, and @rnewman pushed the refactoring
across the line in #659. However, we didn't flip the switch at that
time. For #673, we'd like to include TypedValue instances in errors,
and with error-chain (and failure) error types need to be 'Sync +
'Send, so we need Arc.

This builds on #659 and should also finish #656.