### PR TITLE
Build `Entity` instances, not `Term*` instances.  (#674)

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -60,8 +60,13 @@ pub use cache::{
 
 /// Core types defining a Mentat knowledge base.
 mod types;
+mod tx_report;
 mod value_type_set;
 mod sql_types;
+
+pub use tx_report::{
+    TxReport,
+};
 
 pub use types::{
     Binding,
@@ -365,7 +370,6 @@ impl HasSchema for Schema {
     }
 }
 
-pub mod intern_set;
 pub mod counter;
 pub mod util;
 

--- a/core/src/tx_report.rs
+++ b/core/src/tx_report.rs
@@ -1,0 +1,38 @@
+// Copyright 2018 Mozilla
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#![allow(dead_code)]
+
+use std::collections::{
+    BTreeMap,
+};
+
+use ::{
+    DateTime,
+    Entid,
+    Utc,
+};
+
+/// A transaction report summarizes an applied transaction.
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialOrd, PartialEq)]
+pub struct TxReport {
+    /// The transaction ID of the transaction.
+    pub tx_id: Entid,
+
+    /// The timestamp when the transaction began to be committed.
+    pub tx_instant: DateTime<Utc>,
+
+    /// A map from string literal tempid to resolved or allocated entid.
+    ///
+    /// Every string literal tempid presented to the transactor either resolves via upsert to an
+    /// existing entid, or is allocated a new entid.  (It is possible for multiple distinct string
+    /// literal tempids to all unify to a single freshly allocated entid.)
+    pub tempids: BTreeMap<String, Entid>,
+}

--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -47,6 +47,14 @@ use ::edn::{
     ValueRc,
 };
 
+use ::edn::entities::{
+    AttributePlace,
+    EntidOrIdent,
+    EntityPlace,
+    ValuePlace,
+    TransactableValueMarker,
+};
+
 use values;
 
 /// Represents one entid in the entid space.
