### PR TITLE
Android SDK: Remove unused "app_name" string.

### DIFF
--- a/sdks/android/Mentat/library/src/main/res/values/strings.xml
+++ b/sdks/android/Mentat/library/src/main/res/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-    <string name="app_name">Mentat</string>
-</resources>


### PR DESCRIPTION
It seems like this string is unused (although I'm unable to build the library locally) and a library overriding this default string can cause funny problems. :)