### PR TITLE
Avoid using 1.26.0-only features when using sqlcipher, and move the sqlcipher Store support to the correct file

### DIFF
--- a/db/src/db.rs
+++ b/db/src/db.rs
@@ -125,12 +125,14 @@ pub fn new_connection<T>(uri: T) -> rusqlite::Result<rusqlite::Connection> where
 }
 
 #[cfg(feature = "sqlcipher")]
-pub fn new_connection_with_key(uri: impl AsRef<Path>, encryption_key: impl AsRef<str>) -> rusqlite::Result<rusqlite::Connection> {
+pub fn new_connection_with_key<P, S>(uri: P, encryption_key: S) -> rusqlite::Result<rusqlite::Connection>
+where P: AsRef<Path>, S: AsRef<str> {
     make_connection(uri.as_ref(), Some(encryption_key.as_ref()))
 }
 
 #[cfg(feature = "sqlcipher")]
-pub fn change_encryption_key(conn: &rusqlite::Connection, encryption_key: impl AsRef<str>) -> rusqlite::Result<()> {
+pub fn change_encryption_key<S>(conn: &rusqlite::Connection, encryption_key: S) -> rusqlite::Result<()>
+where S: AsRef<str> {
     let escaped = escape_string_for_pragma(encryption_key.as_ref());
     // `conn.execute` complains that this returns a result, and using a query
     // for it requires more boilerplate.
@@ -2752,7 +2754,7 @@ mod tests {
     }
 
     #[cfg(feature = "sqlcipher")]
-    fn test_open_fail(opener: impl FnOnce() -> rusqlite::Result<rusqlite::Connection>) {
+    fn test_open_fail<F>(opener: F) where F: FnOnce() -> rusqlite::Result<rusqlite::Connection> {
         let err = opener().expect_err("Should fail to open encrypted DB");
         match err {
             rusqlite::Error::SqliteFailure(err, ..) => {

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -160,48 +160,6 @@ pub struct Conn {
     pub(crate) tx_observer_service: Mutex<TxObservationService>,
 }
 
-#[cfg(feature = "sqlcipher")]
-impl Store {
-    /// Variant of `open` that allows a key (for encryption/decryption) to be
-    /// supplied. Fails unless linked against sqlcipher (or something else that
-    /// supports the Sqlite Encryption Extension).
-    pub fn open_with_key(path: &str, encryption_key: &str) -> Result<Store> {
-        let mut connection = ::new_connection_with_key(path, encryption_key)?;
-        let conn = Conn::connect(&mut connection)?;
-        Ok(Store {
-            conn: conn,
-            sqlite: connection,
-        })
-    }
-
-    /// Variant of `open_empty` that allows a key (for encryption/decryption) to
-    /// be supplied. Fails unless linked against sqlcipher (or something else
-    /// that supports the Sqlite Encryption Extension).
-    pub fn open_empty_with_key(path: &str, encryption_key: &str) -> Result<Store> {
-        if !path.is_empty() {
-            if Path::new(path).exists() {
-                bail!(ErrorKind::PathAlreadyExists(path.to_string()));
-            }
-        }
-
-        let mut connection = ::new_connection_with_key(path, encryption_key)?;
-        let conn = Conn::empty(&mut connection)?;
-        Ok(Store {
-            conn: conn,
-            sqlite: connection,
-        })
-    }
-
-    /// Change the key for a database that was opened using `open_with_key` or
-    /// `open_empty_with_key` (using `PRAGMA rekey`). Fails unless linked
-    /// against sqlcipher (or something else that supports the Sqlite Encryption
-    /// Extension).
-    pub fn change_encryption_key(&mut self, new_encryption_key: &str) -> Result<()> {
-        ::change_encryption_key(&self.sqlite, new_encryption_key)?;
-        Ok(())
-    }
-}
-
 pub trait Queryable {
     fn q_explain<T>(&self, query: &str, inputs: T) -> Result<QueryExplanation>
         where T: Into<Option<QueryInputs>>;

--- a/src/store.rs
+++ b/src/store.rs
@@ -104,6 +104,48 @@ impl Store {
     }
 }
 
+#[cfg(feature = "sqlcipher")]
+impl Store {
+    /// Variant of `open` that allows a key (for encryption/decryption) to be
+    /// supplied. Fails unless linked against sqlcipher (or something else that
+    /// supports the Sqlite Encryption Extension).
+    pub fn open_with_key(path: &str, encryption_key: &str) -> Result<Store> {
+        let mut connection = ::new_connection_with_key(path, encryption_key)?;
+        let conn = Conn::connect(&mut connection)?;
+        Ok(Store {
+            conn: conn,
+            sqlite: connection,
+        })
+    }
+
+    /// Variant of `open_empty` that allows a key (for encryption/decryption) to
+    /// be supplied. Fails unless linked against sqlcipher (or something else
+    /// that supports the Sqlite Encryption Extension).
+    pub fn open_empty_with_key(path: &str, encryption_key: &str) -> Result<Store> {
+        if !path.is_empty() {
+            if Path::new(path).exists() {
+                bail!(ErrorKind::PathAlreadyExists(path.to_string()));
+            }
+        }
+
+        let mut connection = ::new_connection_with_key(path, encryption_key)?;
+        let conn = Conn::empty(&mut connection)?;
+        Ok(Store {
+            conn: conn,
+            sqlite: connection,
+        })
+    }
+
+    /// Change the key for a database that was opened using `open_with_key` or
+    /// `open_empty_with_key` (using `PRAGMA rekey`). Fails unless linked
+    /// against sqlcipher (or something else that supports the Sqlite Encryption
+    /// Extension).
+    pub fn change_encryption_key(&mut self, new_encryption_key: &str) -> Result<()> {
+        ::change_encryption_key(&self.sqlite, new_encryption_key)?;
+        Ok(())
+    }
+}
+
 impl Store {
     /// Intended for use from tests.
     pub fn sqlite_mut(&mut self) -> &mut rusqlite::Connection {


### PR DESCRIPTION
This fixes the issue with the sqlcipher build that was introduced by #741, and makes sure that the work done in f041dfe applies to the sqlcipher feature as well.