### PR TITLE
Make travis test sqlcipher by running the tests on macos. Fixes #738

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: rust
+# We use OSX so that we can get a reasonably up to date version of SQLCipher.
+# (The version in Travis's default Ubuntu Trusty is much too old).
+os: osx
+before_install:
+  - brew install sqlcipher --with-fts
 rust:
   - 1.25.0  # Must align with `build/version.rs`.
   - stable
@@ -10,4 +15,12 @@ matrix:
   fast_finish: true
 script:
   - cargo test --verbose --all
+  # We can't pick individual features out with `cargo test --all` (At the time of this writing, this
+  # works but does the wrong thing because of a bug in cargo, but it's fix will be to disallow doing
+  # this all-together, see https://github.com/rust-lang/cargo/issues/5364 for more information). To
+  # work around this, we run individual tests for each subcrate individually.
+  - |
+    for manifest in $(find . -type f -name Cargo.toml); do
+      cargo test --manifest-path $manifest --verbose --no-default-features --features sqlcipher
+    done
 cache: cargo


### PR DESCRIPTION
The biggest issue here is probably that it requires running travis on mac machines, which I've heard are slower and less reliable.

The fact that `cargo test --all --no-default-features --features sqlcipher` isn't going to work for our case sucks, but it shouldn't be that bad.

Another option might be to use a different apt repository, but it wasn't clear to me how to do that. (Yet another option would be to figure out how to bundle sqlcipher, I guess). Regardless, this should be fine for now (and better than nothing).