### PR TITLE
Generate rust documentation on CI and publish to gh-pages automatically

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,12 @@ script:
     for manifest in $(find . -type f -name Cargo.toml); do
       cargo test --manifest-path $manifest --verbose --no-default-features --features sqlcipher
     done
+after_success:
+  - |
+    if [[ "$TRAVIS_PULL_REQUEST" = "false" && "$TRAVIS_BRANCH" == "master" ]]; then
+      cargo doc &&
+      echo "<meta http-equiv=refresh content=0;url=mentat/index.html>" > target/doc/index.html &&
+      git clone https://github.com/davisp/ghp-import.git &&
+      ./ghp-import/ghp_import.py -n -p -f -r https://"$GH_TOKEN"@github.com/"$TRAVIS_REPO_SLUG.git" target/doc
+    fi
 cache: cargo

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ The first version of Project Mentat, named Datomish, [was written in ClojureScri
 
 The Rust implementation gives us a smaller compiled output, better performance, more type safety, better tooling, and easier deployment into Firefox and mobile platforms.
 
+[Documentation](https://mozilla.github.io/mentat)
+
 ---
 
 ## Motivation


### PR DESCRIPTION
Signed-off-by: Victor Porof <victor.porof@gmail.com>

A very simple start for generating documentation automatically.

Here's how it looks like: https://victorporof.github.io/mentat
When this PR is merged, this link will also point to the rust API documentation: https://mozilla.github.io/mentat

The `gh-pages` branch would look like this: https://github.com/victorporof/mentat/tree/gh-pages

This PR implements the following: 
1. Upon successful test runs on the master branch (and not for pull requests), run `cargo doc` to generate documentation.
2. If that succeeds, create an `index.html` entry-point for the projects's `gh-pages` website that redirects to the generated documentation for the top-level mentat crate.
3. Copy the CI-generated documentation and the index into the `gh-pages` branch, overwriting everything that was previously there.

A link to the documentation is also added to the README.

The importing of the generated documentation into the `gh-pages` branch is done with a very simple [ghp-import](https://github.com/davisp/ghp-import/blob/master/ghp_import.py) python script that I came across. In the long term, it's likely that we'll want to roll out our own, especially since we want to provide more than just Rust API documentation. However I think this is fine for now.

I've added a GitHub token for allowing pushing to the repo from the CI machine: https://travis-ci.org/mozilla/mentat/settings It follows the recommendations from https://docs.travis-ci.com/user/deployment/pages/#Setting-the-GitHub-token