### PR TITLE
Edn serde support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: rust
 script:
   - cargo test --verbose --all
+  - cargo test --features edn/serde_support --verbose --all

--- a/edn/Cargo.toml
+++ b/edn/Cargo.toml
@@ -13,7 +13,8 @@ readme = "./README.md"
 [dependencies]
 chrono = "0.4"
 itertools = "0.7"
-num = "0.1"
+num-bigint = "0.2"
+num-traits = "0.2"
 ordered-float = "0.5"
 pretty = "0.2"
 uuid = { version = "0.5", features = ["v4", "serde"] }
@@ -25,7 +26,7 @@ serde_test = "1.0"
 serde_json = "1.0"
 
 [features]
-serde_support = ["serde", "serde_derive"]
+serde_support = ["serde", "serde_derive", "chrono/serde", "num-bigint/serde", "ordered-float/serde"]
 
 [build-dependencies]
 peg = "0.5"

--- a/edn/src/lib.rs
+++ b/edn/src/lib.rs
@@ -10,7 +10,7 @@
 
 extern crate chrono;
 extern crate itertools;
-extern crate num;
+extern crate num_bigint as num;
 extern crate ordered_float;
 extern crate pretty;
 extern crate uuid;

--- a/edn/src/symbols.rs
+++ b/edn/src/symbols.rs
@@ -25,9 +25,11 @@ macro_rules! ns_keyword {
 
 /// A simplification of Clojure's Symbol.
 #[derive(Clone,Debug,Eq,Hash,Ord,PartialOrd,PartialEq)]
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub struct PlainSymbol(pub String);
 
 #[derive(Clone,Debug,Eq,Hash,Ord,PartialOrd,PartialEq)]
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub struct NamespacedSymbol(NamespaceableName);
 
 /// A keyword is a symbol, optionally with a namespace, that prints with a leading colon.

--- a/edn/src/types.rs
+++ b/edn/src/types.rs
@@ -29,6 +29,7 @@ use symbols;
 
 /// Value represents one of the allowed values in an EDN string.
 #[derive(PartialEq, Eq, Hash, Clone, Debug)]
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub enum Value {
     Nil,
     Boolean(bool),
@@ -653,7 +654,7 @@ impl ToMicros for DateTime<Utc> {
 mod test {
     extern crate chrono;
     extern crate ordered_float;
-    extern crate num;
+    extern crate num_bigint as num;
 
     use super::*;
 

--- a/edn/tests/serde_support.rs
+++ b/edn/tests/serde_support.rs
@@ -16,6 +16,7 @@ extern crate serde_json;
 
 extern crate edn;
 use edn::symbols::Keyword;
+use edn::{parse, Value};
 use serde_test::{assert_tokens, Token};
 
 #[cfg(feature = "serde_support")]
@@ -53,4 +54,121 @@ fn test_deserialize_keyword() {
 }
 
 
+#[cfg(feature = "serde_support")]
+#[test]
+fn test_serialize_value() {
+    let test = "[
+        :find ?id ?reason ?ts
+        :in $
+        :where
+            [?id :session/startReason ?reason ?tx]
+            [?tx :db/txInstant ?ts]
+            (not-join [?id] [?id :session/endReason _])
+    ]";
 
+    let expected = r#"
+{
+  "Vector": [
+    {
+      "Keyword": {
+        "namespace": null,
+        "name": "find"
+      }
+    },
+    {
+      "PlainSymbol": "?id"
+    },
+    {
+      "PlainSymbol": "?reason"
+    },
+    {
+      "PlainSymbol": "?ts"
+    },
+    {
+      "Keyword": {
+        "namespace": null,
+        "name": "in"
+      }
+    },
+    {
+      "PlainSymbol": "$"
+    },
+    {
+      "Keyword": {
+        "namespace": null,
+        "name": "where"
+      }
+    },
+    {
+      "Vector": [
+        {
+          "PlainSymbol": "?id"
+        },
+        {
+          "Keyword": {
+            "namespace": "session",
+            "name": "startReason"
+          }
+        },
+        {
+          "PlainSymbol": "?reason"
+        },
+        {
+          "PlainSymbol": "?tx"
+        }
+      ]
+    },
+    {
+      "Vector": [
+        {
+          "PlainSymbol": "?tx"
+        },
+        {
+          "Keyword": {
+            "namespace": "db",
+            "name": "txInstant"
+          }
+        },
+        {
+          "PlainSymbol": "?ts"
+        }
+      ]
+    },
+    {
+      "List": [
+        {
+          "PlainSymbol": "not-join"
+        },
+        {
+          "Vector": [
+            {
+              "PlainSymbol": "?id"
+            }
+          ]
+        },
+        {
+          "Vector": [
+            {
+              "PlainSymbol": "?id"
+            },
+            {
+              "Keyword": {
+                "namespace": "session",
+                "name": "endReason"
+              }
+            },
+            {
+              "PlainSymbol": "_"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}"#;
+
+    let edn: Value = parse::value(test).unwrap().into();
+    let parsed: Value = serde_json::from_str(expected).unwrap();
+
+    assert_eq!(edn, parsed);
+}

--- a/edn/tests/serde_support.rs
+++ b/edn/tests/serde_support.rs
@@ -19,7 +19,6 @@ use edn::symbols::Keyword;
 use edn::{parse, Value};
 use serde_test::{assert_tokens, Token};
 
-#[cfg(feature = "serde_support")]
 #[test]
 fn test_serialize_keyword() {
     let kw = Keyword::namespaced("foo", "bar");
@@ -36,7 +35,6 @@ fn test_serialize_keyword() {
 }
 
 
-#[cfg(feature = "serde_support")]
 #[test]
 fn test_deserialize_keyword() {
     let json = r#"{"name": "foo", "namespace": "bar"}"#;
@@ -54,7 +52,6 @@ fn test_deserialize_keyword() {
 }
 
 
-#[cfg(feature = "serde_support")]
 #[test]
 fn test_serialize_value() {
     let test = "[

--- a/edn/tests/tests.rs
+++ b/edn/tests/tests.rs
@@ -10,7 +10,8 @@
 
 extern crate chrono;
 extern crate edn;
-extern crate num;
+extern crate num_bigint as num;
+extern crate num_traits;
 extern crate ordered_float;
 extern crate uuid;
 
@@ -18,8 +19,8 @@ use std::collections::{BTreeSet, BTreeMap, LinkedList};
 use std::iter::FromIterator;
 use std::f64;
 
-use num::bigint::ToBigInt;
-use num::traits::{Zero, One};
+use num::ToBigInt;
+use num_traits::{Zero, One};
 use ordered_float::OrderedFloat;
 
 use edn::parse::{self, ParseError};


### PR DESCRIPTION
Fixes https://github.com/mozilla/mentat/issues/708

Simple naive implementation of serde serialization/deserialization for edn values. This is a naive approach, relying on serde's defaults for the internal shape.

We can take this much further, but I'm bit wary of allocating more time on this without an active consumer. Points of improvement are around making the json representation of edn more ergonomic, and adding some helpers to stringify/parse edn into/out of json without having to go through serde_json.

I had to update the num crate to use its serde support. Splitting it into num-traits and num-bigint ended up the way I did it, but there's probably a way to rely on the num mothership crate if necessary.

I also enabled serde-supported tests on travis, they weren't before.