### PR TITLE
Enforce partition integrity & PartitionMap newtype

### DIFF
--- a/db/src/db.rs
+++ b/db/src/db.rs
@@ -14,12 +14,10 @@ use failure::{
     ResultExt,
 };
 
-use std::borrow::Borrow;
 use std::collections::HashMap;
 use std::collections::hash_map::{
     Entry,
 };
-use std::fmt::Display;
 use std::iter::{once, repeat};
 use std::ops::Range;
 use std::path::Path;
@@ -1080,20 +1078,14 @@ SELECT EXISTS
     Ok(())
 }
 
-pub trait PartitionMapping {
-    fn allocate_entid<S: ?Sized + Ord + Display>(&mut self, partition: &S) -> i64 where String: Borrow<S>;
-    fn allocate_entids<S: ?Sized + Ord + Display>(&mut self, partition: &S, n: usize) -> Range<i64> where String: Borrow<S>;
-    fn contains_entid(&self, entid: Entid) -> bool;
-}
-
-impl PartitionMapping for PartitionMap {
+impl PartitionMap {
     /// Allocate a single fresh entid in the given `partition`.
-    fn allocate_entid<S: ?Sized + Ord + Display>(&mut self, partition: &S) -> i64 where String: Borrow<S> {
+    pub(crate) fn allocate_entid(&mut self, partition: &str) -> i64 {
         self.allocate_entids(partition, 1).start
     }
 
     /// Allocate `n` fresh entids in the given `partition`.
-    fn allocate_entids<S: ?Sized + Ord + Display>(&mut self, partition: &S, n: usize) -> Range<i64> where String: Borrow<S> {
+    pub(crate) fn allocate_entids(&mut self, partition: &str, n: usize) -> Range<i64> {
         match self.get_mut(partition) {
             Some(partition) => {
                 let idx = partition.index;
@@ -1105,7 +1097,7 @@ impl PartitionMapping for PartitionMap {
         }
     }
 
-    fn contains_entid(&self, entid: Entid) -> bool {
+    pub(crate) fn contains_entid(&self, entid: Entid) -> bool {
         self.values().any(|partition| partition.contains_entid(entid))
     }
 }
@@ -1113,6 +1105,10 @@ impl PartitionMapping for PartitionMap {
 #[cfg(test)]
 mod tests {
     extern crate env_logger;
+
+    use std::borrow::{
+        Borrow,
+    };
 
     use super::*;
     use debug::{TestConn,tempids};

--- a/db/src/db.rs
+++ b/db/src/db.rs
@@ -1089,13 +1089,8 @@ impl PartitionMap {
     /// Allocate `n` fresh entids in the given `partition`.
     pub(crate) fn allocate_entids(&mut self, partition: &str, n: usize) -> Range<i64> {
         match self.get_mut(partition) {
-            Some(partition) => {
-                let idx = partition.next_entid();
-                partition.set_next_entid(idx + n as i64);
-                idx..partition.next_entid()
-            },
-            // This is a programming error.
-            None => panic!("Cannot allocate entid from unknown partition: {}", partition),
+            Some(partition) => partition.allocate_entids(n),
+            None => panic!("Cannot allocate entid from unknown partition: {}", partition)
         }
     }
 

--- a/db/src/debug.rs
+++ b/db/src/debug.rs
@@ -379,7 +379,7 @@ impl TestConn {
     }
 
     pub fn last_tx_id(&self) -> Entid {
-        self.partition_map.get(&":db.part/tx".to_string()).unwrap().index - 1
+        self.partition_map.get(&":db.part/tx".to_string()).unwrap().next_entid() - 1
     }
 
     pub fn last_transaction(&self) -> Datoms {
@@ -415,7 +415,7 @@ impl TestConn {
         // Add a fake partition to allow tests to do things like
         // [:db/add 111 :foo/bar 222]
         {
-            let fake_partition = Partition { start: 100, end: 2000, index: 1000, allow_excision: true };
+            let fake_partition = Partition::new(100, 2000, 1000, true);
             parts.insert(":db.part/fake".into(), fake_partition);
         }
 

--- a/db/src/tx.rs
+++ b/db/src/tx.rs
@@ -60,7 +60,6 @@ use std::iter::{
 use db;
 use db::{
     MentatStoring,
-    PartitionMapping,
 };
 use edn::{
     InternSet,

--- a/db/src/types.rs
+++ b/db/src/types.rs
@@ -10,10 +10,17 @@
 
 #![allow(dead_code)]
 
-use std::collections::HashMap;
 use std::collections::{
     BTreeMap,
     BTreeSet,
+    HashMap,
+};
+use std::iter::{
+    FromIterator,
+};
+use std::ops::{
+    Deref,
+    DerefMut,
 };
 
 extern crate mentat_core;
@@ -37,7 +44,7 @@ use edn::entities::{
 use errors;
 
 /// Represents one partition of the entid space.
-#[derive(Clone,Debug,Eq,Hash,Ord,PartialOrd,PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialOrd, PartialEq)]
 #[cfg_attr(feature = "syncable", derive(Serialize,Deserialize))]
 pub struct Partition {
     /// The first entid in the partition.
@@ -66,7 +73,28 @@ impl Partition {
 }
 
 /// Map partition names to `Partition` instances.
-pub type PartitionMap = BTreeMap<String, Partition>;
+#[derive(Clone, Debug, Default, Eq, Hash, Ord, PartialOrd, PartialEq)]
+pub struct PartitionMap(BTreeMap<String, Partition>);
+
+impl Deref for PartitionMap {
+    type Target = BTreeMap<String, Partition>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for PartitionMap {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl FromIterator<(String, Partition)> for PartitionMap {
+    fn from_iter<T: IntoIterator<Item=(String, Partition)>>(iter: T) -> Self {
+        PartitionMap(iter.into_iter().collect())
+    }
+}
 
 /// Represents the metadata required to query from, or apply transactions to, a Mentat store.
 ///


### PR DESCRIPTION
Peeling off bits and pieces off of timelines work.

Partition integrity stuff helps us ensure we're doing sane things when moving an index in irregular ways. PartitionMap newtype conversion is non-controversial and helps clean up things a little bit.