### PR TITLE
Pull improvements

### DIFF
--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -315,6 +315,12 @@ impl From<StructuredMap> for Binding {
     }
 }
 
+impl From<Vec<Binding>> for Binding {
+    fn from(value: Vec<Binding>) -> Self {
+        Binding::Vec(ValueRc::new(value))
+    }
+}
+
 impl Binding {
     pub fn val(self) -> Option<TypedValue> {
         match self {

--- a/query-pull/src/errors.rs
+++ b/query-pull/src/errors.rs
@@ -22,6 +22,11 @@ error_chain! {
             description("unnamed attribute")
             display("attribute {:?} has no name", id)
         }
+
+        RepeatedDbId {
+            description(":db/id repeated")
+            display(":db/id repeated")
+        }
     }
 
     links {

--- a/query-pull/src/lib.rs
+++ b/query-pull/src/lib.rs
@@ -145,6 +145,12 @@ pub struct Puller {
     // The range is the set of aliases to use in the output.
     attributes: BTreeMap<Entid, ValueRc<Keyword>>,
     attribute_spec: cache::AttributeSpec,
+
+    // If this is set, each pulled entity is contributed to its own output map, labeled with this
+    // keyword. This is a divergence from Datomic, which has no types by which to differentiate a
+    // long from an entity ID, and thus represents all entities in pull as, _e.g._, `{:db/id 1234}`.
+    //  Mentat can use `TypedValue::Ref(1234)`, but it's sometimes convenient to fetch the entity ID
+    // itself as part of a pull expression: `{:person 1234, :person/name "Peter"}`.
     db_id_alias: Option<ValueRc<NamespacedKeyword>>,
 }
 

--- a/query-pull/src/lib.rs
+++ b/query-pull/src/lib.rs
@@ -149,13 +149,6 @@ pub struct Puller {
 }
 
 impl Puller {
-    pub fn prepare_simple_attributes(schema: &Schema, attributes: Vec<Entid>) -> Result<Puller> {
-        Puller::prepare(schema,
-                        attributes.into_iter()
-                                  .map(|e| PullAttributeSpec::Attribute(PullConcreteAttribute::Entid(e).into()))
-                                  .collect())
-    }
-
     pub fn prepare(schema: &Schema, attributes: Vec<PullAttributeSpec>) -> Result<Puller> {
         // TODO: eventually this entry point will handle aliasing and that kind of
         // thing. For now it's just a convenience.

--- a/query-pull/src/lib.rs
+++ b/query-pull/src/lib.rs
@@ -232,9 +232,7 @@ impl Puller {
         // - Recursing. (TODO: we'll need AttributeCaches to not overwrite in case of recursion! And
         //   ideally not do excess work when some entity/attribute pairs are known.)
         // - Building a structure by walking the pull expression with the caches.
-        //   TODO: aliases.
         // TODO: limits.
-        // TODO: fts.
 
         // Build a cache for these attributes and entities.
         // TODO: use the store's existing cache!

--- a/query-pull/src/lib.rs
+++ b/query-pull/src/lib.rs
@@ -151,7 +151,7 @@ pub struct Puller {
     // long from an entity ID, and thus represents all entities in pull as, _e.g._, `{:db/id 1234}`.
     //  Mentat can use `TypedValue::Ref(1234)`, but it's sometimes convenient to fetch the entity ID
     // itself as part of a pull expression: `{:person 1234, :person/name "Peter"}`.
-    db_id_alias: Option<ValueRc<NamespacedKeyword>>,
+    db_id_alias: Option<ValueRc<Keyword>>,
 }
 
 impl Puller {
@@ -168,7 +168,7 @@ impl Puller {
 
         let mut names: BTreeMap<Entid, ValueRc<Keyword>> = Default::default();
         let mut attrs: BTreeSet<Entid> = Default::default();
-        let db_id = ::std::rc::Rc::new(NamespacedKeyword::new("db", "id"));
+        let db_id = ::std::rc::Rc::new(Keyword::namespaced("db", "id"));
         let mut db_id_alias = None;
 
         for attr in attributes.iter() {

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -518,8 +518,8 @@ pub enum PullAttributeSpec {
     Wildcard,
     Attribute(NamedPullAttribute),
     // PullMapSpec(Vec<…>),
-    // LimitedAttribute(PullConcreteAttribute, u64),  // Limit nil => Attribute instead.
-    // DefaultedAttribute(PullConcreteAttribute, PullDefaultValue),
+    // LimitedAttribute(NamedPullAttribute, u64),  // Limit nil => Attribute instead.
+    // DefaultedAttribute(NamedPullAttribute, PullDefaultValue),
 }
 
 impl std::fmt::Display for PullConcreteAttribute {

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -499,11 +499,25 @@ pub enum PullConcreteAttribute {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub struct NamedPullAttribute {
+    pub attribute: PullConcreteAttribute,
+    pub alias: Option<Rc<NamespacedKeyword>>,
+}
+
+impl From<PullConcreteAttribute> for NamedPullAttribute {
+    fn from(a: PullConcreteAttribute) -> Self {
+        NamedPullAttribute {
+            attribute: a,
+            alias: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum PullAttributeSpec {
     Wildcard,
-    Attribute(PullConcreteAttribute),
+    Attribute(NamedPullAttribute),
     // PullMapSpec(Vec<…>),
-    // AttributeWithOpts(PullConcreteAttribute, …),
     // LimitedAttribute(PullConcreteAttribute, u64),  // Limit nil => Attribute instead.
     // DefaultedAttribute(PullConcreteAttribute, PullDefaultValue),
 }
@@ -521,14 +535,25 @@ impl std::fmt::Display for PullConcreteAttribute {
     }
 }
 
+impl std::fmt::Display for NamedPullAttribute {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        if let &Some(ref alias) = &self.alias {
+            write!(f, "{} :as {}", self.attribute, alias)
+        } else {
+            write!(f, "{}", self.attribute)
+        }
+    }
+}
+
+
 impl std::fmt::Display for PullAttributeSpec {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             &PullAttributeSpec::Wildcard => {
                 write!(f, "*")
             },
-            &PullAttributeSpec::Attribute(ref a) => {
-                write!(f, "{}", a)
+            &PullAttributeSpec::Attribute(ref attr) => {
+                write!(f, "{}", attr)
             },
         }
     }

--- a/query/src/lib.rs
+++ b/query/src/lib.rs
@@ -501,7 +501,7 @@ pub enum PullConcreteAttribute {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct NamedPullAttribute {
     pub attribute: PullConcreteAttribute,
-    pub alias: Option<Rc<NamespacedKeyword>>,
+    pub alias: Option<Rc<Keyword>>,
 }
 
 impl From<PullConcreteAttribute> for NamedPullAttribute {

--- a/tests/pull.rs
+++ b/tests/pull.rs
@@ -116,7 +116,7 @@ fn test_simple_pull() {
     assert_eq!(pulled, expected);
 
     // Now test pull inside the query itself.
-    let query = r#"[:find ?hood (pull ?district [:district/name :district/region])
+    let query = r#"[:find ?hood (pull ?district [[:district/name :as :district/district] :district/region])
                     :where
                     (or [?hood :neighborhood/name "Beacon Hill"]
                         [?hood :neighborhood/name "Capitol Hill"])
@@ -128,12 +128,12 @@ fn test_simple_pull() {
                                            .expect("results");
 
     let beacon_district: Vec<(Keyword, TypedValue)> = vec![
-        (kw!(:district/name), "Greater Duwamish".into()),
+        (kw!(:district/district), "Greater Duwamish".into()),
         (kw!(:district/region), schema.get_entid(&Keyword::namespaced("region", "se")).unwrap().into())
     ];
     let beacon_district: StructuredMap = beacon_district.into();
     let capitol_district: Vec<(Keyword, TypedValue)> = vec![
-        (kw!(:district/name), "East".into()),
+        (kw!(:district/district), "East".into()),
         (kw!(:district/region), schema.get_entid(&Keyword::namespaced("region", "e")).unwrap().into())
     ];
     let capitol_district: StructuredMap = capitol_district.into();

--- a/tests/pull.rs
+++ b/tests/pull.rs
@@ -213,6 +213,35 @@ fn test_simple_pull() {
     let expected: Vec<Binding> = expected.into_iter().map(|m| m.into()).collect();
     assert_eq!(results, expected);
 
+    // Pull fulltext.
+    let query = r#"[:find [(pull ?c [:community/name :community/category]) ...]
+                    :where
+                    [?c :community/name ?name]
+                    [?c :community/type :community.type/website]
+                    [(fulltext $ :community/category "food") [[?c ?cat]]]]"#;
+    let results = reader.q_once(query, None)
+                        .into_coll_result()
+                        .expect("result");
+    let expected: Vec<StructuredMap> = vec![
+        vec![(kw!(:community/name), Binding::Scalar(TypedValue::from("Community Harvest of Southwest Seattle"))),
+             (kw!(:community/category), vec![Binding::Scalar(TypedValue::from("sustainable food"))].into())].into(),
+
+        vec![(kw!(:community/name), Binding::Scalar(TypedValue::from("InBallard"))),
+             (kw!(:community/category), vec![Binding::Scalar(TypedValue::from("shopping")),
+                                             Binding::Scalar(TypedValue::from("food")),
+                                             Binding::Scalar(TypedValue::from("nightlife")),
+                                             Binding::Scalar(TypedValue::from("services"))].into())].into(),
+
+        vec![(kw!(:community/name), Binding::Scalar(TypedValue::from("Seattle Chinatown Guide"))),
+             (kw!(:community/category), vec![Binding::Scalar(TypedValue::from("shopping")),
+                                             Binding::Scalar(TypedValue::from("food"))].into())].into(),
+
+        vec![(kw!(:community/name), Binding::Scalar(TypedValue::from("University District Food Bank"))),
+             (kw!(:community/category), vec![Binding::Scalar(TypedValue::from("food bank"))].into())].into(),
+    ];
+
+    let expected: Vec<Binding> = expected.into_iter().map(|m| m.into()).collect();
+    assert_eq!(results, expected);
 }
 
 // TEST:

--- a/tests/pull.rs
+++ b/tests/pull.rs
@@ -117,7 +117,7 @@ fn test_simple_pull() {
 
     // Now test pull inside the query itself.
     let query = r#"[:find ?hood (pull ?district [:db/id
-                                                 [:district/name :as :district/district]
+                                                 :district/name :as :district/district
                                                  :district/region])
                     :where
                     (or [?hood :neighborhood/name "Beacon Hill"]
@@ -159,7 +159,7 @@ fn test_simple_pull() {
 
     // Execute a scalar query where the body is constant.
     // TODO: we shouldn't require `:where`; that makes this non-constant!
-    let query = r#"[:find (pull ?hood [[:db/id :as :neighborhood/id]
+    let query = r#"[:find (pull ?hood [:db/id :as :neighborhood/id
                                        :neighborhood/name]) .
                     :in ?hood
                     :where [?hood :neighborhood/district _]]"#;

--- a/tests/pull.rs
+++ b/tests/pull.rs
@@ -131,11 +131,14 @@ fn test_simple_pull() {
 
     let beacon_district_pull: Vec<(Keyword, TypedValue)> = vec![
         (kw!(:db/id), TypedValue::Ref(beacon_district)),
-    let beacon_district_pull: StructuredMap = beacon_district.into();
+        (kw!(:district/district), "Greater Duwamish".into()),
+        (kw!(:district/region), schema.get_entid(&Keyword::namespaced("region", "se")).unwrap().into()),
+    ];
+    let beacon_district_pull: StructuredMap = beacon_district_pull.into();
     let capitol_district_pull: Vec<(Keyword, TypedValue)> = vec![
         (kw!(:db/id), TypedValue::Ref(capitol_district)),
         (kw!(:district/district), "East".into()),
-        (kw!(:district/region), schema.get_entid(&Keyword::namespaced("region", "e")).unwrap().into())
+        (kw!(:district/region), schema.get_entid(&Keyword::namespaced("region", "e")).unwrap().into()),
     ];
     let capitol_district_pull: StructuredMap = capitol_district_pull.into();
 

--- a/tests/pull.rs
+++ b/tests/pull.rs
@@ -116,7 +116,9 @@ fn test_simple_pull() {
     assert_eq!(pulled, expected);
 
     // Now test pull inside the query itself.
-    let query = r#"[:find ?hood (pull ?district [[:district/name :as :district/district] :district/region])
+    let query = r#"[:find ?hood (pull ?district [:db/id
+                                                 [:district/name :as :district/district]
+                                                 :district/region])
                     :where
                     (or [?hood :neighborhood/name "Beacon Hill"]
                         [?hood :neighborhood/name "Capitol Hill"])
@@ -127,22 +129,21 @@ fn test_simple_pull() {
                                            .into_rel_result()
                                            .expect("results");
 
-    let beacon_district: Vec<(Keyword, TypedValue)> = vec![
-        (kw!(:district/district), "Greater Duwamish".into()),
-        (kw!(:district/region), schema.get_entid(&Keyword::namespaced("region", "se")).unwrap().into())
-    ];
-    let beacon_district: StructuredMap = beacon_district.into();
-    let capitol_district: Vec<(Keyword, TypedValue)> = vec![
+    let beacon_district_pull: Vec<(Keyword, TypedValue)> = vec![
+        (kw!(:db/id), TypedValue::Ref(beacon_district)),
+    let beacon_district_pull: StructuredMap = beacon_district.into();
+    let capitol_district_pull: Vec<(Keyword, TypedValue)> = vec![
+        (kw!(:db/id), TypedValue::Ref(capitol_district)),
         (kw!(:district/district), "East".into()),
         (kw!(:district/region), schema.get_entid(&Keyword::namespaced("region", "e")).unwrap().into())
     ];
-    let capitol_district: StructuredMap = capitol_district.into();
+    let capitol_district_pull: StructuredMap = capitol_district_pull.into();
 
     let expected = RelResult {
                        width: 2,
                        values: vec![
-                           TypedValue::Ref(capitol).into(), capitol_district.into(),
-                           TypedValue::Ref(beacon).into(), beacon_district.into(),
+                           TypedValue::Ref(capitol).into(), capitol_district_pull.into(),
+                           TypedValue::Ref(beacon).into(), beacon_district_pull.into(),
                        ].into(),
                    };
     assert_eq!(results, expected.clone());
@@ -158,14 +159,19 @@ fn test_simple_pull() {
 
     // Execute a scalar query where the body is constant.
     // TODO: we shouldn't require `:where`; that makes this non-constant!
-    let query = r#"[:find (pull ?hood [:neighborhood/name]) . :in ?hood
+    let query = r#"[:find (pull ?hood [[:db/id :as :neighborhood/id]
+                                       :neighborhood/name]) .
+                    :in ?hood
                     :where [?hood :neighborhood/district _]]"#;
     let result = reader.q_once(query, QueryInputs::with_value_sequence(vec![(var!(?hood), TypedValue::Ref(beacon))]))
                        .into_scalar_result()
                        .expect("success")
                        .expect("result");
 
-    let expected: StructuredMap = vec![(kw!(:neighborhood/name), TypedValue::from("Beacon Hill"))].into();
+    let expected: StructuredMap = vec![
+        (kw!(:neighborhood/name), TypedValue::from("Beacon Hill")),
+        (kw!(:neighborhood/id), TypedValue::Ref(beacon)),
+    ].into();
     assert_eq!(result, expected.into());
 
     // Collect the names and regions of all districts.


### PR DESCRIPTION
This PR allows aliasing of pull expressions and the use of `:db/id` for the entity ID itself:

```edn
(pull ?person [
    [:db/id :as :person/id]
    [:person/name :as :person/fullName]])
```

I wanted to flatten `NamespacedKeyword`, but soon realized that #648 still hasn't been wrapped up and landed, so I'll do that tomorrow. I plan to merge `NamespacedKeyword` and `Keyword`, with the only difference being a non-zero division offset and a different result from a predicate; we can preserve the restriction that all attribute names are namespaced while normalizing the API. That will make aliasing more useful.