### PR TITLE
Run `serde_support` tests for the EDN module on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ matrix:
   fast_finish: true
 script:
   - cargo test --verbose --all
+  - cargo test --features edn/serde_support --verbose --all
   # We can't pick individual features out with `cargo test --all` (At the time of this writing, this
   # works but does the wrong thing because of a bug in cargo, but its fix will be to disallow doing
   # this all-together, see https://github.com/rust-lang/cargo/issues/5364 for more information). To


### PR DESCRIPTION
Signed-off-by: Victor Porof <victor.porof@gmail.com>

This is a leftover from https://github.com/mozilla/mentat/pull/726 which we forgot to land.