@@ -70,6 +78,24 @@ impl From<KnownEntid> for Entid {
 impl From<KnownEntid> for TypedValue {
     fn from(k: KnownEntid) -> TypedValue {
         TypedValue::Ref(k.0)
+    }
+}
+
+impl<V: TransactableValueMarker> Into<EntityPlace<V>> for KnownEntid {
+    fn into(self) -> EntityPlace<V> {
+        EntityPlace::Entid(EntidOrIdent::Entid(self.0))
+    }
+}
+
+impl Into<AttributePlace> for KnownEntid {
+    fn into(self) -> AttributePlace {
+        AttributePlace::Entid(EntidOrIdent::Entid(self.0))
+    }
+}
+
+impl<V: TransactableValueMarker> Into<ValuePlace<V>> for KnownEntid {
+    fn into(self) -> ValuePlace<V> {
+        ValuePlace::Entid(EntidOrIdent::Entid(self.0))
     }
 }
 
@@ -214,6 +240,9 @@ pub enum TypedValue {
     Keyword(ValueRc<Keyword>),
     Uuid(Uuid),                        // It's only 128 bits, so this should be acceptable to clone.
 }
+
+/// `TypedValue` is the value type for programmatic use in transaction builders.
+impl TransactableValueMarker for TypedValue {}
 
 /// The values bound in a query specification can be:
 ///

--- a/db/src/db.rs
+++ b/db/src/db.rs
@@ -1119,20 +1119,22 @@ mod tests {
     use debug;
     use errors;
     use edn;
-    use mentat_core::{
-        HasSchema,
-        Keyword,
-        KnownEntid,
-        attribute,
-    };
-    use mentat_core::intern_set::{
+    use edn::{
         InternSet,
     };
-    use mentat_core::util::Either::*;
     use edn::entities::{
         OpType,
         TempId,
     };
+
+    use mentat_core::{
+        HasSchema,
+        Keyword,
+        KnownEntid,
+        TxReport,
+        attribute,
+    };
+    use mentat_core::util::Either::*;
     use rusqlite;
     use std::collections::{
         BTreeMap,
@@ -1141,7 +1143,6 @@ mod tests {
         Term,
         TermWithTempIds,
     };
-    use types::TxReport;
     use tx::{
         transact_terms,
     };

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -106,7 +106,6 @@ pub use types::{
     DB,
     PartitionMap,
     TransactableValue,
-    TxReport,
 };
 
 pub fn to_namespaced_keyword(s: &str) -> Result<symbols::Keyword> {

--- a/db/src/types.rs
+++ b/db/src/types.rs
@@ -95,23 +95,6 @@ pub type AVMap<'a> = HashMap<&'a AVPair, Entid>;
 // represents a set of entids that are correspond to attributes
 pub type AttributeSet = BTreeSet<Entid>;
 
-/// A transaction report summarizes an applied transaction.
-#[derive(Clone, Debug, Eq, Hash, Ord, PartialOrd, PartialEq)]
-pub struct TxReport {
-    /// The transaction ID of the transaction.
-    pub tx_id: Entid,
-
-    /// The timestamp when the transaction began to be committed.
-    pub tx_instant: DateTime<Utc>,
-
-    /// A map from string literal tempid to resolved or allocated entid.
-    ///
-    /// Every string literal tempid presented to the transactor either resolves via upsert to an
-    /// existing entid, or is allocated a new entid.  (It is possible for multiple distinct string
-    /// literal tempids to all unify to a single freshly allocated entid.)
-    pub tempids: BTreeMap<String, Entid>,
-}
-
 /// The transactor is tied to `edn::ValueAndSpan` right now, but in the future we'd like to support
 /// `TypedValue` directly for programmatic use.  `TransactableValue` encapsulates the interface
 /// value types (i.e., values in the value place) need to support to be transacted.

--- a/edn/src/edn.rustpeg
+++ b/edn/src/edn.rustpeg
@@ -260,7 +260,7 @@ tx_function -> TxFunction
     = "(" __ n:$(symbol_name) __ ")" { TxFunction { op: PlainSymbol::plain(n) } }
 
 entity_place -> EntityPlace<ValueAndSpan>
-    = v:raw_text { EntityPlace::TempId(TempId::External(v)) }
+    = v:raw_text { EntityPlace::TempId(TempId::External(v).into()) }
     / v:entid { EntityPlace::Entid(v) }
     / v:lookup_ref { EntityPlace::LookupRef(v) }
     / v:tx_function { EntityPlace::TxFunction(v) }

--- a/edn/src/entities.rs
+++ b/edn/src/entities.rs
@@ -13,10 +13,28 @@
 use std::collections::BTreeMap;
 use std::fmt;
 
+use value_rc::{
+    ValueRc,
+};
+
 use symbols::{
     Keyword,
     PlainSymbol,
 };
+
+use types::{
+    ValueAndSpan,
+};
+
+/// `EntityPlace` and `ValuePlace` embed values, either directly (i.e., `ValuePlace::Atom`) or
+/// indirectly (i.e., `EntityPlace::LookupRef`).  In order to maintain the graph of `Into` and
+/// `From` relations, we need to ensure that `{Value,Entity}Place` can't match as a potential value.
+/// (If it does, the `impl Into<T> for T` default conflicts.) This marker trait allows to mark
+/// acceptable values, thereby removing `{Entity,Value}Place` from consideration.
+pub trait TransactableValueMarker {}
+
+/// `ValueAndSpan` is the value type coming out of the entity parser.
+impl TransactableValueMarker for ValueAndSpan {}
 
 /// A tempid, either an external tempid given in a transaction (usually as an `Value::Text`),
 /// or an internal tempid allocated by Mentat itself.
@@ -48,6 +66,18 @@ impl fmt::Display for TempId {
 pub enum EntidOrIdent {
     Entid(i64),
     Ident(Keyword),
+}
+
+impl From<i64> for EntidOrIdent {
+    fn from(v: i64) -> Self {
+        EntidOrIdent::Entid(v)
+    }
+}
+
+impl From<Keyword> for EntidOrIdent {
+    fn from(v: Keyword) -> Self {
+        EntidOrIdent::Ident(v)
+    }
 }
 
 impl EntidOrIdent {
@@ -93,7 +123,7 @@ pub enum ValuePlace<V> {
     Entid(EntidOrIdent),
     // We never know at parse-time whether a string is really a tempid, but we will often know when
     // building entities programmatically.
-    TempId(TempId),
+    TempId(ValueRc<TempId>),
     LookupRef(LookupRef<V>),
     TxFunction(TxFunction),
     Vector(Vec<ValuePlace<V>>),
@@ -101,17 +131,101 @@ pub enum ValuePlace<V> {
     MapNotation(MapNotation<V>),
 }
 
+impl<V: TransactableValueMarker> From<EntidOrIdent> for ValuePlace<V> {
+    fn from(v: EntidOrIdent) -> Self {
+        ValuePlace::Entid(v)
+    }
+}
+
+impl<V: TransactableValueMarker> From<TempId> for ValuePlace<V> {
+    fn from(v: TempId) -> Self {
+        ValuePlace::TempId(v.into())
+    }
+}
+
+impl<V: TransactableValueMarker> From<ValueRc<TempId>> for ValuePlace<V> {
+    fn from(v: ValueRc<TempId>) -> Self {
+        ValuePlace::TempId(v)
+    }
+}
+
+impl<V: TransactableValueMarker> From<LookupRef<V>> for ValuePlace<V> {
+    fn from(v: LookupRef<V>) -> Self {
+        ValuePlace::LookupRef(v)
+    }
+}
+
+impl<V: TransactableValueMarker> From<TxFunction> for ValuePlace<V> {
+    fn from(v: TxFunction) -> Self {
+        ValuePlace::TxFunction(v)
+    }
+}
+
+impl<V: TransactableValueMarker> From<Vec<ValuePlace<V>>> for ValuePlace<V> {
+    fn from(v: Vec<ValuePlace<V>>) -> Self {
+        ValuePlace::Vector(v)
+    }
+}
+
+impl<V: TransactableValueMarker> From<V> for ValuePlace<V> {
+    fn from(v: V) -> Self {
+        ValuePlace::Atom(v)
+    }
+}
+
+impl<V: TransactableValueMarker> From<MapNotation<V>> for ValuePlace<V> {
+    fn from(v: MapNotation<V>) -> Self {
+        ValuePlace::MapNotation(v)
+    }
+}
+
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialOrd, PartialEq)]
 pub enum EntityPlace<V> {
     Entid(EntidOrIdent),
-    TempId(TempId),
+    TempId(ValueRc<TempId>),
     LookupRef(LookupRef<V>),
     TxFunction(TxFunction),
+}
+
+impl<V, E: Into<EntidOrIdent>> From<E> for EntityPlace<V> {
+    fn from(v: E) -> Self {
+        EntityPlace::Entid(v.into())
+    }
+}
+
+impl<V: TransactableValueMarker> From<TempId> for EntityPlace<V> {
+    fn from(v: TempId) -> Self {
+        EntityPlace::TempId(v.into())
+    }
+}
+
+impl<V: TransactableValueMarker> From<ValueRc<TempId>> for EntityPlace<V> {
+    fn from(v: ValueRc<TempId>) -> Self {
+        EntityPlace::TempId(v)
+    }
+}
+
+impl<V: TransactableValueMarker> From<LookupRef<V>> for EntityPlace<V> {
+    fn from(v: LookupRef<V>) -> Self {
+        EntityPlace::LookupRef(v)
+    }
+}
+
+impl<V: TransactableValueMarker> From<TxFunction> for EntityPlace<V> {
+    fn from(v: TxFunction) -> Self {
+        EntityPlace::TxFunction(v)
+    }
 }
 
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialOrd, PartialEq)]
 pub enum AttributePlace {
     Entid(EntidOrIdent),
+}
+
+impl<A: Into<EntidOrIdent>> From<A> for AttributePlace {
+    fn from(v: A) -> Self {
+        AttributePlace::Entid(v.into())
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialOrd, PartialEq)]

--- a/edn/src/lib.rs
+++ b/edn/src/lib.rs
@@ -23,6 +23,10 @@ extern crate serde;
 extern crate serde_derive;
 
 pub mod entities;
+pub mod intern_set;
+pub use intern_set::{
+    InternSet,
+};
 // Intentionally not pub.
 mod namespaceable_name;
 pub mod query;

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -120,7 +120,6 @@ pub use mentat::entity_builder::{
     BuildTerms,
     EntityBuilder,
     InProgressBuilder,
-    IntoThing,
 };
 
 pub mod android;
@@ -339,7 +338,7 @@ pub unsafe extern "C" fn in_progress_entity_builder_from_temp_id<'m>(in_progress
 pub unsafe extern "C" fn in_progress_entity_builder_from_entid<'m>(in_progress: *mut InProgress<'m, 'm>, entid: c_longlong) -> *mut EntityBuilder<InProgressBuilder> {
     assert_not_null!(in_progress);
     let in_progress = Box::from_raw(in_progress);
-    Box::into_raw(Box::new(in_progress.builder().describe(&KnownEntid(entid))))
+    Box::into_raw(Box::new(in_progress.builder().describe(KnownEntid(entid))))
 }
 
 /// Starts a new transaction and creates a builder using the transaction
@@ -392,7 +391,7 @@ pub unsafe extern "C" fn store_entity_builder_from_entid<'a, 'c>(store: *mut Sto
     assert_not_null!(store);
     let store = &mut *store;
     let result = store.begin_transaction().and_then(|in_progress| {
-        Ok(in_progress.builder().describe(&KnownEntid(entid)))
+        Ok(in_progress.builder().describe(KnownEntid(entid)))
     });
     translate_result(result, error)
 }
@@ -418,7 +417,7 @@ pub unsafe extern "C" fn in_progress_builder_add_string<'a, 'c>(
     let builder = &mut *builder;
     let kw = kw_from_string(c_char_to_string(kw));
     let value: TypedValue = c_char_to_string(value).into();
-    translate_void_result(builder.add_kw(KnownEntid(entid), &kw, value), error);
+    translate_void_result(builder.add(KnownEntid(entid), kw, value), error);
 }
 
 /// Uses `builder` to assert `value` for `kw` on entity `entid`.
@@ -441,7 +440,7 @@ pub unsafe extern "C" fn in_progress_builder_add_long<'a, 'c>(
     let builder = &mut *builder;
     let kw = kw_from_string(c_char_to_string(kw));
     let value: TypedValue = TypedValue::Long(value);
-    translate_void_result(builder.add_kw(KnownEntid(entid), &kw, value), error);
+    translate_void_result(builder.add(KnownEntid(entid), kw, value), error);
 }
 
 /// Uses `builder` to assert `value` for `kw` on entity `entid`.
@@ -465,7 +464,7 @@ pub unsafe extern "C" fn in_progress_builder_add_ref<'a, 'c>(
     let builder = &mut *builder;
     let kw = kw_from_string(c_char_to_string(kw));
     let value: TypedValue = TypedValue::Ref(value);
-    translate_void_result(builder.add_kw(KnownEntid(entid), &kw, value), error);
+    translate_void_result(builder.add(KnownEntid(entid), kw, value), error);
 }
 
 /// Uses `builder` to assert `value` for `kw` on entity `entid`.
@@ -490,7 +489,7 @@ pub unsafe extern "C" fn in_progress_builder_add_keyword<'a, 'c>(
     let builder = &mut *builder;
     let kw = kw_from_string(c_char_to_string(kw));
     let value: TypedValue = kw_from_string(c_char_to_string(value)).into();
-    translate_void_result(builder.add_kw(KnownEntid(entid), &kw, value), error);
+    translate_void_result(builder.add(KnownEntid(entid), kw, value), error);
 }
 
 /// Uses `builder` to assert `value` for `kw` on entity `entid`.
@@ -514,7 +513,7 @@ pub unsafe extern "C" fn in_progress_builder_add_boolean<'a, 'c>(
     let builder = &mut *builder;
     let kw = kw_from_string(c_char_to_string(kw));
     let value: TypedValue = value.into();
-    translate_void_result(builder.add_kw(KnownEntid(entid), &kw, value), error);
+    translate_void_result(builder.add(KnownEntid(entid), kw, value), error);
 }
 
 /// Uses `builder` to assert `value` for `kw` on entity `entid`.
@@ -538,7 +537,7 @@ pub unsafe extern "C" fn in_progress_builder_add_double<'a, 'c>(
     let builder = &mut *builder;
     let kw = kw_from_string(c_char_to_string(kw));
     let value: TypedValue = value.into();
-    translate_void_result(builder.add_kw(KnownEntid(entid), &kw, value), error);
+    translate_void_result(builder.add(KnownEntid(entid), kw, value), error);
 }
 
 /// Uses `builder` to assert `value` for `kw` on entity `entid`.
@@ -562,7 +561,7 @@ pub unsafe extern "C" fn in_progress_builder_add_timestamp<'a, 'c>(
     let builder = &mut *builder;
     let kw = kw_from_string(c_char_to_string(kw));
     let value: TypedValue = TypedValue::instant(value);
-    translate_void_result(builder.add_kw(KnownEntid(entid), &kw, value), error);
+    translate_void_result(builder.add(KnownEntid(entid), kw, value), error);
 }
 
 /// Uses `builder` to assert `value` for `kw` on entity `entid`.
@@ -588,7 +587,7 @@ pub unsafe extern "C" fn in_progress_builder_add_uuid<'a, 'c>(
     let value = &*value;
     let value = Uuid::from_bytes(value).expect("valid uuid");
     let value: TypedValue = value.into();
-    translate_void_result(builder.add_kw(KnownEntid(entid), &kw, value), error);
+    translate_void_result(builder.add(KnownEntid(entid), kw, value), error);
 }
 
 /// Uses `builder` to retract `value` for `kw` on entity `entid`.
@@ -612,7 +611,7 @@ pub unsafe extern "C" fn in_progress_builder_retract_string<'a, 'c>(
     let builder = &mut *builder;
     let kw = kw_from_string(c_char_to_string(kw));
     let value: TypedValue = c_char_to_string(value).into();
-    translate_void_result(builder.retract_kw(KnownEntid(entid), &kw, value), error);
+    translate_void_result(builder.retract(KnownEntid(entid), kw, value), error);
 }
 
 /// Uses `builder` to retract `value` for `kw` on entity `entid`.
@@ -636,7 +635,7 @@ pub unsafe extern "C" fn in_progress_builder_retract_long<'a, 'c>(
     let builder = &mut *builder;
     let kw = kw_from_string(c_char_to_string(kw));
     let value: TypedValue = TypedValue::Long(value);
-    translate_void_result(builder.retract_kw(KnownEntid(entid), &kw, value), error);
+    translate_void_result(builder.retract(KnownEntid(entid), kw, value), error);
 }
 
 /// Uses `builder` to retract `value` for `kw` on entity `entid`.
@@ -660,7 +659,7 @@ pub unsafe extern "C" fn in_progress_builder_retract_ref<'a, 'c>(
     let builder = &mut *builder;
     let kw = kw_from_string(c_char_to_string(kw));
     let value: TypedValue = TypedValue::Ref(value);
-    translate_void_result(builder.retract_kw(KnownEntid(entid), &kw, value), error);
+    translate_void_result(builder.retract(KnownEntid(entid), kw, value), error);
 }
 
 
@@ -685,7 +684,7 @@ pub unsafe extern "C" fn in_progress_builder_retract_keyword<'a, 'c>(
     let builder = &mut *builder;
     let kw = kw_from_string(c_char_to_string(kw));
     let value: TypedValue = kw_from_string(c_char_to_string(value)).into();
-    translate_void_result(builder.retract_kw(KnownEntid(entid), &kw, value), error);
+    translate_void_result(builder.retract(KnownEntid(entid), kw, value), error);
 }
 
 /// Uses `builder` to retract `value` for `kw` on entity `entid`.
@@ -709,7 +708,7 @@ pub unsafe extern "C" fn in_progress_builder_retract_boolean<'a, 'c>(
     let builder = &mut *builder;
     let kw = kw_from_string(c_char_to_string(kw));
     let value: TypedValue = value.into();
-    translate_void_result(builder.retract_kw(KnownEntid(entid), &kw, value), error);
+    translate_void_result(builder.retract(KnownEntid(entid), kw, value), error);
 }
 
 /// Uses `builder` to retract `value` for `kw` on entity `entid`.
@@ -733,7 +732,7 @@ pub unsafe extern "C" fn in_progress_builder_retract_double<'a, 'c>(
     let builder = &mut *builder;
     let kw = kw_from_string(c_char_to_string(kw));
     let value: TypedValue = value.into();
-    translate_void_result(builder.retract_kw(KnownEntid(entid), &kw, value), error);
+    translate_void_result(builder.retract(KnownEntid(entid), kw, value), error);
 }
 
 /// Uses `builder` to retract `value` for `kw` on entity `entid`.
@@ -757,7 +756,7 @@ pub unsafe extern "C" fn in_progress_builder_retract_timestamp<'a, 'c>(
     let builder = &mut *builder;
     let kw = kw_from_string(c_char_to_string(kw));
     let value: TypedValue = TypedValue::instant(value);
-    translate_void_result(builder.retract_kw(KnownEntid(entid), &kw, value), error);
+    translate_void_result(builder.retract(KnownEntid(entid), kw, value), error);
 }
 
 /// Uses `builder` to retract `value` for `kw` on entity `entid`.
@@ -785,7 +784,7 @@ pub unsafe extern "C" fn in_progress_builder_retract_uuid<'a, 'c>(
     let value = &*value;
     let value = Uuid::from_bytes(value).expect("valid uuid");
     let value: TypedValue = value.into();
-    translate_void_result(builder.retract_kw(KnownEntid(entid), &kw, value), error);
+    translate_void_result(builder.retract(KnownEntid(entid), kw, value), error);
 }
 
 /// Transacts and commits all the assertions and retractions that have been performed
@@ -842,7 +841,7 @@ pub unsafe extern "C" fn entity_builder_add_string<'a, 'c>(
     let builder = &mut *builder;
     let kw = kw_from_string(c_char_to_string(kw));
     let value: TypedValue = c_char_to_string(value).into();
-    translate_void_result(builder.add_kw(&kw, value), error);
+    translate_void_result(builder.add(kw, value), error);
 }
 
 /// Uses `builder` to assert `value` for `kw` on entity `entid`.
@@ -865,7 +864,7 @@ pub unsafe extern "C" fn entity_builder_add_long<'a, 'c>(
     let builder = &mut *builder;
     let kw = kw_from_string(c_char_to_string(kw));
     let value: TypedValue = TypedValue::Long(value);
-    translate_void_result(builder.add_kw(&kw, value), error);
+    translate_void_result(builder.add(kw, value), error);
 }
 
 /// Uses `builder` to assert `value` for `kw` on entity `entid`.
@@ -888,7 +887,7 @@ pub unsafe extern "C" fn entity_builder_add_ref<'a, 'c>(
     let builder = &mut *builder;
     let kw = kw_from_string(c_char_to_string(kw));
     let value: TypedValue = TypedValue::Ref(value);
-    translate_void_result(builder.add_kw(&kw, value), error);
+    translate_void_result(builder.add(kw, value), error);
 }
 
 /// Uses `builder` to assert `value` for `kw` on entity `entid`.
@@ -911,7 +910,7 @@ pub unsafe extern "C" fn entity_builder_add_keyword<'a, 'c>(
     let builder = &mut *builder;
     let kw = kw_from_string(c_char_to_string(kw));
     let value: TypedValue = kw_from_string(c_char_to_string(value)).into();
-    translate_void_result(builder.add_kw(&kw, value), error);
+    translate_void_result(builder.add(kw, value), error);
 }
 
 /// Uses `builder` to assert `value` for `kw` on entity `entid`.
@@ -934,7 +933,7 @@ pub unsafe extern "C" fn entity_builder_add_boolean<'a, 'c>(
     let builder = &mut *builder;
     let kw = kw_from_string(c_char_to_string(kw));
     let value: TypedValue = value.into();
-    translate_void_result(builder.add_kw(&kw, value), error);
+    translate_void_result(builder.add(kw, value), error);
 }
 
 /// Uses `builder` to assert `value` for `kw` on entity `entid`.
@@ -957,7 +956,7 @@ pub unsafe extern "C" fn entity_builder_add_double<'a, 'c>(
     let builder = &mut *builder;
     let kw = kw_from_string(c_char_to_string(kw));
     let value: TypedValue = value.into();
-    translate_void_result(builder.add_kw(&kw, value), error);
+    translate_void_result(builder.add(kw, value), error);
 }
 
 /// Uses `builder` to assert `value` for `kw` on entity `entid`.
@@ -980,7 +979,7 @@ pub unsafe extern "C" fn entity_builder_add_timestamp<'a, 'c>(
     let builder = &mut *builder;
     let kw = kw_from_string(c_char_to_string(kw));
     let value: TypedValue = TypedValue::instant(value);
-    translate_void_result(builder.add_kw(&kw, value), error);
+    translate_void_result(builder.add(kw, value), error);
 }
 
 /// Uses `builder` to assert `value` for `kw` on entity `entid`.
@@ -1005,7 +1004,7 @@ pub unsafe extern "C" fn entity_builder_add_uuid<'a, 'c>(
     let value = &*value;
     let value = Uuid::from_bytes(value).expect("valid uuid");
     let value: TypedValue = value.into();
-    translate_void_result(builder.add_kw(&kw, value), error);
+    translate_void_result(builder.add(kw, value), error);
 }
 
 /// Uses `builder` to retract `value` for `kw` on entity `entid`.
@@ -1028,7 +1027,7 @@ pub unsafe extern "C" fn entity_builder_retract_string<'a, 'c>(
     let builder = &mut *builder;
     let kw = kw_from_string(c_char_to_string(kw));
     let value: TypedValue = c_char_to_string(value).into();
-    translate_void_result(builder.retract_kw(&kw, value), error);
+    translate_void_result(builder.retract(kw, value), error);
 }
 
 /// Uses `builder` to retract `value` for `kw` on entity `entid`.
@@ -1051,7 +1050,7 @@ pub unsafe extern "C" fn entity_builder_retract_long<'a, 'c>(
     let builder = &mut *builder;
     let kw = kw_from_string(c_char_to_string(kw));
     let value: TypedValue = TypedValue::Long(value);
-    translate_void_result(builder.retract_kw(&kw, value), error);
+    translate_void_result(builder.retract(kw, value), error);
 }
 
 /// Uses `builder` to retract `value` for `kw` on entity `entid`.
@@ -1074,7 +1073,7 @@ pub unsafe extern "C" fn entity_builder_retract_ref<'a, 'c>(
     let builder = &mut *builder;
     let kw = kw_from_string(c_char_to_string(kw));
     let value: TypedValue = TypedValue::Ref(value);
-    translate_void_result(builder.retract_kw(&kw, value), error);
+    translate_void_result(builder.retract(kw, value), error);
 }
 
 /// Uses `builder` to retract `value` for `kw` on entity `entid`.
@@ -1097,7 +1096,7 @@ pub unsafe extern "C" fn entity_builder_retract_keyword<'a, 'c>(
     let builder = &mut *builder;
     let kw = kw_from_string(c_char_to_string(kw));
     let value: TypedValue = kw_from_string(c_char_to_string(value)).into();
-    translate_void_result(builder.retract_kw(&kw, value), error);
+    translate_void_result(builder.retract(kw, value), error);
 }
 
 /// Uses `builder` to retract `value` for `kw` on entity `entid`.
@@ -1120,7 +1119,7 @@ pub unsafe extern "C" fn entity_builder_retract_boolean<'a, 'c>(
     let builder = &mut *builder;
     let kw = kw_from_string(c_char_to_string(kw));
     let value: TypedValue = value.into();
-    translate_void_result(builder.retract_kw(&kw, value), error);
+    translate_void_result(builder.retract(kw, value), error);
 }
 
 /// Uses `builder` to retract `value` for `kw` on entity `entid`.
@@ -1143,7 +1142,7 @@ pub unsafe extern "C" fn entity_builder_retract_double<'a, 'c>(
     let builder = &mut *builder;
     let kw = kw_from_string(c_char_to_string(kw));
     let value: TypedValue = value.into();
-    translate_void_result(builder.retract_kw(&kw, value), error);
+    translate_void_result(builder.retract(kw, value), error);
 }
 
 /// Uses `builder` to retract `value` for `kw` on entity `entid`.
@@ -1166,7 +1165,7 @@ pub unsafe extern "C" fn entity_builder_retract_timestamp<'a, 'c>(
     let builder = &mut *builder;
     let kw = kw_from_string(c_char_to_string(kw));
     let value: TypedValue = TypedValue::instant(value);
-    translate_void_result(builder.retract_kw(&kw, value), error);
+    translate_void_result(builder.retract(kw, value), error);
 }
 
 /// Uses `builder` to retract `value` for `kw` on entity `entid`.
@@ -1192,7 +1191,7 @@ pub unsafe extern "C" fn entity_builder_retract_uuid<'a, 'c>(
     let value = &*value;
     let value = Uuid::from_bytes(value).expect("valid uuid");
     let value: TypedValue = value.into();
-    translate_void_result(builder.retract_kw(&kw, value), error);
+    translate_void_result(builder.retract(kw, value), error);
 }
 
 /// Transacts all the assertions and retractions that have been performed

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -41,6 +41,9 @@ use rusqlite::{
 };
 
 use edn;
+use edn::{
+    InternSet,
+};
 
 use mentat_core::{
     Attribute,
@@ -50,12 +53,11 @@ use mentat_core::{
     Keyword,
     Schema,
     StructuredMap,
+    TxReport,
     TypedValue,
     ValueRc,
     ValueType,
 };
-
-use mentat_core::intern_set::InternSet;
 
 use mentat_db::cache::{
     InProgressCacheTransactWatcher,
@@ -73,7 +75,6 @@ use mentat_db::{
     TransactWatcher,
     TxObservationService,
     TxObserver,
-    TxReport,
 };
 
 use mentat_db::internal_types::TermWithTempIds;
@@ -401,8 +402,8 @@ impl<'a, 'c> InProgress<'a, 'c> {
     /// This exists so you can make your own.
     pub fn transact_builder(&mut self, builder: TermBuilder) -> Result<TxReport> {
         builder.build()
-               .and_then(|(terms, tempid_set)| {
-                    self.transact_terms(terms, tempid_set)
+               .and_then(|(terms, _tempid_set)| {
+                    self.transact_entities(terms)
                })
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@ pub use mentat_core::{
     Keyword,
     Schema,
     Binding,
+    TxReport,
     TypedValue,
     Uuid,
     Utc,
@@ -56,7 +57,6 @@ pub use mentat_db::{
     DB_SCHEMA_CORE,
     AttributeSet,
     TxObserver,
-    TxReport,
     new_connection,
 };
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -30,12 +30,12 @@ use mentat_core::{
     Entid,
     Keyword,
     StructuredMap,
+    TxReport,
     TypedValue,
     ValueRc,
 };
 use mentat_db::{
     TxObserver,
-    TxReport,
 };
 
 use mentat_tolstoy::Syncer;
@@ -607,12 +607,12 @@ mod tests {
                 let name = format!("todo{}", i);
                 let uuid = Uuid::new_v4();
                 let mut builder = in_progress.builder().describe_tempid(&name);
-                builder.add_kw(&kw!(:todo/uuid), TypedValue::Uuid(uuid)).expect("Expected added uuid");
+                builder.add(kw!(:todo/uuid), TypedValue::Uuid(uuid)).expect("Expected added uuid");
                 changeset.insert(uuid_entid.clone());
-                builder.add_kw(&kw!(:todo/name), TypedValue::typed_string(&name)).expect("Expected added name");
+                builder.add(kw!(:todo/name), TypedValue::typed_string(&name)).expect("Expected added name");
                 changeset.insert(name_entid.clone());
                 if i % 2 == 0 {
-                    builder.add_kw(&kw!(:todo/completion_date), TypedValue::current_instant()).expect("Expected added date");
+                    builder.add(kw!(:todo/completion_date), TypedValue::current_instant()).expect("Expected added date");
                     changeset.insert(date_entid.clone());
                 }
                 let (ip, r) = builder.transact();
@@ -622,8 +622,8 @@ mod tests {
                 in_progress = ip;
             }
             let mut builder = in_progress.builder().describe_tempid("Label");
-            builder.add_kw(&kw!(:label/name), TypedValue::typed_string("Label 1")).expect("Expected added name");
-            builder.add_kw(&kw!(:label/color), TypedValue::typed_string("blue")).expect("Expected added color");
+            builder.add(kw!(:label/name), TypedValue::typed_string("Label 1")).expect("Expected added name");
+            builder.add(kw!(:label/color), TypedValue::typed_string("blue")).expect("Expected added color");
             builder.commit().expect("expect transaction to occur");
         }
 
@@ -678,8 +678,8 @@ mod tests {
             for i in 0..3 {
                 let name = format!("label{}", i);
                 let mut builder = in_progress.builder().describe_tempid(&name);
-                builder.add_kw(&kw!(:label/name), TypedValue::typed_string(&name)).expect("Expected added name");
-                builder.add_kw(&kw!(:label/color), TypedValue::typed_string("blue")).expect("Expected added color");
+                builder.add(kw!(:label/name), TypedValue::typed_string(&name)).expect("Expected added name");
+                builder.add(kw!(:label/color), TypedValue::typed_string("blue")).expect("Expected added color");
                 let (ip, _) = builder.transact();
                 in_progress = ip;
             }

--- a/src/vocabulary.rs
+++ b/src/vocabulary.rs
@@ -812,14 +812,14 @@ impl VocabularySource for SimpleVocabularySource {
 impl<'a, 'c> VocabularyMechanics for InProgress<'a, 'c> {
     /// Turn the vocabulary into datoms, transact them, and on success return the outcome.
     fn install_vocabulary(&mut self, definition: &Definition) -> Result<VocabularyOutcome> {
-        let (terms, tempids) = definition.description(self)?;
-        self.transact_terms(terms, tempids)?;
+        let (terms, _tempids) = definition.description(self)?;
+        self.transact_entities(terms)?;
         Ok(VocabularyOutcome::Installed)
     }
 
     fn install_attributes_for<'definition>(&mut self, definition: &'definition Definition, attributes: Vec<&'definition (Keyword, Attribute)>) -> Result<VocabularyOutcome> {
-        let (terms, tempids) = definition.description_for_attributes(&attributes, self, None)?;
-        self.transact_terms(terms, tempids)?;
+        let (terms, _tempids) = definition.description_for_attributes(&attributes, self, None)?;
+        self.transact_entities(terms)?;
         Ok(VocabularyOutcome::InstalledMissingAttributes)
     }
 
@@ -834,8 +834,8 @@ impl<'a, 'c> VocabularyMechanics for InProgress<'a, 'c> {
 
         // TODO: don't do work for attributes that are unchanged. Here we rely on the transactor
         // to elide duplicate datoms.
-        let (terms, tempids) = definition.description_diff(self, &from_version)?;
-        self.transact_terms(terms, tempids)?;
+        let (terms, _tempids) = definition.description_diff(self, &from_version)?;
+        self.transact_entities(terms)?;
 
         definition.post(self, &from_version)?;
         Ok(VocabularyOutcome::Upgraded)


### PR DESCRIPTION
I haven't tried to rename `EntityBuilder` (or remove it), and I haven't tried to rename `TermBuilder` to `EntityBuilder`.  Those can come later.

This also doesn't intern `TempId` handles at parse time; we can get to that.

This addresses #674.