### PR TITLE
Make sure mentat error types preserve failure backtraces (wip)

### DIFF
--- a/query-algebrizer/src/clauses/convert.rs
+++ b/query-algebrizer/src/clauses/convert.rs
@@ -28,7 +28,7 @@ use clauses::{
 };
 
 use errors::{
-    AlgebrizerError,
+    AlgebrizerErrorKind,
     Result,
 };
 
@@ -80,12 +80,12 @@ impl ValueTypes for FnArg {
 
                 &FnArg::Constant(NonIntegerConstant::BigInteger(_)) => {
                     // Not yet implemented.
-                    bail!(AlgebrizerError::UnsupportedArgument)
+                    bail!(AlgebrizerErrorKind::UnsupportedArgument)
                 },
 
                 // These don't make sense here. TODO: split FnArg into scalar and non-scalar…
                 &FnArg::Vector(_) |
-                &FnArg::SrcVar(_) => bail!(AlgebrizerError::UnsupportedArgument),
+                &FnArg::SrcVar(_) => bail!(AlgebrizerErrorKind::UnsupportedArgument),
 
                 // These are all straightforward.
                 &FnArg::Constant(NonIntegerConstant::Boolean(_)) => ValueTypeSet::of_one(ValueType::Boolean),
@@ -196,7 +196,7 @@ impl ConjoiningClauses {
             FnArg::Variable(in_var) => {
                 // TODO: technically you could ground an existing variable inside the query….
                 if !self.input_variables.contains(&in_var) {
-                    bail!(AlgebrizerError::UnboundVariable((*in_var.0).clone()))
+                    bail!(AlgebrizerErrorKind::UnboundVariable((*in_var.0).clone()))
                 }
                 match self.bound_value(&in_var) {
                     // The type is already known if it's a bound variable….
@@ -205,7 +205,7 @@ impl ConjoiningClauses {
                         // The variable is present in `:in`, but it hasn't yet been provided.
                         // This is a restriction we will eventually relax: we don't yet have a way
                         // to collect variables as part of a computed table or substitution.
-                        bail!(AlgebrizerError::UnboundVariable((*in_var.0).clone()))
+                        bail!(AlgebrizerErrorKind::UnboundVariable((*in_var.0).clone()))
                     },
                 }
             },
@@ -215,7 +215,7 @@ impl ConjoiningClauses {
 
             // These don't make sense here.
             FnArg::Vector(_) |
-            FnArg::SrcVar(_) => bail!(AlgebrizerError::InvalidGroundConstant),
+            FnArg::SrcVar(_) => bail!(AlgebrizerErrorKind::InvalidGroundConstant),
 
             // These are all straightforward.
             FnArg::Constant(NonIntegerConstant::Boolean(x)) => {

--- a/query-algebrizer/src/clauses/fulltext.rs
+++ b/query-algebrizer/src/clauses/fulltext.rs
@@ -30,7 +30,7 @@ use clauses::{
 };
 
 use errors::{
-    AlgebrizerError,
+    AlgebrizerErrorKind,
     BindingError,
     Result,
 };
@@ -53,17 +53,17 @@ impl ConjoiningClauses {
     #[allow(unused_variables)]
     pub(crate) fn apply_fulltext(&mut self, known: Known, where_fn: WhereFn) -> Result<()> {
         if where_fn.args.len() != 3 {
-            bail!(AlgebrizerError::InvalidNumberOfArguments(where_fn.operator.clone(), where_fn.args.len(), 3));
+            bail!(AlgebrizerErrorKind::InvalidNumberOfArguments(where_fn.operator.clone(), where_fn.args.len(), 3));
         }
 
         if where_fn.binding.is_empty() {
             // The binding must introduce at least one bound variable.
-            bail!(AlgebrizerError::InvalidBinding(where_fn.operator.clone(), BindingError::NoBoundVariable));
+            bail!(AlgebrizerErrorKind::InvalidBinding(where_fn.operator.clone(), BindingError::NoBoundVariable));
         }
 
         if !where_fn.binding.is_valid() {
             // The binding must not duplicate bound variables.
-            bail!(AlgebrizerError::InvalidBinding(where_fn.operator.clone(), BindingError::RepeatedBoundVariable));
+            bail!(AlgebrizerErrorKind::InvalidBinding(where_fn.operator.clone(), BindingError::RepeatedBoundVariable));
         }
 
         // We should have exactly four bindings. Destructure them now.
@@ -71,7 +71,7 @@ impl ConjoiningClauses {
             Binding::BindRel(bindings) => {
                 let bindings_count = bindings.len();
                 if bindings_count < 1 || bindings_count > 4 {
-                    bail!(AlgebrizerError::InvalidBinding(where_fn.operator.clone(),
+                    bail!(AlgebrizerErrorKind::InvalidBinding(where_fn.operator.clone(),
                         BindingError::InvalidNumberOfBindings {
                             number: bindings.len(),
                             expected: 4,
@@ -82,7 +82,7 @@ impl ConjoiningClauses {
             },
             Binding::BindScalar(_) |
             Binding::BindTuple(_) |
-            Binding::BindColl(_) => bail!(AlgebrizerError::InvalidBinding(where_fn.operator.clone(), BindingError::ExpectedBindRel)),
+            Binding::BindColl(_) => bail!(AlgebrizerErrorKind::InvalidBinding(where_fn.operator.clone(), BindingError::ExpectedBindRel)),
         };
         let mut bindings = bindings.into_iter();
         let b_entity = bindings.next().unwrap();
@@ -95,7 +95,7 @@ impl ConjoiningClauses {
         // TODO: process source variables.
         match args.next().unwrap() {
             FnArg::SrcVar(SrcVar::DefaultSrc) => {},
-            _ => bail!(AlgebrizerError::InvalidArgument(where_fn.operator.clone(), "source variable", 0)),
+            _ => bail!(AlgebrizerErrorKind::InvalidArgument(where_fn.operator.clone(), "source variable", 0)),
         }
 
         let schema = known.schema;
@@ -115,10 +115,10 @@ impl ConjoiningClauses {
                 match self.bound_value(&v) {
                     Some(TypedValue::Ref(entid)) => Some(entid),
                     Some(tv) => {
-                        bail!(AlgebrizerError::InputTypeDisagreement(v.name().clone(), ValueType::Ref, tv.value_type()))
+                        bail!(AlgebrizerErrorKind::InputTypeDisagreement(v.name().clone(), ValueType::Ref, tv.value_type()))
                     },
                     None => {
-                        bail!(AlgebrizerError::UnboundVariable((*v.0).clone()))
+                        bail!(AlgebrizerErrorKind::UnboundVariable((*v.0).clone()))
                     }
                 }
             },
@@ -128,10 +128,10 @@ impl ConjoiningClauses {
         // An unknown ident, or an entity that isn't present in the store, or isn't a fulltext
         // attribute, is likely enough to be a coding error that we choose to bail instead of
         // marking the pattern as known-empty.
-        let a = a.ok_or(AlgebrizerError::InvalidArgument(where_fn.operator.clone(), "attribute", 1))?;
+        let a = a.ok_or(AlgebrizerErrorKind::InvalidArgument(where_fn.operator.clone(), "attribute", 1))?;
         let attribute = schema.attribute_for_entid(a)
                               .cloned()
-                              .ok_or(AlgebrizerError::InvalidArgument(where_fn.operator.clone(),
+                              .ok_or(AlgebrizerErrorKind::InvalidArgument(where_fn.operator.clone(),
                                                                 "attribute", 1))?;
 
         if !attribute.fulltext {
@@ -170,18 +170,18 @@ impl ConjoiningClauses {
             FnArg::Variable(in_var) => {
                 match self.bound_value(&in_var) {
                     Some(t @ TypedValue::String(_)) => Either::Left(t),
-                    Some(_) => bail!(AlgebrizerError::InvalidArgument(where_fn.operator.clone(), "string", 2)),
+                    Some(_) => bail!(AlgebrizerErrorKind::InvalidArgument(where_fn.operator.clone(), "string", 2)),
                     None => {
                         // Regardless of whether we'll be providing a string later, or the value
                         // comes from a column, it must be a string.
                         if self.known_type(&in_var) != Some(ValueType::String) {
-                            bail!(AlgebrizerError::InvalidArgument(where_fn.operator.clone(), "string", 2))
+                            bail!(AlgebrizerErrorKind::InvalidArgument(where_fn.operator.clone(), "string", 2))
                         }
 
                         if self.input_variables.contains(&in_var) {
                             // Sorry, we haven't implemented late binding.
                             // TODO: implement this.
-                            bail!(AlgebrizerError::UnboundVariable((*in_var.0).clone()))
+                            bail!(AlgebrizerErrorKind::UnboundVariable((*in_var.0).clone()))
                         } else {
                             // It must be bound earlier in the query. We already established that
                             // it must be a string column.
@@ -190,13 +190,13 @@ impl ConjoiningClauses {
                                                        .and_then(|bindings| bindings.get(0).cloned()) {
                                 Either::Right(binding)
                             } else {
-                                bail!(AlgebrizerError::UnboundVariable((*in_var.0).clone()))
+                                bail!(AlgebrizerErrorKind::UnboundVariable((*in_var.0).clone()))
                             }
                         }
                     },
                 }
             },
-            _ => bail!(AlgebrizerError::InvalidArgument(where_fn.operator.clone(), "string", 2)),
+            _ => bail!(AlgebrizerErrorKind::InvalidArgument(where_fn.operator.clone(), "string", 2)),
         };
 
         let qv = match search {
@@ -245,7 +245,7 @@ impl ConjoiningClauses {
 
             // We do not allow the score to be bound.
             if self.value_bindings.contains_key(var) || self.input_variables.contains(var) {
-                bail!(AlgebrizerError::InvalidBinding(var.name(), BindingError::UnexpectedBinding));
+                bail!(AlgebrizerErrorKind::InvalidBinding(var.name(), BindingError::UnexpectedBinding));
             }
 
             // We bind the value ourselves. This handily takes care of substituting into existing uses.

--- a/query-algebrizer/src/clauses/inputs.rs
+++ b/query-algebrizer/src/clauses/inputs.rs
@@ -20,7 +20,7 @@ use mentat_query::{
 };
 
 use errors::{
-    AlgebrizerError,
+    AlgebrizerErrorKind,
     Result,
 };
 
@@ -72,7 +72,7 @@ impl QueryInputs {
             let old = types.insert(var.clone(), t);
             if let Some(old) = old {
                 if old != t {
-                    bail!(AlgebrizerError::InputTypeDisagreement(var.name(), old, t));
+                    bail!(AlgebrizerErrorKind::InputTypeDisagreement(var.name(), old, t));
                 }
             }
         }

--- a/query-algebrizer/src/clauses/mod.rs
+++ b/query-algebrizer/src/clauses/mod.rs
@@ -53,7 +53,7 @@ use mentat_query::{
 };
 
 use errors::{
-    AlgebrizerError,
+    AlgebrizerErrorKind,
     Result,
 };
 
@@ -1013,7 +1013,7 @@ impl ConjoiningClauses {
 
             let qa = self.extracted_types
                          .get(&var)
-                         .ok_or_else(|| AlgebrizerError::UnboundVariable(var.name()))?;
+                         .ok_or_else(|| AlgebrizerErrorKind::UnboundVariable(var.name()))?;
             self.wheres.add_intersection(ColumnConstraint::HasTypes {
                 value: qa.0.clone(),
                 value_types: types,

--- a/query-algebrizer/src/clauses/not.rs
+++ b/query-algebrizer/src/clauses/not.rs
@@ -17,7 +17,7 @@ use mentat_query::{
 use clauses::ConjoiningClauses;
 
 use errors::{
-    AlgebrizerError,
+    AlgebrizerErrorKind,
     Result,
 };
 
@@ -45,7 +45,7 @@ impl ConjoiningClauses {
                 let col = self.column_bindings.get(&v).unwrap()[0].clone();
                 template.column_bindings.insert(v.clone(), vec![col]);
             } else {
-                bail!(AlgebrizerError::UnboundVariable(v.name()));
+                bail!(AlgebrizerErrorKind::UnboundVariable(v.name()));
             }
         }
 
@@ -111,7 +111,7 @@ mod testing {
     };
 
     use errors::{
-        AlgebrizerError,
+        AlgebrizerErrorKind,
     };
 
     use types::{
@@ -553,8 +553,8 @@ mod testing {
          :where (not [?x :foo/knows ?y])]"#;
         let parsed = parse_find_string(query).expect("parse failed");
         let err = algebrize(known, parsed).expect_err("algebrization should have failed");
-        match err {
-            AlgebrizerError::UnboundVariable(var) => { assert_eq!(var, PlainSymbol("?x".to_string())); },
+        match err.kind() {
+            &AlgebrizerErrorKind::UnboundVariable(ref var) => { assert_eq!(var, &PlainSymbol("?x".to_string())); },
             x => panic!("expected Unbound Variable error, got {:?}", x),
         }
     }

--- a/query-algebrizer/src/clauses/tx_log_api.rs
+++ b/query-algebrizer/src/clauses/tx_log_api.rs
@@ -25,7 +25,7 @@ use clauses::{
 };
 
 use errors::{
-    AlgebrizerError,
+    AlgebrizerErrorKind,
     BindingError,
     Result,
 };
@@ -60,17 +60,17 @@ impl ConjoiningClauses {
     // transactions that impact one of the given attributes.
     pub(crate) fn apply_tx_ids(&mut self, known: Known, where_fn: WhereFn) -> Result<()> {
         if where_fn.args.len() != 3 {
-            bail!(AlgebrizerError::InvalidNumberOfArguments(where_fn.operator.clone(), where_fn.args.len(), 3));
+            bail!(AlgebrizerErrorKind::InvalidNumberOfArguments(where_fn.operator.clone(), where_fn.args.len(), 3));
         }
 
         if where_fn.binding.is_empty() {
             // The binding must introduce at least one bound variable.
-            bail!(AlgebrizerError::InvalidBinding(where_fn.operator.clone(), BindingError::NoBoundVariable));
+            bail!(AlgebrizerErrorKind::InvalidBinding(where_fn.operator.clone(), BindingError::NoBoundVariable));
         }
 
         if !where_fn.binding.is_valid() {
             // The binding must not duplicate bound variables.
-            bail!(AlgebrizerError::InvalidBinding(where_fn.operator.clone(), BindingError::RepeatedBoundVariable));
+            bail!(AlgebrizerErrorKind::InvalidBinding(where_fn.operator.clone(), BindingError::RepeatedBoundVariable));
         }
 
         // We should have exactly one binding. Destructure it now.
@@ -78,7 +78,7 @@ impl ConjoiningClauses {
             Binding::BindRel(bindings) => {
                 let bindings_count = bindings.len();
                 if bindings_count != 1 {
-                    bail!(AlgebrizerError::InvalidBinding(where_fn.operator.clone(),
+                    bail!(AlgebrizerErrorKind::InvalidBinding(where_fn.operator.clone(),
                                                     BindingError::InvalidNumberOfBindings {
                                                         number: bindings_count,
                                                         expected: 1,
@@ -92,7 +92,7 @@ impl ConjoiningClauses {
             Binding::BindColl(v) => v,
             Binding::BindScalar(_) |
             Binding::BindTuple(_) => {
-                bail!(AlgebrizerError::InvalidBinding(where_fn.operator.clone(), BindingError::ExpectedBindRelOrBindColl))
+                bail!(AlgebrizerErrorKind::InvalidBinding(where_fn.operator.clone(), BindingError::ExpectedBindRelOrBindColl))
             },
         };
 
@@ -101,7 +101,7 @@ impl ConjoiningClauses {
         // TODO: process source variables.
         match args.next().unwrap() {
             FnArg::SrcVar(SrcVar::DefaultSrc) => {},
-            _ => bail!(AlgebrizerError::InvalidArgument(where_fn.operator.clone(), "source variable", 0)),
+            _ => bail!(AlgebrizerErrorKind::InvalidArgument(where_fn.operator.clone(), "source variable", 0)),
         }
 
         let tx1 = self.resolve_tx_argument(&known.schema, &where_fn.operator, 1, args.next().unwrap())?;
@@ -138,17 +138,17 @@ impl ConjoiningClauses {
 
     pub(crate) fn apply_tx_data(&mut self, known: Known, where_fn: WhereFn) -> Result<()> {
         if where_fn.args.len() != 2 {
-            bail!(AlgebrizerError::InvalidNumberOfArguments(where_fn.operator.clone(), where_fn.args.len(), 2));
+            bail!(AlgebrizerErrorKind::InvalidNumberOfArguments(where_fn.operator.clone(), where_fn.args.len(), 2));
         }
 
         if where_fn.binding.is_empty() {
             // The binding must introduce at least one bound variable.
-            bail!(AlgebrizerError::InvalidBinding(where_fn.operator.clone(), BindingError::NoBoundVariable));
+            bail!(AlgebrizerErrorKind::InvalidBinding(where_fn.operator.clone(), BindingError::NoBoundVariable));
         }
 
         if !where_fn.binding.is_valid() {
             // The binding must not duplicate bound variables.
-            bail!(AlgebrizerError::InvalidBinding(where_fn.operator.clone(), BindingError::RepeatedBoundVariable));
+            bail!(AlgebrizerErrorKind::InvalidBinding(where_fn.operator.clone(), BindingError::RepeatedBoundVariable));
         }
 
         // We should have at most five bindings. Destructure them now.
@@ -156,7 +156,7 @@ impl ConjoiningClauses {
             Binding::BindRel(bindings) => {
                 let bindings_count = bindings.len();
                 if bindings_count < 1 || bindings_count > 5 {
-                    bail!(AlgebrizerError::InvalidBinding(where_fn.operator.clone(),
+                    bail!(AlgebrizerErrorKind::InvalidBinding(where_fn.operator.clone(),
                                                     BindingError::InvalidNumberOfBindings {
                                                         number: bindings.len(),
                                                         expected: 5,
@@ -166,7 +166,7 @@ impl ConjoiningClauses {
             },
             Binding::BindScalar(_) |
             Binding::BindTuple(_) |
-            Binding::BindColl(_) => bail!(AlgebrizerError::InvalidBinding(where_fn.operator.clone(), BindingError::ExpectedBindRel)),
+            Binding::BindColl(_) => bail!(AlgebrizerErrorKind::InvalidBinding(where_fn.operator.clone(), BindingError::ExpectedBindRel)),
         };
         let mut bindings = bindings.into_iter();
         let b_e = bindings.next().unwrap_or(VariableOrPlaceholder::Placeholder);
@@ -180,7 +180,7 @@ impl ConjoiningClauses {
         // TODO: process source variables.
         match args.next().unwrap() {
             FnArg::SrcVar(SrcVar::DefaultSrc) => {},
-            _ => bail!(AlgebrizerError::InvalidArgument(where_fn.operator.clone(), "source variable", 0)),
+            _ => bail!(AlgebrizerErrorKind::InvalidArgument(where_fn.operator.clone(), "source variable", 0)),
         }
 
         let tx = self.resolve_tx_argument(&known.schema, &where_fn.operator, 1, args.next().unwrap())?;

--- a/query-algebrizer/src/clauses/where_fn.rs
+++ b/query-algebrizer/src/clauses/where_fn.rs
@@ -17,7 +17,7 @@ use clauses::{
 };
 
 use errors::{
-    AlgebrizerError,
+    AlgebrizerErrorKind,
     Result,
 };
 
@@ -39,7 +39,7 @@ impl ConjoiningClauses {
             "ground" => self.apply_ground(known, where_fn),
             "tx-data" => self.apply_tx_data(known, where_fn),
             "tx-ids" => self.apply_tx_ids(known, where_fn),
-            _ => bail!(AlgebrizerError::UnknownFunction(where_fn.operator.clone())),
+            _ => bail!(AlgebrizerErrorKind::UnknownFunction(where_fn.operator.clone())),
         }
     }
 }

--- a/query-algebrizer/src/validate.rs
+++ b/query-algebrizer/src/validate.rs
@@ -19,7 +19,7 @@ use mentat_query::{
 };
 
 use errors::{
-    AlgebrizerError,
+    AlgebrizerErrorKind,
     Result,
 };
 
@@ -56,7 +56,7 @@ pub(crate) fn validate_or_join(or_join: &OrJoin) -> Result<()> {
                 let template = clauses.next().unwrap().collect_mentioned_variables();
                 for clause in clauses {
                     if template != clause.collect_mentioned_variables() {
-                        bail!(AlgebrizerError::NonMatchingVariablesInOrClause)
+                        bail!(AlgebrizerErrorKind::NonMatchingVariablesInOrClause)
                     }
                 }
                 Ok(())
@@ -67,7 +67,7 @@ pub(crate) fn validate_or_join(or_join: &OrJoin) -> Result<()> {
             let var_set: BTreeSet<Variable> = vars.iter().cloned().collect();
             for clause in &or_join.clauses {
                 if !var_set.is_subset(&clause.collect_mentioned_variables()) {
-                    bail!(AlgebrizerError::NonMatchingVariablesInOrClause)
+                    bail!(AlgebrizerErrorKind::NonMatchingVariablesInOrClause)
                 }
             }
             Ok(())
@@ -85,7 +85,7 @@ pub(crate) fn validate_not_join(not_join: &NotJoin) -> Result<()> {
             // The joined vars must each appear somewhere in the clause's mentioned variables.
             let var_set: BTreeSet<Variable> = vars.iter().cloned().collect();
             if !var_set.is_subset(&not_join.collect_mentioned_variables()) {
-                bail!(AlgebrizerError::NonMatchingVariablesInNotClause)
+                bail!(AlgebrizerErrorKind::NonMatchingVariablesInNotClause)
             }
             Ok(())
         },

--- a/query-algebrizer/tests/ground.rs
+++ b/query-algebrizer/tests/ground.rs
@@ -30,7 +30,7 @@ use mentat_query::{
 };
 
 use mentat_query_algebrizer::{
-    AlgebrizerError,
+    AlgebrizerErrorKind,
     BindingError,
     ComputedTable,
     Known,
@@ -254,8 +254,8 @@ fn test_ground_coll_heterogeneous_types() {
     let q = r#"[:find ?x :where [?x _ ?v] [(ground [false 8.5]) [?v ...]]]"#;
     let schema = prepopulated_schema();
     let known = Known::for_schema(&schema);
-    assert_eq!(bails(known, &q),
-               AlgebrizerError::InvalidGroundConstant);
+    assert_eq!(bails(known, &q).kind(),
+               &AlgebrizerErrorKind::InvalidGroundConstant);
 }
 
 #[test]
@@ -263,8 +263,8 @@ fn test_ground_rel_heterogeneous_types() {
     let q = r#"[:find ?x :where [?x _ ?v] [(ground [[false] [5]]) [[?v]]]]"#;
     let schema = prepopulated_schema();
     let known = Known::for_schema(&schema);
-    assert_eq!(bails(known, &q),
-               AlgebrizerError::InvalidGroundConstant);
+    assert_eq!(bails(known, &q).kind(),
+               &AlgebrizerErrorKind::InvalidGroundConstant);
 }
 
 #[test]
@@ -272,8 +272,8 @@ fn test_ground_tuple_duplicate_vars() {
     let q = r#"[:find ?x :where [?x :foo/age ?v] [(ground [8 10]) [?x ?x]]]"#;
     let schema = prepopulated_schema();
     let known = Known::for_schema(&schema);
-    assert_eq!(bails(known, &q),
-               AlgebrizerError::InvalidBinding(PlainSymbol::plain("ground"), BindingError::RepeatedBoundVariable));
+    assert_eq!(bails(known, &q).kind(),
+               &AlgebrizerErrorKind::InvalidBinding(PlainSymbol::plain("ground"), BindingError::RepeatedBoundVariable));
 }
 
 #[test]
@@ -281,8 +281,8 @@ fn test_ground_rel_duplicate_vars() {
     let q = r#"[:find ?x :where [?x :foo/age ?v] [(ground [[8 10]]) [[?x ?x]]]]"#;
     let schema = prepopulated_schema();
     let known = Known::for_schema(&schema);
-    assert_eq!(bails(known, &q),
-               AlgebrizerError::InvalidBinding(PlainSymbol::plain("ground"), BindingError::RepeatedBoundVariable));
+    assert_eq!(bails(known, &q).kind(),
+               &AlgebrizerErrorKind::InvalidBinding(PlainSymbol::plain("ground"), BindingError::RepeatedBoundVariable));
 }
 
 #[test]
@@ -290,8 +290,8 @@ fn test_ground_nonexistent_variable_invalid() {
     let q = r#"[:find ?x ?e :where [?e _ ?x] (not [(ground 17) ?v])]"#;
     let schema = prepopulated_schema();
     let known = Known::for_schema(&schema);
-    assert_eq!(bails(known, &q),
-               AlgebrizerError::UnboundVariable(PlainSymbol::plain("?v")));
+    assert_eq!(bails(known, &q).kind(),
+               &AlgebrizerErrorKind::UnboundVariable(PlainSymbol::plain("?v")));
 }
 
 #[test]
@@ -307,6 +307,6 @@ fn test_unbound_input_variable_invalid() {
 
     let i = QueryInputs::new(types, BTreeMap::default()).expect("valid QueryInputs");
 
-    assert_eq!(bails_with_inputs(known, &q, i),
-               AlgebrizerError::UnboundVariable(PlainSymbol::plain("?x")));
+    assert_eq!(bails_with_inputs(known, &q, i).kind(),
+               &AlgebrizerErrorKind::UnboundVariable(PlainSymbol::plain("?x")));
 }

--- a/query-algebrizer/tests/predicate.rs
+++ b/query-algebrizer/tests/predicate.rs
@@ -31,7 +31,7 @@ use mentat_query::{
 };
 
 use mentat_query_algebrizer::{
-    AlgebrizerError,
+    AlgebrizerErrorKind,
     EmptyBecause,
     Known,
     QueryInputs,
@@ -78,8 +78,8 @@ fn test_instant_predicates_require_instants() {
                     :where
                     [?e :foo/date ?t]
                     [(> ?t "2017-06-16T00:56:41.257Z")]]"#;
-    assert_eq!(bails(known, query),
-        AlgebrizerError::InvalidArgumentType(
+    assert_eq!(bails(known, query).kind(),
+        &AlgebrizerErrorKind::InvalidArgumentType(
             PlainSymbol::plain(">"),
             ValueTypeSet::of_numeric_and_instant_types(),
             1));
@@ -88,8 +88,8 @@ fn test_instant_predicates_require_instants() {
                     :where
                     [?e :foo/date ?t]
                     [(> "2017-06-16T00:56:41.257Z", ?t)]]"#;
-    assert_eq!(bails(known, query),
-        AlgebrizerError::InvalidArgumentType(
+    assert_eq!(bails(known, query).kind(),
+        &AlgebrizerErrorKind::InvalidArgumentType(
             PlainSymbol::plain(">"),
             ValueTypeSet::of_numeric_and_instant_types(),
             0)); // We get this right.

--- a/query-projector/src/aggregates.rs
+++ b/query-projector/src/aggregates.rs
@@ -33,7 +33,7 @@ use mentat_query_sql::{
 };
 
 use errors::{
-    ProjectorError,
+    ProjectorErrorKind,
     Result,
 };
 
@@ -79,7 +79,7 @@ impl SimpleAggregationOp {
     pub(crate) fn is_applicable_to_types(&self, possibilities: ValueTypeSet) -> Result<ValueType> {
         use self::SimpleAggregationOp::*;
         if possibilities.is_empty() {
-            bail!(ProjectorError::CannotProjectImpossibleBinding(*self))
+            bail!(ProjectorErrorKind::CannotProjectImpossibleBinding(*self))
         }
 
         match self {
@@ -92,7 +92,7 @@ impl SimpleAggregationOp {
                     // The mean of a set of numeric values will always, for our purposes, be a double.
                     Ok(ValueType::Double)
                 } else {
-                    bail!(ProjectorError::CannotApplyAggregateOperationToTypes(*self, possibilities))
+                    bail!(ProjectorErrorKind::CannotApplyAggregateOperationToTypes(*self, possibilities))
                 }
             },
             &Sum => {
@@ -104,7 +104,7 @@ impl SimpleAggregationOp {
                         Ok(ValueType::Long)
                     }
                 } else {
-                    bail!(ProjectorError::CannotApplyAggregateOperationToTypes(*self, possibilities))
+                    bail!(ProjectorErrorKind::CannotApplyAggregateOperationToTypes(*self, possibilities))
                 }
             },
 
@@ -124,7 +124,7 @@ impl SimpleAggregationOp {
 
                         // These types are unordered.
                         Keyword | Ref | Uuid => {
-                            bail!(ProjectorError::CannotApplyAggregateOperationToTypes(*self, possibilities))
+                            bail!(ProjectorErrorKind::CannotApplyAggregateOperationToTypes(*self, possibilities))
                         },
                     }
                 } else {
@@ -139,7 +139,7 @@ impl SimpleAggregationOp {
                             Ok(ValueType::Long)
                         }
                     } else {
-                        bail!(ProjectorError::CannotApplyAggregateOperationToTypes(*self, possibilities))
+                        bail!(ProjectorErrorKind::CannotApplyAggregateOperationToTypes(*self, possibilities))
                     }
                 }
             },

--- a/query-projector/src/binding_tuple.rs
+++ b/query-projector/src/binding_tuple.rs
@@ -13,7 +13,7 @@ use mentat_core::{
 };
 
 use errors::{
-    ProjectorError,
+    ProjectorErrorKind,
     Result,
 };
 
@@ -32,7 +32,7 @@ impl BindingTuple for Vec<Binding> {
             None => Ok(None),
             Some(vec) => {
                 if expected != vec.len() {
-                    Err(ProjectorError::UnexpectedResultsTupleLength(expected, vec.len()))
+                    Err(ProjectorErrorKind::UnexpectedResultsTupleLength(expected, vec.len()).into())
                 } else {
                     Ok(Some(vec))
                 }
@@ -45,13 +45,13 @@ impl BindingTuple for Vec<Binding> {
 impl BindingTuple for (Binding,) {
     fn from_binding_vec(expected: usize, vec: Option<Vec<Binding>>) -> Result<Option<Self>> {
         if expected != 1 {
-            return Err(ProjectorError::UnexpectedResultsTupleLength(1, expected));
+            return Err(ProjectorErrorKind::UnexpectedResultsTupleLength(1, expected).into());
         }
         match vec {
             None => Ok(None),
             Some(vec) => {
                 if expected != vec.len() {
-                    Err(ProjectorError::UnexpectedResultsTupleLength(expected, vec.len()))
+                    Err(ProjectorErrorKind::UnexpectedResultsTupleLength(expected, vec.len()).into())
                 } else {
                     let mut iter = vec.into_iter();
                     Ok(Some((iter.next().unwrap(),)))
@@ -64,13 +64,13 @@ impl BindingTuple for (Binding,) {
 impl BindingTuple for (Binding, Binding) {
     fn from_binding_vec(expected: usize, vec: Option<Vec<Binding>>) -> Result<Option<Self>> {
         if expected != 2 {
-            return Err(ProjectorError::UnexpectedResultsTupleLength(2, expected));
+            return Err(ProjectorErrorKind::UnexpectedResultsTupleLength(2, expected).into());
         }
         match vec {
             None => Ok(None),
             Some(vec) => {
                 if expected != vec.len() {
-                    Err(ProjectorError::UnexpectedResultsTupleLength(expected, vec.len()))
+                    Err(ProjectorErrorKind::UnexpectedResultsTupleLength(expected, vec.len()).into())
                 } else {
                     let mut iter = vec.into_iter();
                     Ok(Some((iter.next().unwrap(), iter.next().unwrap())))
@@ -83,13 +83,13 @@ impl BindingTuple for (Binding, Binding) {
 impl BindingTuple for (Binding, Binding, Binding) {
     fn from_binding_vec(expected: usize, vec: Option<Vec<Binding>>) -> Result<Option<Self>> {
         if expected != 3 {
-            return Err(ProjectorError::UnexpectedResultsTupleLength(3, expected));
+            return Err(ProjectorErrorKind::UnexpectedResultsTupleLength(3, expected).into());
         }
         match vec {
             None => Ok(None),
             Some(vec) => {
                 if expected != vec.len() {
-                    Err(ProjectorError::UnexpectedResultsTupleLength(expected, vec.len()))
+                    Err(ProjectorErrorKind::UnexpectedResultsTupleLength(expected, vec.len()).into())
                 } else {
                     let mut iter = vec.into_iter();
                     Ok(Some((iter.next().unwrap(), iter.next().unwrap(), iter.next().unwrap())))
@@ -102,13 +102,13 @@ impl BindingTuple for (Binding, Binding, Binding) {
 impl BindingTuple for (Binding, Binding, Binding, Binding) {
     fn from_binding_vec(expected: usize, vec: Option<Vec<Binding>>) -> Result<Option<Self>> {
         if expected != 4 {
-            return Err(ProjectorError::UnexpectedResultsTupleLength(4, expected));
+            return Err(ProjectorErrorKind::UnexpectedResultsTupleLength(4, expected).into());
         }
         match vec {
             None => Ok(None),
             Some(vec) => {
                 if expected != vec.len() {
-                    Err(ProjectorError::UnexpectedResultsTupleLength(expected, vec.len()))
+                    Err(ProjectorErrorKind::UnexpectedResultsTupleLength(expected, vec.len()).into())
                 } else {
                     let mut iter = vec.into_iter();
                     Ok(Some((iter.next().unwrap(), iter.next().unwrap(), iter.next().unwrap(), iter.next().unwrap())))
@@ -121,13 +121,13 @@ impl BindingTuple for (Binding, Binding, Binding, Binding) {
 impl BindingTuple for (Binding, Binding, Binding, Binding, Binding) {
     fn from_binding_vec(expected: usize, vec: Option<Vec<Binding>>) -> Result<Option<Self>> {
         if expected != 5 {
-            return Err(ProjectorError::UnexpectedResultsTupleLength(5, expected));
+            return Err(ProjectorErrorKind::UnexpectedResultsTupleLength(5, expected).into());
         }
         match vec {
             None => Ok(None),
             Some(vec) => {
                 if expected != vec.len() {
-                    Err(ProjectorError::UnexpectedResultsTupleLength(expected, vec.len()))
+                    Err(ProjectorErrorKind::UnexpectedResultsTupleLength(expected, vec.len()).into())
                 } else {
                     let mut iter = vec.into_iter();
                     Ok(Some((iter.next().unwrap(), iter.next().unwrap(), iter.next().unwrap(), iter.next().unwrap(), iter.next().unwrap())))
@@ -142,13 +142,13 @@ impl BindingTuple for (Binding, Binding, Binding, Binding, Binding) {
 impl BindingTuple for (Binding, Binding, Binding, Binding, Binding, Binding) {
     fn from_binding_vec(expected: usize, vec: Option<Vec<Binding>>) -> Result<Option<Self>> {
         if expected != 6 {
-            return Err(ProjectorError::UnexpectedResultsTupleLength(6, expected));
+            return Err(ProjectorErrorKind::UnexpectedResultsTupleLength(6, expected).into());
         }
         match vec {
             None => Ok(None),
             Some(vec) => {
                 if expected != vec.len() {
-                    Err(ProjectorError::UnexpectedResultsTupleLength(expected, vec.len()))
+                    Err(ProjectorErrorKind::UnexpectedResultsTupleLength(expected, vec.len()).into())
                 } else {
                     let mut iter = vec.into_iter();
                     Ok(Some((iter.next().unwrap(), iter.next().unwrap(), iter.next().unwrap(), iter.next().unwrap(), iter.next().unwrap(), iter.next().unwrap())))

--- a/query-projector/src/lib.rs
+++ b/query-projector/src/lib.rs
@@ -117,6 +117,7 @@ pub use relresult::{
 };
 
 pub use errors::{
+    ProjectorErrorKind,
     ProjectorError,
     Result,
 };
@@ -311,35 +312,35 @@ impl QueryResults {
     pub fn into_scalar(self) -> Result<Option<Binding>> {
         match self {
             QueryResults::Scalar(o) => Ok(o),
-            QueryResults::Coll(_) => bail!(ProjectorError::UnexpectedResultsType("coll", "scalar")),
-            QueryResults::Tuple(_) => bail!(ProjectorError::UnexpectedResultsType("tuple", "scalar")),
-            QueryResults::Rel(_) => bail!(ProjectorError::UnexpectedResultsType("rel", "scalar")),
+            QueryResults::Coll(_) => bail!(ProjectorErrorKind::UnexpectedResultsType("coll", "scalar")),
+            QueryResults::Tuple(_) => bail!(ProjectorErrorKind::UnexpectedResultsType("tuple", "scalar")),
+            QueryResults::Rel(_) => bail!(ProjectorErrorKind::UnexpectedResultsType("rel", "scalar")),
         }
     }
 
     pub fn into_coll(self) -> Result<Vec<Binding>> {
         match self {
-            QueryResults::Scalar(_) => bail!(ProjectorError::UnexpectedResultsType("scalar", "coll")),
+            QueryResults::Scalar(_) => bail!(ProjectorErrorKind::UnexpectedResultsType("scalar", "coll")),
             QueryResults::Coll(c) => Ok(c),
-            QueryResults::Tuple(_) => bail!(ProjectorError::UnexpectedResultsType("tuple", "coll")),
-            QueryResults::Rel(_) => bail!(ProjectorError::UnexpectedResultsType("rel", "coll")),
+            QueryResults::Tuple(_) => bail!(ProjectorErrorKind::UnexpectedResultsType("tuple", "coll")),
+            QueryResults::Rel(_) => bail!(ProjectorErrorKind::UnexpectedResultsType("rel", "coll")),
         }
     }
 
     pub fn into_tuple(self) -> Result<Option<Vec<Binding>>> {
         match self {
-            QueryResults::Scalar(_) => bail!(ProjectorError::UnexpectedResultsType("scalar", "tuple")),
-            QueryResults::Coll(_) => bail!(ProjectorError::UnexpectedResultsType("coll", "tuple")),
+            QueryResults::Scalar(_) => bail!(ProjectorErrorKind::UnexpectedResultsType("scalar", "tuple")),
+            QueryResults::Coll(_) => bail!(ProjectorErrorKind::UnexpectedResultsType("coll", "tuple")),
             QueryResults::Tuple(t) => Ok(t),
-            QueryResults::Rel(_) => bail!(ProjectorError::UnexpectedResultsType("rel", "tuple")),
+            QueryResults::Rel(_) => bail!(ProjectorErrorKind::UnexpectedResultsType("rel", "tuple")),
         }
     }
 
     pub fn into_rel(self) -> Result<RelResult<Binding>> {
         match self {
-            QueryResults::Scalar(_) => bail!(ProjectorError::UnexpectedResultsType("scalar", "rel")),
-            QueryResults::Coll(_) => bail!(ProjectorError::UnexpectedResultsType("coll", "rel")),
-            QueryResults::Tuple(_) => bail!(ProjectorError::UnexpectedResultsType("tuple", "rel")),
+            QueryResults::Scalar(_) => bail!(ProjectorErrorKind::UnexpectedResultsType("scalar", "rel")),
+            QueryResults::Coll(_) => bail!(ProjectorErrorKind::UnexpectedResultsType("coll", "rel")),
+            QueryResults::Tuple(_) => bail!(ProjectorErrorKind::UnexpectedResultsType("tuple", "rel")),
             QueryResults::Rel(r) => Ok(r),
         }
     }
@@ -541,8 +542,13 @@ fn test_into_tuple() {
                      Binding::Scalar(TypedValue::Long(2)))));
 
     match query_output.clone().into_tuple() {
-        Err(ProjectorError::UnexpectedResultsTupleLength(expected, got)) => {
-            assert_eq!((expected, got), (3, 2));
+        Err(e) => {
+            match e.kind() {
+                &ProjectorErrorKind::UnexpectedResultsTupleLength(ref expected, ref got) => {
+                    assert_eq!((*expected, *got), (3, 2));
+                }
+                err => panic!("unexpected error kind {:?}", err),
+            }
         },
         // This forces the result type.
         Ok(Some((_, _, _))) | _ => panic!("expected error"),
@@ -562,8 +568,13 @@ fn test_into_tuple() {
     }
 
     match query_output.clone().into_tuple() {
-        Err(ProjectorError::UnexpectedResultsTupleLength(expected, got)) => {
-            assert_eq!((expected, got), (3, 2));
+        Err(e) => {
+            match e.kind() {
+                &ProjectorErrorKind::UnexpectedResultsTupleLength(ref expected, ref got) => {
+                    assert_eq!((*expected, *got), (3, 2));
+                },
+                e => panic!("unexpected error kind {:?}", e),
+            }
         },
         // This forces the result type.
         Ok(Some((_, _, _))) | _ => panic!("expected error"),

--- a/query-projector/src/project.rs
+++ b/query-projector/src/project.rs
@@ -55,7 +55,7 @@ use aggregates::{
 };
 
 use errors::{
-    ProjectorError,
+    ProjectorErrorKind,
     Result,
 };
 
@@ -127,14 +127,14 @@ fn candidate_type_column(cc: &ConjoiningClauses, var: &Variable) -> Result<(Colu
           let type_name = VariableColumn::VariableTypeTag(var.clone()).column_name();
           (ColumnOrExpression::Column(alias), type_name)
       })
-      .ok_or_else(|| ProjectorError::UnboundVariable(var.name()).into())
+      .ok_or_else(|| ProjectorErrorKind::UnboundVariable(var.name()).into())
 }
 
 fn cc_column(cc: &ConjoiningClauses, var: &Variable) -> Result<QualifiedAlias> {
     cc.column_bindings
       .get(var)
       .and_then(|cols| cols.get(0).cloned())
-      .ok_or_else(|| ProjectorError::UnboundVariable(var.name()).into())
+      .ok_or_else(|| ProjectorErrorKind::UnboundVariable(var.name()).into())
 }
 
 fn candidate_column(cc: &ConjoiningClauses, var: &Variable) -> Result<(ColumnOrExpression, Name)> {
@@ -211,18 +211,18 @@ pub(crate) fn project_elements<'a, I: IntoIterator<Item = &'a Element>>(
         match e {
             &Element::Variable(ref var) => {
                 if outer_variables.contains(var) {
-                    bail!(ProjectorError::InvalidProjection(format!("Duplicate variable {} in query.", var)));
+                    bail!(ProjectorErrorKind::InvalidProjection(format!("Duplicate variable {} in query.", var)));
                 }
                 if corresponded_variables.contains(var) {
-                    bail!(ProjectorError::InvalidProjection(format!("Can't project both {} and `(the {})` from a query.", var, var)));
+                    bail!(ProjectorErrorKind::InvalidProjection(format!("Can't project both {} and `(the {})` from a query.", var, var)));
                 }
             },
             &Element::Corresponding(ref var) => {
                 if outer_variables.contains(var) {
-                    bail!(ProjectorError::InvalidProjection(format!("Can't project both {} and `(the {})` from a query.", var, var)));
+                    bail!(ProjectorErrorKind::InvalidProjection(format!("Can't project both {} and `(the {})` from a query.", var, var)));
                 }
                 if corresponded_variables.contains(var) {
-                    bail!(ProjectorError::InvalidProjection(format!("`(the {})` appears twice in query.", var)));
+                    bail!(ProjectorErrorKind::InvalidProjection(format!("`(the {})` appears twice in query.", var)));
                 }
             },
             &Element::Aggregate(_) => {
@@ -346,7 +346,7 @@ pub(crate) fn project_elements<'a, I: IntoIterator<Item = &'a Element>>(
                     i += 1;
                 } else {
                     // TODO: complex aggregates.
-                    bail!(ProjectorError::NotYetImplemented("complex aggregates".into()));
+                    bail!(ProjectorErrorKind::NotYetImplemented("complex aggregates".into()));
                 }
             },
         }
@@ -355,13 +355,13 @@ pub(crate) fn project_elements<'a, I: IntoIterator<Item = &'a Element>>(
     match (min_max_count, corresponded_variables.len()) {
         (0, 0) | (_, 0) => {},
         (0, _) => {
-            bail!(ProjectorError::InvalidProjection("Warning: used `the` without `min` or `max`.".to_string()));
+            bail!(ProjectorErrorKind::InvalidProjection("Warning: used `the` without `min` or `max`.".to_string()));
         },
         (1, _) => {
             // This is the success case!
         },
         (n, c) => {
-            bail!(ProjectorError::AmbiguousAggregates(n, c));
+            bail!(ProjectorErrorKind::AmbiguousAggregates(n, c));
         },
     }
 
@@ -465,7 +465,7 @@ pub(crate) fn project_elements<'a, I: IntoIterator<Item = &'a Element>>(
                                     .extracted_types
                                     .get(&var)
                                     .cloned()
-                                    .ok_or_else(|| ProjectorError::NoTypeAvailableForVariable(var.name().clone()))?;
+                                    .ok_or_else(|| ProjectorErrorKind::NoTypeAvailableForVariable(var.name().clone()))?;
                 inner_projection.push(ProjectedColumn(ColumnOrExpression::Column(type_col), type_name.clone()));
             }
             if group {

--- a/query-projector/tests/aggregates.rs
+++ b/query-projector/tests/aggregates.rs
@@ -99,10 +99,10 @@ fn test_the_without_max_or_min() {
     let projection = query_projection(&schema, &algebrized);
     assert!(projection.is_err());
     use ::mentat_query_projector::errors::{
-        ProjectorError,
+        ProjectorErrorKind,
     };
-    match projection.err().expect("expected failure") {
-        ProjectorError::InvalidProjection(s) => {
+    match projection.err().expect("expected failure").kind() {
+        &ProjectorErrorKind::InvalidProjection(ref s) => {
                 assert_eq!(s.as_str(), "Warning: used `the` without `min` or `max`.");
             },
         _ => panic!(),

--- a/query-pull/src/lib.rs
+++ b/query-pull/src/lib.rs
@@ -104,6 +104,7 @@ pub mod errors;
 
 pub use errors::{
     PullError,
+    PullErrorKind,
     Result,
 };
 
@@ -165,7 +166,7 @@ impl Puller {
             // In the unlikely event that we have an attribute with no name, we bail.
             schema.get_ident(*i)
                     .map(|ident| ValueRc::new(ident.clone()))
-                    .ok_or_else(|| PullError::UnnamedAttribute(*i))
+                    .ok_or_else(|| PullError::from(PullErrorKind::UnnamedAttribute(*i)))
         };
 
         let mut names: BTreeMap<Entid, ValueRc<Keyword>> = Default::default();
@@ -194,7 +195,7 @@ impl Puller {
                         &PullConcreteAttribute::Ident(ref i) if i.as_ref() == db_id.as_ref() => {
                             // We only allow :db/id once.
                             if db_id_alias.is_some() {
-                                Err(PullError::RepeatedDbId)?
+                                Err(PullErrorKind::RepeatedDbId)?
                             }
                             db_id_alias = Some(alias.unwrap_or_else(|| db_id.to_value_rc()));
                         },

--- a/query-translator/src/lib.rs
+++ b/query-translator/src/lib.rs
@@ -31,4 +31,5 @@ pub use translate::{
 
 // query-translator could be folded into query-projector; for now, just type alias the errors.
 pub type TranslatorError = mentat_query_projector::ProjectorError;
-pub type Result<T> = std::result::Result<T, TranslatorError>;
+pub type TranslatorErrorKind = mentat_query_projector::ProjectorError;
+pub type Result<T> = std::result::Result<T, TranslatorErrorKind>;

--- a/src/entity_builder.rs
+++ b/src/entity_builder.rs
@@ -285,7 +285,7 @@ mod testing {
         Entid,
         HasSchema,
         KnownEntid,
-        MentatError,
+        MentatErrorKind,
         Queryable,
         TxReport,
         TypedValue,
@@ -321,8 +321,8 @@ mod testing {
         let mut in_progress = conn.begin_transaction(&mut sqlite).expect("begun successfully");
 
         // This should fail: unrecognized entid.
-        match in_progress.transact_entities(terms).expect_err("expected transact to fail") {
-            MentatError::DbError(e) => {
+        match in_progress.transact_entities(terms).expect_err("expected transact to fail").kind() {
+            MentatErrorKind::DbError(e) => {
                 assert_eq!(e.kind(), mentat_db::DbErrorKind::UnrecognizedEntid(999));
             },
             _ => panic!("Should have rejected the entid."),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,6 +124,7 @@ macro_rules! kw {
 pub mod errors;
 pub use errors::{
     MentatError,
+    MentatErrorKind,
     Result,
 };
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -74,7 +74,7 @@ pub use mentat_query_projector::{
 };
 
 use errors::{
-    MentatError,
+    MentatErrorKind,
     Result,
 };
 
@@ -178,7 +178,7 @@ fn algebrize_query<T>
     // If they aren't, the user has made an error -- perhaps writing the wrong variable in `:in`, or
     // not binding in the `QueryInput`.
     if !unbound.is_empty() {
-        bail!(MentatError::UnboundVariables(unbound.into_iter().map(|v| v.to_string()).collect()));
+        bail!(MentatErrorKind::UnboundVariables(unbound.into_iter().map(|v| v.to_string()).collect()));
     }
     Ok(algebrized)
 }
@@ -211,7 +211,7 @@ fn fetch_values<'sqlite>
 
 fn lookup_attribute(schema: &Schema, attribute: &Keyword) -> Result<KnownEntid> {
     schema.get_entid(attribute)
-          .ok_or_else(|| MentatError::UnknownAttribute(attribute.name().into()).into())
+          .ok_or_else(|| MentatErrorKind::UnknownAttribute(attribute.name().into()).into())
 }
 
 /// Return a single value for the provided entity and attribute.
@@ -398,7 +398,7 @@ pub fn q_prepare<'sqlite, 'schema, 'cache, 'query, T>
     if !unbound.is_empty() {
         // TODO: Allow binding variables at execution time, not just
         // preparation time.
-        bail!(MentatError::UnboundVariables(unbound.into_iter().map(|v| v.to_string()).collect()));
+        bail!(MentatErrorKind::UnboundVariables(unbound.into_iter().map(|v| v.to_string()).collect()));
     }
 
     if algebrized.is_known_empty() {

--- a/src/query_builder.rs
+++ b/src/query_builder.rs
@@ -34,6 +34,7 @@ use ::{
 };
 
 use errors::{
+    MentatErrorKind,
     MentatError,
     Result,
 };
@@ -56,7 +57,8 @@ impl<'a> QueryBuilder<'a> {
     }
 
     pub fn bind_ref_from_kw(&mut self, var: &str, value: Keyword) -> Result<&mut Self> {
-        let entid = self.store.conn().current_schema().get_entid(&value).ok_or(MentatError::UnknownAttribute(value.to_string()))?;
+        let entid = self.store.conn().current_schema().get_entid(&value).ok_or_else(||
+            MentatError::from(MentatErrorKind::UnknownAttribute(value.to_string())))?;
         self.values.insert(Variable::from_valid_name(var), TypedValue::Ref(entid.into()));
         Ok(self)
     }

--- a/src/store.rs
+++ b/src/store.rs
@@ -85,7 +85,7 @@ impl Store {
     pub fn open_empty(path: &str) -> Result<Store> {
         if !path.is_empty() {
             if Path::new(path).exists() {
-                bail!(MentatError::PathAlreadyExists(path.to_string()));
+                bail!(MentatErrorKind::PathAlreadyExists(path.to_string()));
             }
         }
 
@@ -125,7 +125,7 @@ impl Store {
     pub fn open_empty_with_key(path: &str, encryption_key: &str) -> Result<Store> {
         if !path.is_empty() {
             if Path::new(path).exists() {
-                bail!(MentatError::PathAlreadyExists(path.to_string()));
+                bail!(MentatErrorKind::PathAlreadyExists(path.to_string()));
             }
         }
 
@@ -241,7 +241,7 @@ impl Pullable for Store {
 #[cfg(feature = "syncable")]
 impl Syncable for Store {
     fn sync(&mut self, server_uri: &String, user_uuid: &String) -> Result<()> {
-        let uuid = Uuid::parse_str(&user_uuid).map_err(|_| MentatError::BadUuid(user_uuid.clone()))?;
+        let uuid = Uuid::parse_str(&user_uuid).map_err(|_| MentatErrorKind::BadUuid(user_uuid.clone()))?;
         Ok(Syncer::flow(&mut self.sqlite, server_uri, &uuid)?)
     }
 }

--- a/tests/vocabulary.rs
+++ b/tests/vocabulary.rs
@@ -59,7 +59,7 @@ use mentat::entity_builder::{
     TermBuilder,
 };
 
-use mentat::errors::MentatError;
+use mentat::errors::MentatErrorKind;
 
 lazy_static! {
     static ref FOO_NAME: Keyword = {
@@ -286,13 +286,13 @@ fn test_add_vocab() {
     // Scoped borrow of `conn`.
     {
         let mut in_progress = conn.begin_transaction(&mut sqlite).expect("begun successfully");
-        match in_progress.ensure_vocabulary(&foo_v1_malformed).expect_err("expected vocabulary to fail") {
-            MentatError::ConflictingAttributeDefinitions(vocab, version, attr, theirs, ours) => {
+        match in_progress.ensure_vocabulary(&foo_v1_malformed).expect_err("expected vocabulary to fail").kind() {
+            &MentatErrorKind::ConflictingAttributeDefinitions(ref vocab, ref version, ref attr, ref theirs, ref ours) => {
                 assert_eq!(vocab.as_str(), ":org.mozilla/foo");
                 assert_eq!(attr.as_str(), ":foo/baz");
-                assert_eq!(version, 1);
-                assert_eq!(&theirs, &baz);
-                assert_eq!(&ours, &malformed_baz);
+                assert_eq!(*version, 1);
+                assert_eq!(theirs, &baz);
+                assert_eq!(ours, &malformed_baz);
             },
             _ => panic!(),
         }

--- a/tools/cli/src/mentat_cli/repl.rs
+++ b/tools/cli/src/mentat_cli/repl.rs
@@ -421,7 +421,7 @@ impl Repl {
         if self.path.is_empty() || path != self.path {
             let next = match encryption_key {
                 #[cfg(not(feature = "sqlcipher"))]
-                Some(_) => return Err(::mentat::MentatError::RusqliteError(".open_encrypted and .empty_encrypted require the sqlcipher Mentat feature".into())),
+                Some(_) => return Err(::mentat::MentatErrorKind::RusqliteError(".open_encrypted and .empty_encrypted require the sqlcipher Mentat feature".into()).into()),
 
                 #[cfg(feature = "sqlcipher")]
                 Some(k) => {


### PR DESCRIPTION
This adds a lot of boilerplate which could be simplified by macros.

I was planning on cleaning this up before pushing it but here it is!