### PR TITLE
Allow 'sqlcipher' feature for all uses of rusqlite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,10 @@ script:
   # We can't pick individual features out with `cargo test --all` (At the time of this writing, this
   # works but does the wrong thing because of a bug in cargo, but its fix will be to disallow doing
   # this all-together, see https://github.com/rust-lang/cargo/issues/5364 for more information). To
-  # work around this, we run individual tests for each subcrate individually.
+  # work around this, we run tests individually for subcrates that rely on `rusqlite`.
   - |
-    for manifest in $(find . -type f -name Cargo.toml); do
-      cargo test --manifest-path $manifest --verbose --no-default-features --features sqlcipher
+    for crate in "" "db" "db-traits" "ffi" "public-traits" "query-projector" "query-projector-traits" "query-pull" "sql" "tolstoy" "tolstoy-traits" "tools/cli"; do
+      cargo test --manifest-path ./$crate/Cargo.toml --verbose --no-default-features --features sqlcipher
     done
 after_success:
   - |

--- a/db-traits/Cargo.toml
+++ b/db-traits/Cargo.toml
@@ -7,6 +7,9 @@ workspace = ".."
 name = "db_traits"
 path = "lib.rs"
 
+[features]
+sqlcipher = ["rusqlite/sqlcipher"]
+
 [dependencies]
 failure = "0.1.1"
 failure_derive = "0.1.1"

--- a/public-traits/Cargo.toml
+++ b/public-traits/Cargo.toml
@@ -9,6 +9,7 @@ path = "lib.rs"
 
 [features]
 default = ["syncable"]
+sqlcipher = ["rusqlite/sqlcipher"]
 syncable = ["tolstoy_traits"]
 
 [dependencies]

--- a/query-projector-traits/Cargo.toml
+++ b/query-projector-traits/Cargo.toml
@@ -7,6 +7,9 @@ workspace = ".."
 name = "query_projector_traits"
 path = "lib.rs"
 
+[features]
+sqlcipher = ["rusqlite/sqlcipher"]
+
 [dependencies]
 failure = "0.1.1"
 failure_derive = "0.1.1"

--- a/query-projector/Cargo.toml
+++ b/query-projector/Cargo.toml
@@ -3,6 +3,9 @@ name = "mentat_query_projector"
 version = "0.0.1"
 workspace = ".."
 
+[features]
+sqlcipher = ["rusqlite/sqlcipher"]
+
 [dependencies]
 failure = "0.1.1"
 indexmap = "1"

--- a/query-pull/Cargo.toml
+++ b/query-pull/Cargo.toml
@@ -3,6 +3,9 @@ name = "mentat_query_pull"
 version = "0.0.1"
 workspace = ".."
 
+[features]
+sqlcipher = ["rusqlite/sqlcipher"]
+
 [dependencies]
 failure = "0.1.1"
 

--- a/sql/Cargo.toml
+++ b/sql/Cargo.toml
@@ -3,6 +3,9 @@ name = "mentat_sql"
 version = "0.0.1"
 workspace = ".."
 
+[features]
+sqlcipher = ["rusqlite/sqlcipher"]
+
 [dependencies]
 failure = "0.1.1"
 ordered-float = "0.5"

--- a/tolstoy-traits/Cargo.toml
+++ b/tolstoy-traits/Cargo.toml
@@ -7,6 +7,9 @@ workspace = ".."
 name = "tolstoy_traits"
 path = "lib.rs"
 
+[features]
+sqlcipher = ["rusqlite/sqlcipher"]
+
 [dependencies]
 failure = "0.1.1"
 failure_derive = "0.1.1"

--- a/tolstoy/Cargo.toml
+++ b/tolstoy/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.0.1"
 workspace = ".."
 authors = ["Grisha Kruglov <gkruglov@mozilla.com>"]
 
+[features]
+sqlcipher = ["rusqlite/sqlcipher"]
+
 [dependencies]
 failure = "0.1.1"
 futures = "0.1"


### PR DESCRIPTION
This also patches our CI test script to only run "--feature sqlcipher"
tests on sub-crates which expose this feature (i.e. themselves rely on rusqlite).