### PR TITLE
Add method to get the ValueType of a TypedValue as a keyword to Android API

### DIFF
--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -1556,7 +1556,6 @@ pub unsafe extern "C" fn typed_value_into_long(typed_value: *mut Binding) -> c_l
 pub unsafe extern "C" fn typed_value_into_entid(typed_value: *mut Binding) -> Entid {
     assert_not_null!(typed_value);
     let typed_value = Box::from_raw(typed_value);
-    println!("typed value as entid {:?}", typed_value);
     unwrap_conversion(typed_value.into_entid(), ValueType::Ref)
 }
 
@@ -1657,6 +1656,14 @@ pub unsafe extern "C" fn typed_value_into_uuid(typed_value: *mut Binding) -> *mu
 pub unsafe extern "C" fn typed_value_value_type(typed_value: *mut Binding) -> ValueType {
     let typed_value = &*typed_value;
     typed_value.value_type().unwrap_or_else(|| panic!("Binding is not Scalar and has no ValueType"))
+}
+
+/// Returns the [ValueType](mentat::ValueType) of this [Binding](mentat::Binding).
+#[no_mangle]
+pub unsafe extern "C" fn typed_value_value_type_kw(typed_value: *mut Binding) -> *mut c_char {
+    let typed_value = &*typed_value;
+    let value = typed_value.value_type().unwrap_or_else(|| panic!("Binding is not Scalar and has no ValueType")).into_edn_value().to_string();
+    string_to_c_char(value.clone())
 }
 
 /// Returns the value at the provided `index` as a `Vec<ValueType>`.

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -1666,6 +1666,14 @@ pub unsafe extern "C" fn typed_value_value_type_kw(typed_value: *mut Binding) ->
     string_to_c_char(value.clone())
 }
 
+/// Returns the size of a `row` as usize
+#[no_mangle]
+pub unsafe extern "C" fn typed_value_list_size(values: *mut Vec<Binding>) -> c_int {
+    assert_not_null!(values);
+    let values = &*values;
+    values.len () as c_int
+}
+
 /// Returns the value at the provided `index` as a `Vec<ValueType>`.
 /// If there is no value present at the `index`, a null pointer is returned.
 ///

--- a/sdks/android/Mentat/library/src/main/java/org/mozilla/mentat/JNA.java
+++ b/sdks/android/Mentat/library/src/main/java/org/mozilla/mentat/JNA.java
@@ -158,6 +158,7 @@ public interface JNA extends Library {
     int typed_value_value_type(TypedValue value);
     Pointer typed_value_value_type_kw(TypedValue value);
 
+    int typed_value_list_size(TypedValueList rows);
     TypedValueList row_at_index(RelResult rows, int index);
     RelResultIter typed_value_result_set_into_iter(RelResult rows);
     TypedValueList typed_value_result_set_iter_next(RelResultIter iter);

--- a/sdks/android/Mentat/library/src/main/java/org/mozilla/mentat/JNA.java
+++ b/sdks/android/Mentat/library/src/main/java/org/mozilla/mentat/JNA.java
@@ -156,6 +156,7 @@ public interface JNA extends Library {
     double typed_value_into_double(TypedValue value);
     long typed_value_into_timestamp(TypedValue value);
     int typed_value_value_type(TypedValue value);
+    Pointer typed_value_value_type_kw(TypedValue value);
 
     TypedValueList row_at_index(RelResult rows, int index);
     RelResultIter typed_value_result_set_into_iter(RelResult rows);

--- a/sdks/android/Mentat/library/src/main/java/org/mozilla/mentat/TupleResult.java
+++ b/sdks/android/Mentat/library/src/main/java/org/mozilla/mentat/TupleResult.java
@@ -37,8 +37,11 @@ import java.util.UUID;
  */
 public class TupleResult extends RustObject<JNA.TypedValueList> {
 
+    private int size;
+
     public TupleResult(JNA.TypedValueList pointer) {
         super(pointer);
+        this.size = JNA.INSTANCE.typed_value_list_size(super.validPointer());
     }
 
     /**
@@ -143,6 +146,14 @@ public class TupleResult extends RustObject<JNA.TypedValueList> {
     public UUID asUUID(Integer index) {
         return getAndConsumeUUIDPointer(
                 JNA.INSTANCE.value_at_index_into_uuid(this.validPointer(), index));
+    }
+
+    /**
+     * Return the size of the tuple.
+     * @return The number of items in this tuple
+     */
+    public int size () {
+      return this.size;
     }
 
     @Override

--- a/sdks/android/Mentat/library/src/main/java/org/mozilla/mentat/TypedValue.java
+++ b/sdks/android/Mentat/library/src/main/java/org/mozilla/mentat/TypedValue.java
@@ -28,10 +28,16 @@ import java.util.UUID;
 public class TypedValue extends RustObject<JNA.TypedValue> {
 
     private Object value;
+    private String type = null;
 
     public TypedValue(JNA.TypedValue pointer) {
         super(pointer);
-    }
+        this.type = getAndConsumeMentatString(JNA.INSTANCE.typed_value_value_type_kw(super.validPointer()));
+        if ( this.type == null ) {
+          super.close ();
+          throw new IllegalArgumentException ("Failed to obtain Keyword for the valueType of this TypedValue");
+        }
+      }
 
     /**
      * This value as a {@link Long}. This function will panic if the `ValueType` of this
@@ -129,6 +135,14 @@ public class TypedValue extends RustObject<JNA.TypedValue> {
             this.value = getAndConsumeUUIDPointer(JNA.INSTANCE.typed_value_into_uuid(this.consumePointer()));
         }
         return (UUID)this.value;
+    }
+
+    /**
+    * The :db/valueType of this value as a keyword {@link String}.
+    * @return the value type of this {@link TypedValue} as a Keyword
+    */
+    public String valueTypeKeyword() {
+        return this.type;
     }
 
     @Override


### PR DESCRIPTION
Also remove a println (leftover from debug?)

This makes life easier when dealing with query results, as it allows them to be extracted without knowing the types in advance. This makes use from clojure easier.

Returning standard data structures and types instead (commented on elsewhere) is something that I think is also worth a look.

I would be interested in helping out with this project so I would be happy to chat sometime.