### PR TITLE
[cli] Handle line comments in EDN input. (#759)

### DIFF
--- a/tools/cli/src/mentat_cli/input.rs
+++ b/tools/cli/src/mentat_cli/input.rs
@@ -133,13 +133,13 @@ impl InputReader {
         // If there is no in process command, we parse the read in line as a new command.
         let cmd = match &self.in_process_cmd {
             &Some(Command::QueryPrepared(ref args)) => {
-                Ok(Command::QueryPrepared(args.clone() + " " + &line))
+                Ok(Command::QueryPrepared(args.clone() + "\n" + &line))
             },
             &Some(Command::Query(ref args)) => {
-                Ok(Command::Query(args.clone() + " " + &line))
+                Ok(Command::Query(args.clone() + "\n" + &line))
             },
             &Some(Command::Transact(ref args)) => {
-                Ok(Command::Transact(args.clone() + " " + &line))
+                Ok(Command::Transact(args.clone() + "\n" + &line))
             },
             _ => {
                 command(&self.buffer)


### PR DESCRIPTION
What was happening is that ["[;", "]"] would get glued to "[; ]",
which of course can never complete.

It would be good to add tests of this, but the existing multi-line
`InputReader` makes that challenging and I don't want to invest the
time to improve it: I expect it to be overhauled as part of a
transition away from parsing with `combine` and toward parsing with
`rust-peg`.