### PR TITLE
Android build script which supports target specification

### DIFF
--- a/android_build_all.sh
+++ b/android_build_all.sh
@@ -1,4 +1,0 @@
-# This will eventually become a complete build script, not just for Android
-cargo build -p mentat_ffi --target i686-linux-android --release
-cargo build -p mentat_ffi --target armv7-linux-androideabi --release
-cargo build -p mentat_ffi --target aarch64-linux-android --release

--- a/scripts/android_build.sh
+++ b/scripts/android_build.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# This will eventually become a complete build script, not just for Android
+
+set -e
+
+declare -A android_targets
+android_targets=(
+	["x86"]="i686-linux-android"
+	["arm"]="armv7-linux-androideabi"
+	["arm64"]="aarch64-linux-android"
+)
+
+if [ "$#" -eq 0 ]
+then
+	selected_targets=(x86 arm arm64)
+else
+	for target_arg in "$@"
+	do
+		[[ -z "${android_targets[$target_arg]+yes}" ]] && echo "Unrecognized target $target_arg. Supported targets: ${!android_targets[@]}" && exit 1
+		selected_targets=("${selected_targets[@]}" $target_arg)
+	done
+	
+fi
+
+echo "Building selected targets: ${selected_targets[@]}."
+
+for target in "${selected_targets[@]}"
+do
+	echo "Building target $target. Signature: ${android_targets[$target]}"
+	cargo build -p mentat_ffi --target ${android_targets[$target]} --release
+done
+


### PR DESCRIPTION
A slight improvement over the current script. Most of the time during development I just want to rebuild one target, not all. Currently that means either typing out the `cargo build....` command or commenting out lines in the script.

Recognized targets: `x86`, `arm`, `arm64`.

`./android_build.sh` - builds all supported targets
`./android_build.sh x86 arm` - builds for `x86` and `arm`
`./android_build.sh arm64 x86 dummy` - fails and complains because `dummy` isn't a supported target.