### PR TITLE
add plus symbol

### DIFF
--- a/edn/src/edn.rustpeg
+++ b/edn/src/edn.rustpeg
@@ -146,7 +146,7 @@ namespace_separator = "/"
 // Keywords follow the rules of symbols, except they can (and must) begin with :
 // e.g. :fred or :my/fred. See https://github.com/edn-format/edn#keywords
 symbol_char_initial = [a-zA-Z0-9*!_?$%&=<>]
-symbol_char_subsequent = [a-zA-Z0-9*!_?$%&=<>-]
+symbol_char_subsequent = [+a-zA-Z0-9*!_?$%&=<>-]
 
 symbol_namespace = symbol_char_initial symbol_char_subsequent* (namespace_divider symbol_char_subsequent+)*
 symbol_name = ( symbol_char_initial+ symbol_char_subsequent* )

--- a/edn/tests/tests.rs
+++ b/edn/tests/tests.rs
@@ -413,6 +413,9 @@ fn test_keyword() {
 
     assert!(keyword(":").is_err());
     assert!(keyword(":foo/").is_err());
+
+    assert_eq!(keyword(":foo*!_?$%&=<>-+").unwrap(), k_plain("foo*!_?$%&=<>-+"));
+    assert_eq!(keyword(":foo/bar*!_?$%&=<>-+").unwrap(), k_ns("foo", "bar*!_?$%&=<>-+"));
 }
 
 #[test]


### PR DESCRIPTION
Note that the position of + in the char set can break the build.

--- a/edn/src/edn.rustpeg
+++ b/edn/src/edn.rustpeg
@@ -146,7 +146,7 @@ namespace_separator = "/"
 // Keywords follow the rules of symbols, except they can (and must) begin with :
 // e.g. :fred or :my/fred. See https://github.com/edn-format/edn#keywords
 symbol_char_initial = [a-zA-Z0-9*!_?$%&=<>]
-symbol_char_subsequent = [+a-zA-Z0-9*!_?$%&=<>-]
+symbol_char_subsequent = [a-zA-Z0-9*!_?$%&=<>-+]

At the start seems to be fine, but at the end after the - caused this:

error[E0030]: lower range bound must be less than or equal to upper
   --> foobar/target/debug/build/edn-ef28a228c59621bd/out/edn.rs:153:395
    |
153 |  fn __parse_symbol_char_subsequent < 'input > ( __input : & 'input str , __state : & mut ParseState < 'input > , __pos : usize ) -> RuleResult < () > { # ! [ allow ( non_snake_case , unused ) ] if __input . len ( ) > __pos { let ( __ch , __next ) = char_range_at ( __input , __pos ) ; match __ch { 'a' ... 'z' | 'A' ... 'Z' | '0' ... '9' | '*' | '!' | '_' | '?' | '$' | '%' | '&' | '=' | '<' | '>' ... '+' => Matched ( __next , ( ) ) , _ => __state . mark_failure ( __pos , "[a-zA-Z0-9*!_?$%&=<>-+]" ) , } } else { __state . mark_failure ( __pos , "[a-zA-Z0-9*!_?$%&=<>-+]" ) } } 
    |                                                                                                                                                                                                                                                                                                                                                                                                           ^^^ lower bound larger than upper bound
 If anyone knows why I would love to know.

Finally I feel like I am adding clutter with lots of branches, can I do something better?