### PR TITLE
Fix broken iOS SDK tests

### DIFF
--- a/sdks/swift/Mentat/MentatTests/MentatTests.swift
+++ b/sdks/swift/Mentat/MentatTests/MentatTests.swift
@@ -30,7 +30,7 @@ class MentatTests: XCTestCase {
 
     // test that a store can be opened in memory
     func testOpenInMemoryStore() {
-        XCTAssertNotNil(Mentat().raw)
+        XCTAssertNotNil(try Mentat.open().raw)
     }
 
     // test that a store can be opened in a specific location
@@ -38,7 +38,8 @@ class MentatTests: XCTestCase {
         let paths = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)
         let documentsURL = paths[0]
         let storeURI = documentsURL.appendingPathComponent("test.db", isDirectory: false).absoluteString
-        XCTAssertNotNil(Mentat(storeURI: storeURI).raw)
+    
+        XCTAssertNotNil(try Mentat.open(storeURI: storeURI).raw)
     }
 
     func readFile(forResource resource: String, withExtension ext: String, subdirectory: String ) throws -> String {
@@ -80,7 +81,7 @@ class MentatTests: XCTestCase {
 
     func openAndInitializeCitiesStore() -> Mentat {
         guard let mentat = self.store else {
-            let mentat = Mentat()
+            let mentat = try! Mentat.open()
             let _ = try! self.transactCitiesSchema(mentat: mentat)
             let _ = try! self.transactSeattleData(mentat: mentat)
             self.store = mentat
@@ -154,7 +155,7 @@ class MentatTests: XCTestCase {
 
     func test1TransactVocabulary() {
         do {
-            let mentat = Mentat()
+            let mentat = try Mentat.open()
             let vocab = try readCitiesSchema()
             let report = try mentat.transact(transaction: vocab)
             XCTAssertNotNil(report)
@@ -166,7 +167,7 @@ class MentatTests: XCTestCase {
 
     func test2TransactEntities() {
         do {
-            let mentat = Mentat()
+            let mentat = try Mentat.open()
             let vocab = try readCitiesSchema()
             let _ = try mentat.transact(transaction: vocab)
             let data = try readSeattleData()
@@ -338,7 +339,7 @@ class MentatTests: XCTestCase {
     }
 
     func testBindLong() {
-        let mentat = Mentat()
+        let mentat = try! Mentat.open()
         let (_, report) = self.populateWithTypesSchema(mentat: mentat)
         let aEntid = report!.entid(forTempId: "a")
         let query = "[:find ?e . :in ?long :where [?e :foo/long ?long]]"
@@ -358,7 +359,7 @@ class MentatTests: XCTestCase {
     }
 
     func testBindRef() {
-        let mentat = Mentat()
+        let mentat = try! Mentat.open()
         let (_, report) = self.populateWithTypesSchema(mentat: mentat)
         let stringEntid = mentat.entidForAttribute(attribute: ":foo/string")
         let bEntid = report!.entid(forTempId: "b")
@@ -379,7 +380,7 @@ class MentatTests: XCTestCase {
     }
 
     func testBindKwRef() {
-        let mentat = Mentat()
+        let mentat = try! Mentat.open()
         let (_, report) = self.populateWithTypesSchema(mentat: mentat)
         let bEntid = report!.entid(forTempId: "b")
         let query = "[:find ?e . :in ?ref :where [?e :foo/ref ?ref]]"
@@ -399,7 +400,7 @@ class MentatTests: XCTestCase {
     }
 
     func testBindKw() {
-        let mentat = Mentat()
+        let mentat = try! Mentat.open()
         let (_, report) = self.populateWithTypesSchema(mentat: mentat)
         let aEntid = report!.entid(forTempId: "a")
         let query = "[:find ?e . :in ?kw :where [?e :foo/keyword ?kw]]"
@@ -419,7 +420,7 @@ class MentatTests: XCTestCase {
     }
 
     func testBindDate() {
-        let mentat = Mentat()
+        let mentat = try! Mentat.open()
         let (_, report) = self.populateWithTypesSchema(mentat: mentat)
         let aEntid = report!.entid(forTempId: "a")
         let query = "[:find [?e ?d] :in ?now :where [?e :foo/instant ?d] [(< ?d ?now)]]"
@@ -465,7 +466,7 @@ class MentatTests: XCTestCase {
     }
 
     func testBindUuid() {
-        let mentat = Mentat()
+        let mentat = try! Mentat.open()
         let (_, report) = self.populateWithTypesSchema(mentat: mentat)
         let aEntid = report!.entid(forTempId: "a")
         let query = "[:find ?e . :in ?uuid :where [?e :foo/uuid ?uuid]]"
@@ -486,7 +487,7 @@ class MentatTests: XCTestCase {
     }
 
     func testBindBoolean() {
-        let mentat = Mentat()
+        let mentat = try! Mentat.open()
         let (_, report) = self.populateWithTypesSchema(mentat: mentat)
         let aEntid = report!.entid(forTempId: "a")
         let query = "[:find ?e . :in ?bool :where [?e :foo/boolean ?bool]]"
@@ -506,7 +507,7 @@ class MentatTests: XCTestCase {
     }
 
     func testBindDouble() {
-        let mentat = Mentat()
+        let mentat = try! Mentat.open()
         let (_, report) = self.populateWithTypesSchema(mentat: mentat)
         let aEntid = report!.entid(forTempId: "a")
         let query = "[:find ?e . :in ?double :where [?e :foo/double ?double]]"
@@ -526,7 +527,7 @@ class MentatTests: XCTestCase {
     }
 
     func testTypedValueAsLong() {
-        let mentat = Mentat()
+        let mentat = try! Mentat.open()
         let (_, report) = self.populateWithTypesSchema(mentat: mentat)
         let aEntid = report!.entid(forTempId: "a")!
         let query = "[:find ?v . :in ?e :where [?e :foo/long ?v]]"
@@ -547,7 +548,7 @@ class MentatTests: XCTestCase {
     }
 
     func testTypedValueAsRef() {
-        let mentat = Mentat()
+        let mentat = try! Mentat.open()
         let (_, report) = self.populateWithTypesSchema(mentat: mentat)
         let aEntid = report!.entid(forTempId: "a")!
         let query = "[:find ?e . :where [?e :foo/long 25]]"
@@ -567,7 +568,7 @@ class MentatTests: XCTestCase {
     }
 
     func testTypedValueAsKw() {
-        let mentat = Mentat()
+        let mentat = try! Mentat.open()
         let (_, report) = self.populateWithTypesSchema(mentat: mentat)
         let aEntid = report!.entid(forTempId: "a")!
         let query = "[:find ?v . :in ?e :where [?e :foo/keyword ?v]]"
@@ -588,7 +589,7 @@ class MentatTests: XCTestCase {
     }
 
     func testTypedValueAsBoolean() {
-        let mentat = Mentat()
+        let mentat = try! Mentat.open()
         let (_, report) = self.populateWithTypesSchema(mentat: mentat)
         let aEntid = report!.entid(forTempId: "a")!
         let query = "[:find ?v . :in ?e :where [?e :foo/boolean ?v]]"
@@ -609,7 +610,7 @@ class MentatTests: XCTestCase {
     }
 
     func testTypedValueAsDouble() {
-        let mentat = Mentat()
+        let mentat = try! Mentat.open()
         let (_, report) = self.populateWithTypesSchema(mentat: mentat)
         let aEntid = report!.entid(forTempId: "a")!
         let query = "[:find ?v . :in ?e :where [?e :foo/double ?v]]"
@@ -630,7 +631,7 @@ class MentatTests: XCTestCase {
     }
 
     func testTypedValueAsDate() {
-        let mentat = Mentat()
+        let mentat = try! Mentat.open()
         let (_, report) = self.populateWithTypesSchema(mentat: mentat)
         let aEntid = report!.entid(forTempId: "a")!
         let query = "[:find ?v . :in ?e :where [?e :foo/instant ?v]]"
@@ -656,7 +657,7 @@ class MentatTests: XCTestCase {
     }
 
     func testTypedValueAsString() {
-        let mentat = Mentat()
+        let mentat = try! Mentat.open()
         let (_, report) = self.populateWithTypesSchema(mentat: mentat)
         let aEntid = report!.entid(forTempId: "a")!
         let query = "[:find ?v . :in ?e :where [?e :foo/string ?v]]"
@@ -677,7 +678,7 @@ class MentatTests: XCTestCase {
     }
 
     func testTypedValueAsUuid() {
-        let mentat = Mentat()
+        let mentat = try! Mentat.open()
         let (_, report) = self.populateWithTypesSchema(mentat: mentat)
         let aEntid = report!.entid(forTempId: "a")!
         let query = "[:find ?v . :in ?e :where [?e :foo/uuid ?v]]"
@@ -699,7 +700,7 @@ class MentatTests: XCTestCase {
     }
 
     func testValueForAttributeOfEntity() {
-        let mentat = Mentat()
+        let mentat = try! Mentat.open()
         let (_, report) = self.populateWithTypesSchema(mentat: mentat)
         let aEntid = report!.entid(forTempId: "a")!
         var value: TypedValue? = nil;
@@ -709,14 +710,14 @@ class MentatTests: XCTestCase {
     }
 
     func testEntidForAttribute() {
-        let mentat = Mentat()
+        let mentat = try! Mentat.open()
         let _ = self.populateWithTypesSchema(mentat: mentat)
         let entid = mentat.entidForAttribute(attribute: ":foo/long")
         assert(entid == 65540)
     }
 
     func testMultipleQueries() {
-        let mentat = Mentat()
+        let mentat = try! Mentat.open()
         let _ = self.populateWithTypesSchema(mentat: mentat)
         let q1 = mentat.query(query: "[:find ?x :where [?x _ _]]")
 
@@ -741,7 +742,7 @@ class MentatTests: XCTestCase {
     }
 
     func testNestedQueries() {
-        let mentat = Mentat()
+        let mentat = try! Mentat.open()
         let _ = self.populateWithTypesSchema(mentat: mentat)
         let q1 = mentat.query(query: "[:find ?x :where [?x _ _]]")
         let q2 = mentat.query(query: "[:find ?x :where [_ _ ?x]]")
@@ -763,13 +764,13 @@ class MentatTests: XCTestCase {
     }
 
     func test3InProgressTransact() {
-        let mentat = Mentat()
+        let mentat = try! Mentat.open()
         let (_, report) = self.populateWithTypesSchema(mentat: mentat)
         XCTAssertNotNil(report)
     }
 
     func testInProgressRollback() {
-        let mentat = Mentat()
+        let mentat = try! Mentat.open()
         let (_, report) = self.populateWithTypesSchema(mentat: mentat)
         XCTAssertNotNil(report)
         let aEntid = report!.entid(forTempId: "a")!
@@ -787,7 +788,7 @@ class MentatTests: XCTestCase {
     }
 
     func testInProgressEntityBuilder() {
-        let mentat = Mentat()
+        let mentat = try! Mentat.open()
         let (schemaReport, dataReport) = self.populateWithTypesSchema(mentat: mentat)
         let bEntid = dataReport!.entid(forTempId: "b")!
         let longEntid = schemaReport!.entid(forTempId: "l")!
@@ -852,7 +853,7 @@ class MentatTests: XCTestCase {
     }
 
     func testEntityBuilderForEntid() {
-        let mentat = Mentat()
+        let mentat = try! Mentat.open()
         let (schemaReport, dataReport) = self.populateWithTypesSchema(mentat: mentat)
         let bEntid = dataReport!.entid(forTempId: "b")!
         let longEntid = schemaReport!.entid(forTempId: "l")!
@@ -917,7 +918,7 @@ class MentatTests: XCTestCase {
     }
 
     func testEntityBuilderForTempid() {
-        let mentat = Mentat()
+        let mentat = try! Mentat.open()
         let (schemaReport, _) = self.populateWithTypesSchema(mentat: mentat)
         let longEntid = schemaReport!.entid(forTempId: "l")!
         // test that the values are as expected
@@ -964,7 +965,7 @@ class MentatTests: XCTestCase {
     }
 
     func testInProgressBuilderTransact() {
-        let mentat = Mentat()
+        let mentat = try! Mentat.open()
         let (schemaReport, dataReport) = self.populateWithTypesSchema(mentat: mentat)
         let aEntid = dataReport!.entid(forTempId: "a")!
         let bEntid = dataReport!.entid(forTempId: "b")!
@@ -1020,7 +1021,7 @@ class MentatTests: XCTestCase {
     }
 
     func testEntityBuilderTransact() {
-        let mentat = Mentat()
+        let mentat = try! Mentat.open()
         let (schemaReport, dataReport) = self.populateWithTypesSchema(mentat: mentat)
         let aEntid = dataReport!.entid(forTempId: "a")!
         let bEntid = dataReport!.entid(forTempId: "b")!
@@ -1076,7 +1077,7 @@ class MentatTests: XCTestCase {
     }
 
     func testEntityBuilderRetract() {
-        let mentat = Mentat()
+        let mentat = try! Mentat.open()
         let (schemaReport, dataReport) = self.populateWithTypesSchema(mentat: mentat)
         let bEntid = dataReport!.entid(forTempId: "b")!
         let stringEntid = schemaReport!.entid(forTempId: "s")!
@@ -1126,7 +1127,7 @@ class MentatTests: XCTestCase {
     }
 
     func testInProgressEntityBuilderRetract() {
-        let mentat = Mentat()
+        let mentat = try! Mentat.open()
         let (schemaReport, dataReport) = self.populateWithTypesSchema(mentat: mentat)
         let bEntid = dataReport!.entid(forTempId: "b")!
         let stringEntid = schemaReport!.entid(forTempId: "s")!

--- a/sdks/swift/Mentat/MentatTests/MentatTests.swift
+++ b/sdks/swift/Mentat/MentatTests/MentatTests.swift
@@ -35,10 +35,8 @@ class MentatTests: XCTestCase {
 
     // test that a store can be opened in a specific location
     func testOpenStoreInLocation() {
-        let paths = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)
-        let documentsURL = paths[0]
-        let storeURI = documentsURL.appendingPathComponent("test.db", isDirectory: false).absoluteString
-    
+        let documentsURL = NSURL(fileURLWithPath: NSTemporaryDirectory())
+        let storeURI = documentsURL.appendingPathComponent("test.db", isDirectory: false)!.absoluteString
         XCTAssertNotNil(try Mentat.open(storeURI: storeURI).raw)
     }
 


### PR DESCRIPTION
Changes to error handling had caused the iOS tests to no longer compile. Plus a test creating a named database was failing. This patch fixes those problems.